### PR TITLE
[STORY-201] 다중 계정 메일 인박스

### DIFF
--- a/.claude/skills/spring-api-rules.md
+++ b/.claude/skills/spring-api-rules.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Write, Edit, Glob
 Standard rules for Spring Boot REST API development in this project.
 
 - Root Package: `com.mailsangja.{module}`
-- Java 21 / Spring Boot 4.0.5 / MySQL
+- Java 21 / Spring Boot 4.0.5 / PostgreSQL / Redis / RabbitMQ
 
 ---
 

--- a/core/src/main/java/com/mailsangja/core/common/exception/inbox/InboxErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/inbox/InboxErrorCode.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum InboxErrorCode implements ErrorCode {
 
-    INVALID_THREAD_MARKER(400, "MS-INBOX-INVALID-THREAD-MARKER", "유효하지 않은 marker 입니다."),
     THREAD_NOT_FOUND(404, "MS-INBOX-THREAD-NOT-FOUND", "메일 스레드를 찾을 수 없습니다."),
     THREAD_ACCESS_DENIED(403, "MS-INBOX-THREAD-ACCESS-DENIED", "해당 메일 스레드에 접근할 권한이 없습니다.");
 

--- a/core/src/main/java/com/mailsangja/core/common/exception/inbox/InboxErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/inbox/InboxErrorCode.java
@@ -1,0 +1,17 @@
+package com.mailsangja.core.common.exception.inbox;
+
+import com.mailsangja.core.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum InboxErrorCode implements ErrorCode {
+
+    THREAD_NOT_FOUND(404, "MS-INBOX-THREAD-NOT-FOUND", "메일 스레드를 찾을 수 없습니다."),
+    THREAD_ACCESS_DENIED(403, "MS-INBOX-THREAD-ACCESS-DENIED", "해당 메일 스레드에 접근할 권한이 없습니다.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/core/src/main/java/com/mailsangja/core/common/exception/inbox/InboxErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/inbox/InboxErrorCode.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum InboxErrorCode implements ErrorCode {
 
+    INVALID_THREAD_MARKER(400, "MS-INBOX-INVALID-THREAD-MARKER", "유효하지 않은 marker 입니다."),
     THREAD_NOT_FOUND(404, "MS-INBOX-THREAD-NOT-FOUND", "메일 스레드를 찾을 수 없습니다."),
     THREAD_ACCESS_DENIED(403, "MS-INBOX-THREAD-ACCESS-DENIED", "해당 메일 스레드에 접근할 권한이 없습니다.");
 

--- a/core/src/main/java/com/mailsangja/core/common/exception/inbox/InboxException.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/inbox/InboxException.java
@@ -1,0 +1,10 @@
+package com.mailsangja.core.common.exception.inbox;
+
+import com.mailsangja.core.common.exception.BaseException;
+
+public class InboxException extends BaseException {
+
+    public InboxException(InboxErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/config/SecurityConfig.java
+++ b/core/src/main/java/com/mailsangja/core/config/SecurityConfig.java
@@ -3,7 +3,6 @@ package com.mailsangja.core.config;
 import com.mailsangja.core.common.auth.CustomAccessDeniedHandler;
 import com.mailsangja.core.common.auth.CustomAuthenticationEntryPoint;
 import com.mailsangja.core.config.properties.CorsProperties;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -61,13 +60,6 @@ public class SecurityConfig {
                 )
                 .securityContext(context -> context
                         .securityContextRepository(securityContextRepository())
-                )
-                .logout(logout -> logout
-                        .logoutUrl("/api/v1/auth/logout")
-                        .invalidateHttpSession(true)
-                        .clearAuthentication(true)
-                        .deleteCookies("SESSION")
-                        .logoutSuccessHandler((request, response, authentication) -> response.setStatus(HttpServletResponse.SC_NO_CONTENT))
                 );
 
         return http.build();

--- a/core/src/main/java/com/mailsangja/core/config/properties/InboxProperties.java
+++ b/core/src/main/java/com/mailsangja/core/config/properties/InboxProperties.java
@@ -11,5 +11,5 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "mailsangja.inbox")
 public class InboxProperties {
 
-    private int pageSize = 20;
+    private int pageSize = 50;
 }

--- a/core/src/main/java/com/mailsangja/core/config/properties/InboxProperties.java
+++ b/core/src/main/java/com/mailsangja/core/config/properties/InboxProperties.java
@@ -1,0 +1,15 @@
+package com.mailsangja.core.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "mailsangja.inbox")
+public class InboxProperties {
+
+    private int pageSize = 20;
+}

--- a/core/src/main/java/com/mailsangja/core/config/properties/package-info.java
+++ b/core/src/main/java/com/mailsangja/core/config/properties/package-info.java
@@ -1,1 +1,0 @@
-package com.mailsangja.core.config.properties;

--- a/core/src/main/java/com/mailsangja/core/controller/AuthController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/AuthController.java
@@ -33,4 +33,11 @@ public class AuthController implements AuthControllerDocs {
                                                    HttpServletResponse httpResponse) {
         return ResponseEntity.ok(authFacade.login(request, httpRequest, httpResponse));
     }
+
+    @Override
+    @PostMapping("/api/v1/auth/logout")
+    public ResponseEntity<Void> logout(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
+        authFacade.logout(httpRequest, httpResponse);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/core/src/main/java/com/mailsangja/core/controller/InboxController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/InboxController.java
@@ -1,0 +1,48 @@
+package com.mailsangja.core.controller;
+
+import com.mailsangja.core.common.auth.AuthUser;
+import com.mailsangja.core.controller.docs.InboxControllerDocs;
+import com.mailsangja.core.dto.common.SliceResponse;
+import com.mailsangja.core.dto.inbox.ThreadDetailResponse;
+import com.mailsangja.core.dto.inbox.ThreadSummaryResponse;
+import com.mailsangja.core.facade.InboxFacade;
+import com.mailsangja.db.entity.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+public class InboxController implements InboxControllerDocs {
+
+    private final InboxFacade inboxFacade;
+
+    @Override
+    @GetMapping("/api/v1/threads/inbox")
+    public ResponseEntity<SliceResponse<ThreadSummaryResponse>> getInbox(
+            @AuthUser User user,
+            @RequestParam(defaultValue = "0") int page
+    ) {
+        return ResponseEntity.ok(inboxFacade.getInbox(user, page));
+    }
+
+    @Override
+    @GetMapping("/api/v1/threads/sent")
+    public ResponseEntity<SliceResponse<ThreadSummaryResponse>> getSent(
+            @AuthUser User user,
+            @RequestParam(defaultValue = "0") int page
+    ) {
+        return ResponseEntity.ok(inboxFacade.getSent(user, page));
+    }
+
+    @Override
+    @GetMapping("/api/v1/threads/{threadId}")
+    public ResponseEntity<ThreadDetailResponse> getThreadDetail(
+            @AuthUser User user,
+            @PathVariable UUID threadId
+    ) {
+        return ResponseEntity.ok(inboxFacade.getThreadDetail(user, threadId));
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/controller/InboxController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/InboxController.java
@@ -24,7 +24,7 @@ public class InboxController implements InboxControllerDocs {
     public ResponseEntity<MarkerSliceResponse<ThreadSummaryResponse>> getInbox(
             @AuthUser User user,
             @RequestParam(required = false) UUID marker,
-            @RequestParam(defaultValue = "50") int size
+            @RequestParam(defaultValue = "${mailsangja.inbox.page-size:50}") int size
     ) {
         return ResponseEntity.ok(inboxFacade.getInbox(user, marker, size));
     }
@@ -34,7 +34,7 @@ public class InboxController implements InboxControllerDocs {
     public ResponseEntity<MarkerSliceResponse<ThreadSummaryResponse>> getSent(
             @AuthUser User user,
             @RequestParam(required = false) UUID marker,
-            @RequestParam(defaultValue = "50") int size
+            @RequestParam(defaultValue = "${mailsangja.inbox.page-size:50}") int size
     ) {
         return ResponseEntity.ok(inboxFacade.getSent(user, marker, size));
     }

--- a/core/src/main/java/com/mailsangja/core/controller/InboxController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/InboxController.java
@@ -2,7 +2,7 @@ package com.mailsangja.core.controller;
 
 import com.mailsangja.core.common.auth.AuthUser;
 import com.mailsangja.core.controller.docs.InboxControllerDocs;
-import com.mailsangja.core.dto.common.SliceResponse;
+import com.mailsangja.core.dto.common.MarkerSliceResponse;
 import com.mailsangja.core.dto.inbox.ThreadDetailResponse;
 import com.mailsangja.core.dto.inbox.ThreadSummaryResponse;
 import com.mailsangja.core.facade.InboxFacade;
@@ -21,20 +21,22 @@ public class InboxController implements InboxControllerDocs {
 
     @Override
     @GetMapping("/api/v1/threads/inbox")
-    public ResponseEntity<SliceResponse<ThreadSummaryResponse>> getInbox(
+    public ResponseEntity<MarkerSliceResponse<ThreadSummaryResponse>> getInbox(
             @AuthUser User user,
-            @RequestParam(defaultValue = "0") int page
+            @RequestParam(required = false) UUID marker,
+            @RequestParam(defaultValue = "50") int size
     ) {
-        return ResponseEntity.ok(inboxFacade.getInbox(user, page));
+        return ResponseEntity.ok(inboxFacade.getInbox(user, marker, size));
     }
 
     @Override
     @GetMapping("/api/v1/threads/sent")
-    public ResponseEntity<SliceResponse<ThreadSummaryResponse>> getSent(
+    public ResponseEntity<MarkerSliceResponse<ThreadSummaryResponse>> getSent(
             @AuthUser User user,
-            @RequestParam(defaultValue = "0") int page
+            @RequestParam(required = false) UUID marker,
+            @RequestParam(defaultValue = "50") int size
     ) {
-        return ResponseEntity.ok(inboxFacade.getSent(user, page));
+        return ResponseEntity.ok(inboxFacade.getSent(user, marker, size));
     }
 
     @Override

--- a/core/src/main/java/com/mailsangja/core/controller/docs/AuthControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/AuthControllerDocs.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -65,6 +66,28 @@ public interface AuthControllerDocs {
                     content = @Content(schema = @Schema(implementation = LoginRequest.class))
             )
             LoginRequest request,
+            @Parameter(hidden = true) HttpServletRequest httpRequest,
+            @Parameter(hidden = true) HttpServletResponse httpResponse
+    );
+
+    @Operation(
+            summary = "로그아웃",
+            description = "현재 세션을 무효화하고 로그아웃합니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "로그아웃 성공",
+                    content = @Content(schema = @Schema(hidden = true))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 필요 (로그인되지 않은 상태)",
+                    content = @Content(schema = @Schema(hidden = true))
+            )
+    })
+    ResponseEntity<Void> logout(
             @Parameter(hidden = true) HttpServletRequest httpRequest,
             @Parameter(hidden = true) HttpServletResponse httpResponse
     );

--- a/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
@@ -38,7 +38,7 @@ public interface InboxControllerDocs {
             ),
             @ApiResponse(responseCode = "401", description = "인증 필요",
                     content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", description = "마커 스레드를 찾을 수 없음",
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 marker",
                     content = @Content(schema = @Schema(hidden = true)))
     })
     ResponseEntity<MarkerSliceResponse<ThreadSummaryResponse>> getInbox(
@@ -65,7 +65,7 @@ public interface InboxControllerDocs {
             ),
             @ApiResponse(responseCode = "401", description = "인증 필요",
                     content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", description = "마커 스레드를 찾을 수 없음",
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 marker",
                     content = @Content(schema = @Schema(hidden = true)))
     })
     ResponseEntity<MarkerSliceResponse<ThreadSummaryResponse>> getSent(

--- a/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
@@ -1,0 +1,91 @@
+package com.mailsangja.core.controller.docs;
+
+import com.mailsangja.core.common.auth.AuthUser;
+import com.mailsangja.core.dto.common.SliceResponse;
+import com.mailsangja.core.dto.inbox.ThreadDetailResponse;
+import com.mailsangja.core.dto.inbox.ThreadSummaryResponse;
+import com.mailsangja.db.entity.user.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.UUID;
+
+@Tag(name = "Inbox", description = "통합 인박스 API")
+public interface InboxControllerDocs {
+
+    @Operation(
+            summary = "받은 편지함 스레드 목록 조회",
+            description = "로그인한 사용자의 모든 메일 계정에서 수신된 스레드 목록을 최신순으로 조회합니다. " +
+                    "대화 기록 중 내가 마지막으로 답장한 경우에도 가장 최근 수신 메시지 기준으로 표시됩니다. " +
+                    "무한 스크롤 방식으로 page를 순차 증가시켜 다음 항목을 요청합니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "스레드 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = SliceResponse.class))
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<SliceResponse<ThreadSummaryResponse>> getInbox(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "페이지 번호 (0-indexed)", example = "0")
+            @RequestParam(defaultValue = "0") int page
+    );
+
+    @Operation(
+            summary = "보낸 편지함 스레드 목록 조회",
+            description = "로그인한 사용자의 모든 메일 계정에서 발신된 스레드 목록을 최신순으로 조회합니다. " +
+                    "무한 스크롤 방식으로 page를 순차 증가시켜 다음 항목을 요청합니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "스레드 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = SliceResponse.class))
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<SliceResponse<ThreadSummaryResponse>> getSent(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "페이지 번호 (0-indexed)", example = "0")
+            @RequestParam(defaultValue = "0") int page
+    );
+
+    @Operation(
+            summary = "메일 스레드 상세 조회",
+            description = "특정 스레드의 전체 대화 (수신 + 발신 메시지)를 sentAt ASC 정렬로 조회합니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "스레드 상세 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ThreadDetailResponse.class))
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "스레드 접근 권한 없음",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "스레드를 찾을 수 없음",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<ThreadDetailResponse> getThreadDetail(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "스레드 내부 ID", required = true)
+            @PathVariable UUID threadId
+    );
+}

--- a/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
@@ -1,7 +1,7 @@
 package com.mailsangja.core.controller.docs;
 
 import com.mailsangja.core.common.auth.AuthUser;
-import com.mailsangja.core.dto.common.SliceResponse;
+import com.mailsangja.core.dto.common.MarkerSliceResponse;
 import com.mailsangja.core.dto.inbox.ThreadDetailResponse;
 import com.mailsangja.core.dto.inbox.ThreadSummaryResponse;
 import com.mailsangja.db.entity.user.User;
@@ -25,44 +25,55 @@ public interface InboxControllerDocs {
     @Operation(
             summary = "받은 편지함 스레드 목록 조회",
             description = "로그인한 사용자의 모든 메일 계정에서 수신된 스레드 목록을 최신순으로 조회합니다. " +
-                    "대화 기록 중 내가 마지막으로 답장한 경우에도 가장 최근 수신 메시지 기준으로 표시됩니다. " +
-                    "무한 스크롤 방식으로 page를 순차 증가시켜 다음 항목을 요청합니다.",
+                    "마커 기반 무한 스크롤 방식으로 동작합니다. " +
+                    "첫 요청은 marker 없이 호출하고, 이후 응답의 nextMarker를 다음 요청의 marker로 전달합니다. " +
+                    "nextMarker가 null이면 마지막 페이지입니다.",
             security = @SecurityRequirement(name = "cookieAuth")
     )
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
                     description = "스레드 목록 조회 성공",
-                    content = @Content(schema = @Schema(implementation = SliceResponse.class))
+                    content = @Content(schema = @Schema(implementation = MarkerSliceResponse.class))
             ),
             @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "마커 스레드를 찾을 수 없음",
                     content = @Content(schema = @Schema(hidden = true)))
     })
-    ResponseEntity<SliceResponse<ThreadSummaryResponse>> getInbox(
+    ResponseEntity<MarkerSliceResponse<ThreadSummaryResponse>> getInbox(
             @Parameter(hidden = true) @AuthUser User user,
-            @Parameter(description = "페이지 번호 (0-indexed)", example = "0")
-            @RequestParam(defaultValue = "0") int page
+            @Parameter(description = "이전 응답의 nextMarker (첫 요청 시 생략)", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestParam(required = false) UUID marker,
+            @Parameter(description = "한 번에 조회할 스레드 수", example = "50")
+            @RequestParam(defaultValue = "50") int size
     );
 
     @Operation(
             summary = "보낸 편지함 스레드 목록 조회",
             description = "로그인한 사용자의 모든 메일 계정에서 발신된 스레드 목록을 최신순으로 조회합니다. " +
-                    "무한 스크롤 방식으로 page를 순차 증가시켜 다음 항목을 요청합니다.",
+                    "마커 기반 무한 스크롤 방식으로 동작합니다. " +
+                    "첫 요청은 marker 없이 호출하고, 이후 응답의 nextMarker를 다음 요청의 marker로 전달합니다. " +
+                    "nextMarker가 null이면 마지막 페이지입니다.",
             security = @SecurityRequirement(name = "cookieAuth")
     )
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
                     description = "스레드 목록 조회 성공",
-                    content = @Content(schema = @Schema(implementation = SliceResponse.class))
+                    content = @Content(schema = @Schema(implementation = MarkerSliceResponse.class))
             ),
             @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "마커 스레드를 찾을 수 없음",
                     content = @Content(schema = @Schema(hidden = true)))
     })
-    ResponseEntity<SliceResponse<ThreadSummaryResponse>> getSent(
+    ResponseEntity<MarkerSliceResponse<ThreadSummaryResponse>> getSent(
             @Parameter(hidden = true) @AuthUser User user,
-            @Parameter(description = "페이지 번호 (0-indexed)", example = "0")
-            @RequestParam(defaultValue = "0") int page
+            @Parameter(description = "이전 응답의 nextMarker (첫 요청 시 생략)", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestParam(required = false) UUID marker,
+            @Parameter(description = "한 번에 조회할 스레드 수", example = "50")
+            @RequestParam(defaultValue = "50") int size
     );
 
     @Operation(

--- a/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
@@ -46,7 +46,7 @@ public interface InboxControllerDocs {
             @Parameter(description = "이전 응답의 nextMarker (첫 요청 시 생략)", example = "550e8400-e29b-41d4-a716-446655440000")
             @RequestParam(required = false) UUID marker,
             @Parameter(description = "한 번에 조회할 스레드 수", example = "50")
-            @RequestParam(defaultValue = "50") int size
+            @RequestParam(defaultValue = "${mailsangja.inbox.page-size:50}") int size
     );
 
     @Operation(
@@ -73,7 +73,7 @@ public interface InboxControllerDocs {
             @Parameter(description = "이전 응답의 nextMarker (첫 요청 시 생략)", example = "550e8400-e29b-41d4-a716-446655440000")
             @RequestParam(required = false) UUID marker,
             @Parameter(description = "한 번에 조회할 스레드 수", example = "50")
-            @RequestParam(defaultValue = "50") int size
+            @RequestParam(defaultValue = "${mailsangja.inbox.page-size:50}") int size
     );
 
     @Operation(

--- a/core/src/main/java/com/mailsangja/core/dto/common/MarkerSliceResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/common/MarkerSliceResponse.java
@@ -1,0 +1,20 @@
+package com.mailsangja.core.dto.common;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "마커 기반 무한 스크롤 응답 래퍼")
+public record MarkerSliceResponse<T>(
+        @Schema(description = "조회된 데이터 목록")
+        List<T> content,
+        @Schema(description = "다음 요청에 사용할 마커 (마지막 스레드의 threadId), null이면 마지막 페이지", example = "550e8400-e29b-41d4-a716-446655440000")
+        UUID nextMarker,
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext
+) {
+    public static <T> MarkerSliceResponse<T> of(List<T> content, UUID nextMarker, boolean hasNext) {
+        return new MarkerSliceResponse<>(content, nextMarker, hasNext);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/common/PageResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/common/PageResponse.java
@@ -1,0 +1,33 @@
+package com.mailsangja.core.dto.common;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Schema(description = "페이지 응답 래퍼")
+public record PageResponse<T>(
+        @Schema(description = "조회된 데이터 목록")
+        List<T> content,
+        @Schema(description = "현재 페이지 번호 (0-indexed)", example = "0")
+        int page,
+        @Schema(description = "페이지 크기", example = "20")
+        int size,
+        @Schema(description = "전체 요소 수", example = "100")
+        long totalElements,
+        @Schema(description = "전체 페이지 수", example = "5")
+        int totalPages,
+        @Schema(description = "마지막 페이지 여부", example = "false")
+        boolean last
+) {
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isLast()
+        );
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/common/SliceResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/common/SliceResponse.java
@@ -1,0 +1,20 @@
+package com.mailsangja.core.dto.common;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Schema(description = "무한 스크롤 슬라이스 응답 래퍼")
+public record SliceResponse<T>(
+        @Schema(description = "조회된 데이터 목록")
+        List<T> content,
+        @Schema(description = "현재 페이지 번호 (0-indexed)", example = "0")
+        int page,
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext
+) {
+    public static <T> SliceResponse<T> from(Slice<T> slice) {
+        return new SliceResponse<>(slice.getContent(), slice.getNumber(), slice.hasNext());
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/AttachmentResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/AttachmentResponse.java
@@ -1,0 +1,30 @@
+package com.mailsangja.core.dto.inbox;
+
+import com.mailsangja.db.entity.mail.Attachment;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "첨부파일 정보")
+public record AttachmentResponse(
+        @Schema(description = "첨부파일 ID")
+        UUID id,
+        @Schema(description = "Gmail 첨부파일 ID (다운로드 시 사용)", example = "ANGjdJ8...")
+        String gmailAttachmentId,
+        @Schema(description = "파일명", example = "document.pdf")
+        String filename,
+        @Schema(description = "MIME 타입", example = "application/pdf")
+        String mimeType,
+        @Schema(description = "파일 크기 (bytes)", example = "102400")
+        Integer size
+) {
+    public static AttachmentResponse from(Attachment attachment) {
+        return new AttachmentResponse(
+                attachment.getId(),
+                attachment.getGmailAttachmentId(),
+                attachment.getFilename(),
+                attachment.getMimeType(),
+                attachment.getSize()
+        );
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/MessageResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/MessageResponse.java
@@ -1,0 +1,61 @@
+package com.mailsangja.core.dto.inbox;
+
+import com.mailsangja.db.entity.mail.Direction;
+import com.mailsangja.db.entity.mail.Message;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "메일 메시지 상세 정보")
+public record MessageResponse(
+        @Schema(description = "메시지 ID")
+        UUID id,
+        @Schema(description = "Gmail 메시지 ID", example = "18a2b3c4d5e6f7a8")
+        String gmailMessageId,
+        @Schema(description = "제목", example = "Re: 프로젝트 미팅 일정")
+        String subject,
+        @Schema(description = "메시지 방향 (INBOUND: 수신, OUTBOUND: 발신)")
+        Direction direction,
+        @Schema(description = "발신자 이메일", example = "hong@example.com")
+        String fromAddress,
+        @Schema(description = "수신자 목록", example = "[\"user@gmail.com\"]")
+        List<String> toAddresses,
+        @Schema(description = "CC 수신자 목록", example = "[]")
+        List<String> ccAddresses,
+        @Schema(description = "메시지 스니펫 (미리보기)", example = "안녕하세요, 미팅 관련하여...")
+        String snippet,
+        @Schema(description = "읽음 여부", example = "true")
+        boolean isRead,
+        @Schema(description = "발송/수신 시각")
+        LocalDateTime sentAt,
+        @Schema(description = "본문 plain text")
+        String bodyText,
+        @Schema(description = "본문 HTML")
+        String bodyHtml,
+        @Schema(description = "첨부파일 목록")
+        List<AttachmentResponse> attachments
+) {
+    public static MessageResponse from(Message message) {
+        List<AttachmentResponse> attachmentResponses = message.getAttachments().stream()
+                .map(AttachmentResponse::from)
+                .toList();
+
+        return new MessageResponse(
+                message.getId(),
+                message.getGmailMessageId(),
+                message.getSubject(),
+                message.getDirection(),
+                message.getFromAddress(),
+                message.getToAddresses(),
+                message.getCcAddresses(),
+                message.getSnippet(),
+                message.isRead(),
+                message.getSentAt(),
+                message.getBodyText(),
+                message.getBodyHtml(),
+                attachmentResponses
+        );
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadDetailResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadDetailResponse.java
@@ -1,0 +1,43 @@
+package com.mailsangja.core.dto.inbox;
+
+import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.entity.mail.Thread;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "메일 스레드 상세 응답")
+public record ThreadDetailResponse(
+        @Schema(description = "스레드 내부 ID")
+        UUID threadId,
+        @Schema(description = "Gmail 스레드 ID", example = "18a2b3c4d5e6f7a8")
+        String gmailThreadId,
+        @Schema(description = "스레드가 속한 메일 계정 ID")
+        UUID accountId,
+        @Schema(description = "최신 메시지 제목", example = "프로젝트 미팅 일정 안내")
+        String latestSubject,
+        @Schema(description = "읽음 여부", example = "false")
+        boolean isRead,
+        @Schema(description = "최신 메시지 시각")
+        LocalDateTime lastMessageAt,
+        @Schema(description = "스레드 내 메시지 목록 (sentAt ASC 정렬)")
+        List<MessageResponse> messages
+) {
+    public static ThreadDetailResponse from(Thread thread, List<Message> messages) {
+        List<MessageResponse> messageResponses = messages.stream()
+                .map(MessageResponse::from)
+                .toList();
+
+        return new ThreadDetailResponse(
+                thread.getId(),
+                thread.getGmailThreadId(),
+                thread.getMailAccount().getId(),
+                thread.getLatestSubject(),
+                thread.isRead(),
+                thread.getLastMessageAt(),
+                messageResponses
+        );
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponse.java
@@ -1,0 +1,49 @@
+package com.mailsangja.core.dto.inbox;
+
+import com.mailsangja.db.entity.mail.Attachment;
+import com.mailsangja.db.entity.mail.Thread;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "통합 인박스 스레드 목록 항목")
+public record ThreadSummaryResponse(
+        @Schema(description = "스레드 내부 ID")
+        UUID threadId,
+        @Schema(description = "Gmail 스레드 ID", example = "18a2b3c4d5e6f7a8")
+        String gmailThreadId,
+        @Schema(description = "스레드가 속한 메일 계정 ID")
+        UUID accountId,
+        @Schema(description = "최신 메시지 제목", example = "프로젝트 미팅 일정 안내")
+        String latestSubject,
+        @Schema(description = "INBOUND일 때 발신자 이메일, OUTBOUND일 때 주 수신자 이메일", example = "hong@example.com")
+        String participantAddress,
+        @Schema(description = "최신 메시지 미리보기 텍스트", example = "안녕하세요, 다음 주 미팅 일정을 안내드립니다...")
+        String snippet,
+        @Schema(description = "읽음 여부", example = "false")
+        boolean isRead,
+        @Schema(description = "최신 메시지 시각")
+        LocalDateTime lastMessageAt,
+        @Schema(description = "스레드 내 첨부파일 목록")
+        List<AttachmentResponse> attachments
+) {
+    public static ThreadSummaryResponse from(Thread thread, List<Attachment> attachments) {
+        List<AttachmentResponse> attachmentResponses = attachments.stream()
+                .map(AttachmentResponse::from)
+                .toList();
+
+        return new ThreadSummaryResponse(
+                thread.getId(),
+                thread.getGmailThreadId(),
+                thread.getMailAccount().getId(),
+                thread.getLatestSubject(),
+                thread.getLatestParticipantAddress(),
+                thread.getLatestSnippet(),
+                thread.isRead(),
+                thread.getLastMessageAt(),
+                attachmentResponses
+        );
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/facade/AuthFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/AuthFacade.java
@@ -8,6 +8,7 @@ import com.mailsangja.core.dto.auth.UserInfoResponse;
 import com.mailsangja.core.service.user.UserCommandService;
 import com.mailsangja.core.service.user.UserQueryService;
 import com.mailsangja.db.entity.user.User;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,11 +19,14 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class AuthFacade {
+
+    private static final String SESSION_COOKIE_NAME = "SESSION";
 
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
@@ -49,5 +53,17 @@ public class AuthFacade {
         } catch (BadCredentialsException e) {
             throw new UserException(UserErrorCode.INVALID_CREDENTIALS);
         }
+    }
+
+    public void logout(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        new SecurityContextLogoutHandler().logout(httpRequest, httpResponse, authentication);
+
+        Cookie expiredSessionCookie = new Cookie(SESSION_COOKIE_NAME, "");
+        expiredSessionCookie.setPath("/");
+        expiredSessionCookie.setMaxAge(0);
+        expiredSessionCookie.setSecure(true);
+        expiredSessionCookie.setHttpOnly(true);
+        httpResponse.addCookie(expiredSessionCookie);
     }
 }

--- a/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
@@ -18,11 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Component

--- a/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
@@ -8,7 +8,6 @@ import com.mailsangja.core.dto.inbox.ThreadSummaryResponse;
 import com.mailsangja.core.service.inbox.InboxQueryService;
 import com.mailsangja.core.service.mail.MailAccountQueryService;
 import com.mailsangja.db.entity.mail.Attachment;
-import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.Thread;
 import com.mailsangja.db.entity.user.User;
@@ -18,7 +17,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Component
@@ -37,7 +39,7 @@ public class InboxFacade {
     }
 
     public ThreadDetailResponse getThreadDetail(User user, UUID threadId) {
-        List<MailAccount> userAccounts = mailAccountQueryService.findAllByUserId(user.getId());
+        List<com.mailsangja.db.entity.mail.MailAccount> userAccounts = mailAccountQueryService.findAllByUserId(user.getId());
         Thread thread = inboxQueryService.findThreadById(threadId);
         validateThreadAccess(userAccounts, thread);
 
@@ -50,39 +52,25 @@ public class InboxFacade {
     }
 
     private MarkerSliceResponse<ThreadSummaryResponse> getThreadList(User user, UUID marker, int size, boolean isSent) {
-        List<UUID> accountIds = mailAccountQueryService.findAllByUserId(user.getId()).stream()
-                .map(MailAccount::getId)
-                .toList();
-
-        if (accountIds.isEmpty()) {
-            return MarkerSliceResponse.of(Collections.emptyList(), null, false);
-        }
-
         Pageable pageable = PageRequest.of(0, size);
         Slice<Thread> threads = isSent
-                ? inboxQueryService.findSentThreadsByAccountIds(accountIds, marker, pageable)
-                : inboxQueryService.findInboxThreadsByAccountIds(accountIds, marker, pageable);
+                ? inboxQueryService.findSentThreadsByUserId(user.getId(), marker, pageable)
+                : inboxQueryService.findInboxThreadsByUserId(user.getId(), marker, pageable);
 
         List<UUID> threadIds = threads.getContent().stream().map(Thread::getId).toList();
         Map<UUID, List<Attachment>> attachmentsByThreadId = inboxQueryService.findAttachmentsByThreadIds(threadIds);
 
         List<ThreadSummaryResponse> content = threads.getContent().stream()
-                .map(thread -> ThreadSummaryResponse.from(
-                        thread,
-                        attachmentsByThreadId.getOrDefault(thread.getId(), List.of())
-                ))
+                .map(thread -> ThreadSummaryResponse.from(thread, attachmentsByThreadId.getOrDefault(thread.getId(), List.of())))
                 .toList();
 
-        UUID nextMarker = threads.hasNext()
-                ? threads.getContent().get(threads.getContent().size() - 1).getId()
-                : null;
-
+        UUID nextMarker = threads.hasNext() ? threads.getContent().getLast().getId() : null;
         return MarkerSliceResponse.of(content, nextMarker, threads.hasNext());
     }
 
-    private void validateThreadAccess(List<MailAccount> userAccounts, Thread thread) {
+    private void validateThreadAccess(List<com.mailsangja.db.entity.mail.MailAccount> userAccounts, Thread thread) {
         Set<UUID> userAccountIds = userAccounts.stream()
-                .map(MailAccount::getId)
+                .map(com.mailsangja.db.entity.mail.MailAccount::getId)
                 .collect(Collectors.toSet());
 
         if (!userAccountIds.contains(thread.getMailAccount().getId())) {

--- a/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
@@ -1,0 +1,95 @@
+package com.mailsangja.core.facade;
+
+import com.mailsangja.core.common.exception.inbox.InboxErrorCode;
+import com.mailsangja.core.common.exception.inbox.InboxException;
+import com.mailsangja.core.dto.common.SliceResponse;
+import com.mailsangja.core.dto.inbox.ThreadDetailResponse;
+import com.mailsangja.core.dto.inbox.ThreadSummaryResponse;
+import com.mailsangja.core.config.properties.InboxProperties;
+import com.mailsangja.core.service.inbox.InboxQueryService;
+import com.mailsangja.core.service.mail.MailAccountQueryService;
+import com.mailsangja.db.entity.mail.Attachment;
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.entity.mail.Thread;
+import com.mailsangja.db.entity.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class InboxFacade {
+
+    private final InboxProperties inboxProperties;
+    private final InboxQueryService inboxQueryService;
+    private final MailAccountQueryService mailAccountQueryService;
+
+    public SliceResponse<ThreadSummaryResponse> getInbox(User user, int page) {
+        return getThreadList(user, page, false);
+    }
+
+    public SliceResponse<ThreadSummaryResponse> getSent(User user, int page) {
+        return getThreadList(user, page, true);
+    }
+
+    public ThreadDetailResponse getThreadDetail(User user, UUID threadId) {
+        List<MailAccount> userAccounts = mailAccountQueryService.findAllByUserId(user.getId());
+        Thread thread = inboxQueryService.findThreadById(threadId);
+        validateThreadAccess(userAccounts, thread);
+
+        // 같은 gmail_thread_id의 INBOUND + OUTBOUND 메시지를 모두 반환 (전체 대화)
+        List<Message> messages = inboxQueryService.findAllMessagesByThread(
+                thread.getMailAccount().getId(),
+                thread.getGmailThreadId()
+        );
+        return ThreadDetailResponse.from(thread, messages);
+    }
+
+    private SliceResponse<ThreadSummaryResponse> getThreadList(User user, int page, boolean isSent) {
+        List<UUID> accountIds = mailAccountQueryService.findAllByUserId(user.getId()).stream()
+                .map(MailAccount::getId)
+                .toList();
+
+        if (accountIds.isEmpty()) {
+            return SliceResponse.from(new SliceImpl<>(Collections.emptyList()));
+        }
+
+        Pageable pageable = PageRequest.of(page, inboxProperties.getPageSize());
+        Slice<Thread> threads = isSent
+                ? inboxQueryService.findSentThreadsByAccountIds(accountIds, pageable)
+                : inboxQueryService.findInboxThreadsByAccountIds(accountIds, pageable);
+
+        List<UUID> threadIds = threads.getContent().stream().map(Thread::getId).toList();
+        Map<UUID, List<Attachment>> attachmentsByThreadId = inboxQueryService.findAttachmentsByThreadIds(threadIds);
+
+        List<ThreadSummaryResponse> content = threads.getContent().stream()
+                .map(thread -> ThreadSummaryResponse.from(
+                        thread,
+                        attachmentsByThreadId.getOrDefault(thread.getId(), List.of())
+                ))
+                .toList();
+
+        return new SliceResponse<>(content, threads.getNumber(), threads.hasNext());
+    }
+
+    private void validateThreadAccess(List<MailAccount> userAccounts, Thread thread) {
+        Set<UUID> userAccountIds = userAccounts.stream()
+                .map(MailAccount::getId)
+                .collect(Collectors.toSet());
+
+        if (!userAccountIds.contains(thread.getMailAccount().getId())) {
+            throw new InboxException(InboxErrorCode.THREAD_ACCESS_DENIED);
+        }
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
@@ -8,6 +8,7 @@ import com.mailsangja.core.dto.inbox.ThreadSummaryResponse;
 import com.mailsangja.core.service.inbox.InboxQueryService;
 import com.mailsangja.core.service.mail.MailAccountQueryService;
 import com.mailsangja.db.entity.mail.Attachment;
+import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.Thread;
 import com.mailsangja.db.entity.user.User;
@@ -39,7 +40,7 @@ public class InboxFacade {
     }
 
     public ThreadDetailResponse getThreadDetail(User user, UUID threadId) {
-        List<com.mailsangja.db.entity.mail.MailAccount> userAccounts = mailAccountQueryService.findAllByUserId(user.getId());
+        List<MailAccount> userAccounts = mailAccountQueryService.findAllByUserId(user.getId());
         Thread thread = inboxQueryService.findThreadById(threadId);
         validateThreadAccess(userAccounts, thread);
 
@@ -68,9 +69,9 @@ public class InboxFacade {
         return MarkerSliceResponse.of(content, nextMarker, threads.hasNext());
     }
 
-    private void validateThreadAccess(List<com.mailsangja.db.entity.mail.MailAccount> userAccounts, Thread thread) {
+    private void validateThreadAccess(List<MailAccount> userAccounts, Thread thread) {
         Set<UUID> userAccountIds = userAccounts.stream()
-                .map(com.mailsangja.db.entity.mail.MailAccount::getId)
+                .map(MailAccount::getId)
                 .collect(Collectors.toSet());
 
         if (!userAccountIds.contains(thread.getMailAccount().getId())) {

--- a/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
@@ -2,10 +2,9 @@ package com.mailsangja.core.facade;
 
 import com.mailsangja.core.common.exception.inbox.InboxErrorCode;
 import com.mailsangja.core.common.exception.inbox.InboxException;
-import com.mailsangja.core.dto.common.SliceResponse;
+import com.mailsangja.core.dto.common.MarkerSliceResponse;
 import com.mailsangja.core.dto.inbox.ThreadDetailResponse;
 import com.mailsangja.core.dto.inbox.ThreadSummaryResponse;
-import com.mailsangja.core.config.properties.InboxProperties;
 import com.mailsangja.core.service.inbox.InboxQueryService;
 import com.mailsangja.core.service.mail.MailAccountQueryService;
 import com.mailsangja.db.entity.mail.Attachment;
@@ -17,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
@@ -31,16 +29,15 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class InboxFacade {
 
-    private final InboxProperties inboxProperties;
     private final InboxQueryService inboxQueryService;
     private final MailAccountQueryService mailAccountQueryService;
 
-    public SliceResponse<ThreadSummaryResponse> getInbox(User user, int page) {
-        return getThreadList(user, page, false);
+    public MarkerSliceResponse<ThreadSummaryResponse> getInbox(User user, UUID marker, int size) {
+        return getThreadList(user, marker, size, false);
     }
 
-    public SliceResponse<ThreadSummaryResponse> getSent(User user, int page) {
-        return getThreadList(user, page, true);
+    public MarkerSliceResponse<ThreadSummaryResponse> getSent(User user, UUID marker, int size) {
+        return getThreadList(user, marker, size, true);
     }
 
     public ThreadDetailResponse getThreadDetail(User user, UUID threadId) {
@@ -56,19 +53,19 @@ public class InboxFacade {
         return ThreadDetailResponse.from(thread, messages);
     }
 
-    private SliceResponse<ThreadSummaryResponse> getThreadList(User user, int page, boolean isSent) {
+    private MarkerSliceResponse<ThreadSummaryResponse> getThreadList(User user, UUID marker, int size, boolean isSent) {
         List<UUID> accountIds = mailAccountQueryService.findAllByUserId(user.getId()).stream()
                 .map(MailAccount::getId)
                 .toList();
 
         if (accountIds.isEmpty()) {
-            return SliceResponse.from(new SliceImpl<>(Collections.emptyList()));
+            return MarkerSliceResponse.of(Collections.emptyList(), null, false);
         }
 
-        Pageable pageable = PageRequest.of(page, inboxProperties.getPageSize());
+        Pageable pageable = PageRequest.of(0, size);
         Slice<Thread> threads = isSent
-                ? inboxQueryService.findSentThreadsByAccountIds(accountIds, pageable)
-                : inboxQueryService.findInboxThreadsByAccountIds(accountIds, pageable);
+                ? inboxQueryService.findSentThreadsByAccountIds(accountIds, marker, pageable)
+                : inboxQueryService.findInboxThreadsByAccountIds(accountIds, marker, pageable);
 
         List<UUID> threadIds = threads.getContent().stream().map(Thread::getId).toList();
         Map<UUID, List<Attachment>> attachmentsByThreadId = inboxQueryService.findAttachmentsByThreadIds(threadIds);
@@ -80,7 +77,11 @@ public class InboxFacade {
                 ))
                 .toList();
 
-        return new SliceResponse<>(content, threads.getNumber(), threads.hasNext());
+        UUID nextMarker = threads.hasNext()
+                ? threads.getContent().get(threads.getContent().size() - 1).getId()
+                : null;
+
+        return MarkerSliceResponse.of(content, nextMarker, threads.hasNext());
     }
 
     private void validateThreadAccess(List<MailAccount> userAccounts, Thread thread) {

--- a/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+
 @Service
 @RequiredArgsConstructor
 public class InboxQueryService {
@@ -24,12 +25,12 @@ public class InboxQueryService {
     private final ThreadRepositoryPort threadRepositoryPort;
     private final MessageRepositoryPort messageRepositoryPort;
 
-    public Slice<Thread> findInboxThreadsByAccountIds(List<UUID> accountIds, UUID markerId, Pageable pageable) {
-        return threadRepositoryPort.findInboxByMailAccountIdInAndDeletedAtIsNull(accountIds, markerId, pageable);
+    public Slice<Thread> findInboxThreadsByUserId(UUID userId, UUID markerId, Pageable pageable) {
+        return threadRepositoryPort.findInboxByUserIdAndDeletedAtIsNull(userId, markerId, pageable);
     }
 
-    public Slice<Thread> findSentThreadsByAccountIds(List<UUID> accountIds, UUID markerId, Pageable pageable) {
-        return threadRepositoryPort.findSentByMailAccountIdInAndDeletedAtIsNull(accountIds, markerId, pageable);
+    public Slice<Thread> findSentThreadsByUserId(UUID userId, UUID markerId, Pageable pageable) {
+        return threadRepositoryPort.findSentByUserIdAndDeletedAtIsNull(userId, markerId, pageable);
     }
 
     public Thread findThreadById(UUID threadId) {

--- a/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
@@ -24,12 +24,12 @@ public class InboxQueryService {
     private final ThreadRepositoryPort threadRepositoryPort;
     private final MessageRepositoryPort messageRepositoryPort;
 
-    public Slice<Thread> findInboxThreadsByAccountIds(List<UUID> accountIds, Pageable pageable) {
-        return threadRepositoryPort.findInboxByMailAccountIdInAndDeletedAtIsNull(accountIds, pageable);
+    public Slice<Thread> findInboxThreadsByAccountIds(List<UUID> accountIds, UUID markerId, Pageable pageable) {
+        return threadRepositoryPort.findInboxByMailAccountIdInAndDeletedAtIsNull(accountIds, markerId, pageable);
     }
 
-    public Slice<Thread> findSentThreadsByAccountIds(List<UUID> accountIds, Pageable pageable) {
-        return threadRepositoryPort.findSentByMailAccountIdInAndDeletedAtIsNull(accountIds, pageable);
+    public Slice<Thread> findSentThreadsByAccountIds(List<UUID> accountIds, UUID markerId, Pageable pageable) {
+        return threadRepositoryPort.findSentByMailAccountIdInAndDeletedAtIsNull(accountIds, markerId, pageable);
     }
 
     public Thread findThreadById(UUID threadId) {

--- a/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
@@ -1,0 +1,60 @@
+package com.mailsangja.core.service.inbox;
+
+import com.mailsangja.core.common.exception.inbox.InboxErrorCode;
+import com.mailsangja.core.common.exception.inbox.InboxException;
+import com.mailsangja.db.entity.mail.Attachment;
+import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.entity.mail.Thread;
+import com.mailsangja.db.port.MessageRepositoryPort;
+import com.mailsangja.db.port.ThreadRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class InboxQueryService {
+
+    private final ThreadRepositoryPort threadRepositoryPort;
+    private final MessageRepositoryPort messageRepositoryPort;
+
+    public Slice<Thread> findInboxThreadsByAccountIds(List<UUID> accountIds, Pageable pageable) {
+        return threadRepositoryPort.findInboxByMailAccountIdInAndDeletedAtIsNull(accountIds, pageable);
+    }
+
+    public Slice<Thread> findSentThreadsByAccountIds(List<UUID> accountIds, Pageable pageable) {
+        return threadRepositoryPort.findSentByMailAccountIdInAndDeletedAtIsNull(accountIds, pageable);
+    }
+
+    public Thread findThreadById(UUID threadId) {
+        return threadRepositoryPort.findByIdAndDeletedAtIsNull(threadId)
+                .orElseThrow(() -> new InboxException(InboxErrorCode.THREAD_NOT_FOUND));
+    }
+
+    // 스레드 상세: INBOUND/OUTBOUND 두 행의 메시지를 모두 반환 (전체 대화)
+    public List<Message> findAllMessagesByThread(UUID mailAccountId, String gmailThreadId) {
+        return messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, gmailThreadId);
+    }
+
+    // 목록용: 여러 스레드의 첨부파일을 한 번에 조회 (N+1 방지)
+    public Map<UUID, List<Attachment>> findAttachmentsByThreadIds(List<UUID> threadIds) {
+        if (threadIds.isEmpty()) {
+            return Map.of();
+        }
+        List<Message> messages = messageRepositoryPort.findAllByThreadIdInAndDeletedAtIsNull(threadIds);
+        return messages.stream()
+                .filter(m -> !m.getAttachments().isEmpty())
+                .flatMap(m -> m.getAttachments().stream()
+                        .map(a -> Map.entry(m.getThread().getId(), a)))
+                .collect(Collectors.groupingBy(
+                        Map.Entry::getKey,
+                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())
+                ));
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/service/mail/MailAccountQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/mail/MailAccountQueryService.java
@@ -19,21 +19,21 @@ public class MailAccountQueryService {
     private final MailAccountRepositoryPort mailAccountRepositoryPort;
 
     public MailAccount findById(UUID id) {
-        return mailAccountRepositoryPort.findById(id)
+        return mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new MailAccountException(MailAccountErrorCode.MAIL_ACCOUNT_NOT_FOUND));
     }
 
     public MailAccount findActiveById(UUID id) {
-        return mailAccountRepositoryPort.findByIdAndActive(id, true)
+        return mailAccountRepositoryPort.findByIdAndActiveAndDeletedAtIsNull(id, true)
                 .orElseThrow(() -> new MailAccountException(MailAccountErrorCode.MAIL_ACCOUNT_NOT_FOUND));
     }
 
     public Optional<MailAccount> findByUserIdAndProviderAndEmailAddress(UUID userId, MailProvider provider, String emailAddress) {
-        return mailAccountRepositoryPort.findByUserIdAndProviderAndEmailAddress(userId, provider, emailAddress);
+        return mailAccountRepositoryPort.findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(userId, provider, emailAddress);
     }
 
     public Optional<MailAccount> findByProviderAndEmailAddress(MailProvider provider, String emailAddress) {
-        return mailAccountRepositoryPort.findByProviderAndEmailAddress(provider, emailAddress);
+        return mailAccountRepositoryPort.findByProviderAndEmailAddressAndDeletedAtIsNull(provider, emailAddress);
     }
 
     public List<MailAccount> findAllByUserId(UUID userId) {

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -40,6 +40,8 @@ scalar:
   page-title: MailSangja API Reference
 
 mailsangja:
+  inbox:
+    page-size: ${INBOX_PAGE_SIZE:20}
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:8080}
   oauth:

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -41,7 +41,7 @@ scalar:
 
 mailsangja:
   inbox:
-    page-size: ${INBOX_PAGE_SIZE:20}
+    page-size: ${INBOX_PAGE_SIZE:50}
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:8080}
   oauth:

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/AttachmentRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/AttachmentRepositoryAdapter.java
@@ -1,0 +1,27 @@
+package com.mailsangja.db.adapter.mail;
+
+import com.mailsangja.db.entity.mail.Attachment;
+import com.mailsangja.db.module.mail.AttachmentJpaRepositoryModule;
+import com.mailsangja.db.port.AttachmentRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class AttachmentRepositoryAdapter implements AttachmentRepositoryPort {
+
+    private final AttachmentJpaRepositoryModule attachmentJpaRepositoryModule;
+
+    @Override
+    public Attachment save(Attachment attachment) {
+        return attachmentJpaRepositoryModule.save(attachment);
+    }
+
+    @Override
+    public List<Attachment> findAllByMessageId(UUID messageId) {
+        return attachmentJpaRepositoryModule.findAllByMessageId(messageId);
+    }
+}

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/LabelRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/LabelRepositoryAdapter.java
@@ -1,0 +1,38 @@
+package com.mailsangja.db.adapter.mail;
+
+import com.mailsangja.db.entity.mail.Label;
+import com.mailsangja.db.module.mail.LabelJpaRepositoryModule;
+import com.mailsangja.db.port.LabelRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class LabelRepositoryAdapter implements LabelRepositoryPort {
+
+    private final LabelJpaRepositoryModule labelJpaRepositoryModule;
+
+    @Override
+    public Label save(Label label) {
+        return labelJpaRepositoryModule.save(label);
+    }
+
+    @Override
+    public List<Label> findAllByUserIdAndDeletedAtIsNull(UUID userId) {
+        return labelJpaRepositoryModule.findAllByUserIdAndDeletedAtIsNull(userId);
+    }
+
+    @Override
+    public Optional<Label> findByIdAndDeletedAtIsNull(UUID id) {
+        return labelJpaRepositoryModule.findByIdAndDeletedAtIsNull(id);
+    }
+
+    @Override
+    public Optional<Label> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId) {
+        return labelJpaRepositoryModule.findByIdAndUserIdAndDeletedAtIsNull(id, userId);
+    }
+}

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/MailAccountRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/MailAccountRepositoryAdapter.java
@@ -23,33 +23,33 @@ public class MailAccountRepositoryAdapter implements MailAccountRepositoryPort {
     }
 
     @Override
-    public Optional<MailAccount> findById(UUID id) {
-        return mailAccountJpaRepositoryModule.findById(id);
+    public Optional<MailAccount> findByIdAndDeletedAtIsNull(UUID id) {
+        return mailAccountJpaRepositoryModule.findByIdAndDeletedAtIsNull(id);
     }
 
     @Override
-    public Optional<MailAccount> findByIdAndActive(UUID id, boolean active) {
-        return mailAccountJpaRepositoryModule.findByIdAndActive(id, active);
+    public Optional<MailAccount> findByIdAndActiveAndDeletedAtIsNull(UUID id, boolean active) {
+        return mailAccountJpaRepositoryModule.findByIdAndActiveAndDeletedAtIsNull(id, active);
     }
 
     @Override
-    public Optional<MailAccount> findByEmailAddress(String emailAddress) {
-        return mailAccountJpaRepositoryModule.findByEmailAddress(emailAddress);
+    public Optional<MailAccount> findByEmailAddressAndDeletedAtIsNull(String emailAddress) {
+        return mailAccountJpaRepositoryModule.findByEmailAddressAndDeletedAtIsNull(emailAddress);
     }
 
     @Override
-    public Optional<MailAccount> findByUserIdAndProvider(UUID userId, MailProvider provider) {
-        return mailAccountJpaRepositoryModule.findByUserIdAndProvider(userId, provider);
+    public Optional<MailAccount> findByUserIdAndProviderAndDeletedAtIsNull(UUID userId, MailProvider provider) {
+        return mailAccountJpaRepositoryModule.findByUserIdAndProviderAndDeletedAtIsNull(userId, provider);
     }
 
     @Override
-    public Optional<MailAccount> findByUserIdAndProviderAndEmailAddress(UUID userId, MailProvider provider, String emailAddress) {
-        return mailAccountJpaRepositoryModule.findByUserIdAndProviderAndEmailAddress(userId, provider, emailAddress);
+    public Optional<MailAccount> findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(UUID userId, MailProvider provider, String emailAddress) {
+        return mailAccountJpaRepositoryModule.findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(userId, provider, emailAddress);
     }
 
     @Override
-    public Optional<MailAccount> findByProviderAndEmailAddress(MailProvider provider, String emailAddress) {
-        return mailAccountJpaRepositoryModule.findByProviderAndEmailAddress(provider, emailAddress);
+    public Optional<MailAccount> findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress) {
+        return mailAccountJpaRepositoryModule.findByProviderAndEmailAddressAndDeletedAtIsNull(provider, emailAddress);
     }
 
     @Override

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
@@ -1,0 +1,37 @@
+package com.mailsangja.db.adapter.mail;
+
+import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.module.mail.MessageJpaRepositoryModule;
+import com.mailsangja.db.port.MessageRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class MessageRepositoryAdapter implements MessageRepositoryPort {
+
+    private final MessageJpaRepositoryModule messageJpaRepositoryModule;
+
+    @Override
+    public Message save(Message message) {
+        return messageJpaRepositoryModule.save(message);
+    }
+
+    @Override
+    public List<Message> findAllByThreadIdAndDeletedAtIsNull(UUID threadId) {
+        return messageJpaRepositoryModule.findAllByThreadIdAndDeletedAtIsNull(threadId);
+    }
+
+    @Override
+    public List<Message> findAllByThreadIdInAndDeletedAtIsNull(List<UUID> threadIds) {
+        return messageJpaRepositoryModule.findAllByThreadIdInAndDeletedAtIsNull(threadIds);
+    }
+
+    @Override
+    public List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId) {
+        return messageJpaRepositoryModule.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, gmailThreadId);
+    }
+}

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/ThreadRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/ThreadRepositoryAdapter.java
@@ -1,0 +1,50 @@
+package com.mailsangja.db.adapter.mail;
+
+import com.mailsangja.db.entity.mail.Direction;
+import com.mailsangja.db.entity.mail.Thread;
+import com.mailsangja.db.module.mail.ThreadJpaRepositoryModule;
+import com.mailsangja.db.port.ThreadRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class ThreadRepositoryAdapter implements ThreadRepositoryPort {
+
+    private final ThreadJpaRepositoryModule threadJpaRepositoryModule;
+
+    @Override
+    public Thread save(Thread thread) {
+        return threadJpaRepositoryModule.save(thread);
+    }
+
+    @Override
+    public Optional<Thread> findByIdAndDeletedAtIsNull(UUID id) {
+        return threadJpaRepositoryModule.findByIdAndDeletedAtIsNull(id);
+    }
+
+    @Override
+    public Optional<Thread> findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+            UUID mailAccountId, String gmailThreadId, Direction direction
+    ) {
+        return threadJpaRepositoryModule.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccountId, gmailThreadId, direction
+        );
+    }
+
+    @Override
+    public Slice<Thread> findInboxByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, Pageable pageable) {
+        return threadJpaRepositoryModule.findInboxByMailAccountIdInAndDeletedAtIsNull(accountIds, pageable);
+    }
+
+    @Override
+    public Slice<Thread> findSentByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, Pageable pageable) {
+        return threadJpaRepositoryModule.findSentByMailAccountIdInAndDeletedAtIsNull(accountIds, pageable);
+    }
+}

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/ThreadRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/ThreadRepositoryAdapter.java
@@ -9,7 +9,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -39,12 +38,12 @@ public class ThreadRepositoryAdapter implements ThreadRepositoryPort {
     }
 
     @Override
-    public Slice<Thread> findInboxByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, UUID markerId, Pageable pageable) {
-        return threadJpaRepositoryModule.findInboxByMailAccountIdInAndDeletedAtIsNull(accountIds, markerId, pageable);
+    public Slice<Thread> findInboxByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable) {
+        return threadJpaRepositoryModule.findInboxByUserIdAndDeletedAtIsNull(userId, markerId, pageable);
     }
 
     @Override
-    public Slice<Thread> findSentByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, UUID markerId, Pageable pageable) {
-        return threadJpaRepositoryModule.findSentByMailAccountIdInAndDeletedAtIsNull(accountIds, markerId, pageable);
+    public Slice<Thread> findSentByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable) {
+        return threadJpaRepositoryModule.findSentByUserIdAndDeletedAtIsNull(userId, markerId, pageable);
     }
 }

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/ThreadRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/ThreadRepositoryAdapter.java
@@ -39,12 +39,12 @@ public class ThreadRepositoryAdapter implements ThreadRepositoryPort {
     }
 
     @Override
-    public Slice<Thread> findInboxByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, Pageable pageable) {
-        return threadJpaRepositoryModule.findInboxByMailAccountIdInAndDeletedAtIsNull(accountIds, pageable);
+    public Slice<Thread> findInboxByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, UUID markerId, Pageable pageable) {
+        return threadJpaRepositoryModule.findInboxByMailAccountIdInAndDeletedAtIsNull(accountIds, markerId, pageable);
     }
 
     @Override
-    public Slice<Thread> findSentByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, Pageable pageable) {
-        return threadJpaRepositoryModule.findSentByMailAccountIdInAndDeletedAtIsNull(accountIds, pageable);
+    public Slice<Thread> findSentByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, UUID markerId, Pageable pageable) {
+        return threadJpaRepositoryModule.findSentByMailAccountIdInAndDeletedAtIsNull(accountIds, markerId, pageable);
     }
 }

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Attachment.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Attachment.java
@@ -1,0 +1,42 @@
+package com.mailsangja.db.entity.mail;
+
+import com.mailsangja.db.entity.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "attachments")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Attachment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "CHAR(36)")
+    @JdbcTypeCode(SqlTypes.CHAR)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id", nullable = false)
+    private Message message;
+
+    // Gmail attachment ID (다운로드 시 사용)
+    @Column(name = "gmail_attachment_id", length = 255)
+    private String gmailAttachmentId;
+
+    @Column(name = "filename", nullable = false, length = 255)
+    private String filename;
+
+    @Column(name = "mime_type", nullable = false, length = 255)
+    private String mimeType;
+
+    // 첨부파일 크기 (bytes)
+    @Column(name = "size")
+    private Integer size;
+}

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Direction.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Direction.java
@@ -1,0 +1,6 @@
+package com.mailsangja.db.entity.mail;
+
+public enum Direction {
+    INBOUND,
+    OUTBOUND
+}

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Label.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Label.java
@@ -1,0 +1,70 @@
+package com.mailsangja.db.entity.mail;
+
+import com.mailsangja.db.entity.common.BaseEntity;
+import com.mailsangja.db.entity.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Entity
+@Table(name = "labels")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Label extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "CHAR(36)")
+    @JdbcTypeCode(SqlTypes.CHAR)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "color_code", nullable = false, length = 7)
+    private String colorCode;
+
+    @Column(name = "notification_enabled", nullable = false)
+    private boolean notificationEnabled;
+
+    // 자동 분류 규칙 (e.g. {"from": "noreply@github.com", "subject_contains": "PR"})
+    @Column(name = "rule", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private Map<String, Object> rule;
+
+    @Builder.Default
+    @ManyToMany(mappedBy = "labels", fetch = FetchType.LAZY)
+    private List<Thread> threads = new ArrayList<>();
+
+    @Builder.Default
+    @ManyToMany(mappedBy = "labels", fetch = FetchType.LAZY)
+    private List<Message> messages = new ArrayList<>();
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateColorCode(String colorCode) {
+        this.colorCode = colorCode;
+    }
+
+    public void updateNotificationEnabled(boolean notificationEnabled) {
+        this.notificationEnabled = notificationEnabled;
+    }
+
+    public void updateRule(Map<String, Object> rule) {
+        this.rule = rule;
+    }
+}

--- a/db/src/main/java/com/mailsangja/db/entity/mail/MailAccount.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/MailAccount.java
@@ -73,6 +73,9 @@ public class MailAccount extends BaseEntity {
     @Column(name = "sync_history_id", length = 255)
     private String syncHistoryId;
 
+    @Column(name = "watch_expires_at")
+    private LocalDateTime watchExpiresAt;
+
     public void updateAccessToken(String accessToken) {
         this.accessToken = accessToken;
     }
@@ -99,6 +102,10 @@ public class MailAccount extends BaseEntity {
 
     public void updateSyncHistoryId(String syncHistoryId) {
         this.syncHistoryId = syncHistoryId;
+    }
+
+    public void updateWatchExpiresAt(LocalDateTime watchExpiresAt) {
+        this.watchExpiresAt = watchExpiresAt;
     }
 
     public void activate() {

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
@@ -1,0 +1,94 @@
+package com.mailsangja.db.entity.mail;
+
+import com.mailsangja.db.entity.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "messages",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"thread_id", "gmail_message_id"}))
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Message extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "CHAR(36)")
+    @JdbcTypeCode(SqlTypes.CHAR)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "thread_id", nullable = false)
+    private Thread thread;
+
+    @Column(name = "gmail_message_id", nullable = false, length = 255)
+    private String gmailMessageId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "direction", nullable = false, length = 20)
+    private Direction direction;
+
+    @Column(name = "subject", length = 500)
+    private String subject;
+
+    // From 헤더 이메일
+    @Column(name = "from_address", nullable = false, length = 255)
+    private String fromAddress;
+
+    // To 수신자 목록
+    @Column(name = "to_addresses", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private List<String> toAddresses;
+
+    // CC 수신자 목록
+    @Column(name = "cc_addresses", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private List<String> ccAddresses;
+
+    // Gmail 메시지 snippet (180자 이내 미리보기)
+    @Column(name = "snippet", length = 500)
+    private String snippet;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean read;
+
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    @Column(name = "body_text", columnDefinition = "text")
+    private String bodyText;
+
+    @Column(name = "body_html", columnDefinition = "text")
+    private String bodyHtml;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "message", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Attachment> attachments = new ArrayList<>();
+
+    @Builder.Default
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "message_labels",
+            joinColumns = @JoinColumn(name = "message_id"),
+            inverseJoinColumns = @JoinColumn(name = "label_id")
+    )
+    private List<Label> labels = new ArrayList<>();
+
+    public void markAsRead() {
+        this.read = true;
+    }
+
+    public void markAsUnread() {
+        this.read = false;
+    }
+}

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Thread.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Thread.java
@@ -1,0 +1,101 @@
+package com.mailsangja.db.entity.mail;
+
+import com.mailsangja.db.entity.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "threads",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"mail_account_id", "gmail_thread_id", "direction"}))
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Thread extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "CHAR(36)")
+    @JdbcTypeCode(SqlTypes.CHAR)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mail_account_id", nullable = false)
+    private MailAccount mailAccount;
+
+    @Column(name = "gmail_thread_id", nullable = false, length = 255)
+    private String gmailThreadId;
+
+    // 이 행이 받은 편지함(INBOUND)인지 보낸 편지함(OUTBOUND)인지 구분
+    @Enumerated(EnumType.STRING)
+    @Column(name = "direction", nullable = false, length = 20)
+    private Direction direction;
+
+    @Column(name = "history_id", length = 255)
+    private String historyId;
+
+    // 이 direction 기준 가장 최근 메시지 정보
+    @Column(name = "latest_subject", length = 500)
+    private String latestSubject;
+
+    @Column(name = "latest_snippet", length = 500)
+    private String latestSnippet;
+
+    // INBOUND: 발신자 이메일 / OUTBOUND: 주 수신자 이메일
+    @Column(name = "latest_participant_address", length = 255)
+    private String latestParticipantAddress;
+
+    @Column(name = "last_message_at")
+    private LocalDateTime lastMessageAt;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean read;
+
+    @Column(name = "message_count", nullable = false)
+    private int messageCount;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "thread", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Message> messages = new ArrayList<>();
+
+    @Builder.Default
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "thread_labels",
+            joinColumns = @JoinColumn(name = "thread_id"),
+            inverseJoinColumns = @JoinColumn(name = "label_id")
+    )
+    private List<Label> labels = new ArrayList<>();
+
+    public void updateLatestMessageInfo(
+            String subject,
+            String snippet,
+            String participantAddress,
+            LocalDateTime lastMessageAt
+    ) {
+        this.latestSubject = subject;
+        this.latestSnippet = snippet;
+        this.latestParticipantAddress = participantAddress;
+        this.lastMessageAt = lastMessageAt;
+    }
+
+    public void updateReadStatus(boolean read) {
+        this.read = read;
+    }
+
+
+    public void incrementMessageCount() {
+        this.messageCount++;
+    }
+
+    public void updateHistoryId(String historyId) {
+        this.historyId = historyId;
+    }
+}

--- a/db/src/main/java/com/mailsangja/db/module/mail/AttachmentJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/AttachmentJpaRepositoryModule.java
@@ -1,0 +1,11 @@
+package com.mailsangja.db.module.mail;
+
+import com.mailsangja.db.entity.mail.Attachment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AttachmentJpaRepositoryModule extends JpaRepository<Attachment, UUID> {
+    List<Attachment> findAllByMessageId(UUID messageId);
+}

--- a/db/src/main/java/com/mailsangja/db/module/mail/LabelJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/LabelJpaRepositoryModule.java
@@ -1,0 +1,17 @@
+package com.mailsangja.db.module.mail;
+
+import com.mailsangja.db.entity.mail.Label;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LabelJpaRepositoryModule extends JpaRepository<Label, UUID> {
+
+    List<Label> findAllByUserIdAndDeletedAtIsNull(UUID userId);
+
+    Optional<Label> findByIdAndDeletedAtIsNull(UUID id);
+
+    Optional<Label> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId);
+}

--- a/db/src/main/java/com/mailsangja/db/module/mail/MailAccountJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MailAccountJpaRepositoryModule.java
@@ -4,24 +4,30 @@ import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.MailProvider;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface MailAccountJpaRepositoryModule extends JpaRepository<MailAccount, UUID> {
-    Optional<MailAccount> findByEmailAddress(String emailAddress);
-    Optional<MailAccount> findByUserIdAndProvider(UUID userId, MailProvider provider);
-    Optional<MailAccount> findByUserIdAndProviderAndEmailAddress(UUID userId, MailProvider provider, String emailAddress);
+
+    Optional<MailAccount> findByEmailAddressAndDeletedAtIsNull(String emailAddress);
+
+    Optional<MailAccount> findByUserIdAndProviderAndDeletedAtIsNull(UUID userId, MailProvider provider);
+
+    Optional<MailAccount> findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(UUID userId, MailProvider provider, String emailAddress);
 
     @EntityGraph(attributePaths = {"user"})
-    Optional<MailAccount> findByProviderAndEmailAddress(MailProvider provider, String emailAddress);
+    Optional<MailAccount> findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress);
 
     @EntityGraph(attributePaths = {"user"})
-    Optional<MailAccount> findById(UUID id);
+    @Query("SELECT ma FROM MailAccount ma WHERE ma.id = :id AND ma.deletedAt IS NULL")
+    Optional<MailAccount> findByIdAndDeletedAtIsNull(@Param("id") UUID id);
 
     @EntityGraph(attributePaths = {"user"})
-    Optional<MailAccount> findByIdAndActive(UUID id, boolean active);
+    Optional<MailAccount> findByIdAndActiveAndDeletedAtIsNull(UUID id, boolean active);
 
     @EntityGraph(attributePaths = {"user"})
     List<MailAccount> findAllByUserIdAndDeletedAtIsNull(UUID userId);

--- a/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
@@ -1,0 +1,29 @@
+package com.mailsangja.db.module.mail;
+
+import com.mailsangja.db.entity.mail.Message;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID> {
+
+    @EntityGraph(attributePaths = {"attachments"})
+    @Query("SELECT m FROM Message m WHERE m.thread.id = :threadId AND m.deletedAt IS NULL ORDER BY m.sentAt ASC")
+    List<Message> findAllByThreadIdAndDeletedAtIsNull(@Param("threadId") UUID threadId);
+
+    @EntityGraph(attributePaths = {"attachments"})
+    @Query("SELECT m FROM Message m WHERE m.thread.id IN :threadIds AND m.deletedAt IS NULL")
+    List<Message> findAllByThreadIdInAndDeletedAtIsNull(@Param("threadIds") List<UUID> threadIds);
+
+    // 스레드 상세 조회: INBOUND/OUTBOUND 두 Thread 행의 메시지를 모두 반환 (전체 대화)
+    @EntityGraph(attributePaths = {"attachments"})
+    @Query("SELECT m FROM Message m WHERE m.thread.mailAccount.id = :mailAccountId AND m.thread.gmailThreadId = :gmailThreadId AND m.deletedAt IS NULL ORDER BY m.sentAt ASC")
+    List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
+            @Param("mailAccountId") UUID mailAccountId,
+            @Param("gmailThreadId") String gmailThreadId
+    );
+}

--- a/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
 
     @EntityGraph(attributePaths = {"mailAccount"})
-    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN :accountIds AND t.direction = 'INBOUND' AND t.deletedAt IS NULL AND (:markerId IS NULL OR t.lastMessageAt < (SELECT m.lastMessageAt FROM Thread m WHERE m.id = :markerId)) ORDER BY t.lastMessageAt DESC")
+    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN :accountIds AND t.direction = 'INBOUND' AND t.deletedAt IS NULL AND (:markerId IS NULL OR t.lastMessageAt < (SELECT m.lastMessageAt FROM Thread m WHERE m.id = :markerId AND m.mailAccount.id IN :accountIds AND m.direction = 'INBOUND' AND m.deletedAt IS NULL)) ORDER BY t.lastMessageAt DESC")
     Slice<Thread> findInboxByMailAccountIdInAndDeletedAtIsNull(
             @Param("accountIds") List<UUID> accountIds,
             @Param("markerId") UUID markerId,
@@ -23,7 +23,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
     );
 
     @EntityGraph(attributePaths = {"mailAccount"})
-    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN :accountIds AND t.direction = 'OUTBOUND' AND t.deletedAt IS NULL AND (:markerId IS NULL OR t.lastMessageAt < (SELECT m.lastMessageAt FROM Thread m WHERE m.id = :markerId)) ORDER BY t.lastMessageAt DESC")
+    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN :accountIds AND t.direction = 'OUTBOUND' AND t.deletedAt IS NULL AND (:markerId IS NULL OR t.lastMessageAt < (SELECT m.lastMessageAt FROM Thread m WHERE m.id = :markerId AND m.mailAccount.id IN :accountIds AND m.direction = 'OUTBOUND' AND m.deletedAt IS NULL)) ORDER BY t.lastMessageAt DESC")
     Slice<Thread> findSentByMailAccountIdInAndDeletedAtIsNull(
             @Param("accountIds") List<UUID> accountIds,
             @Param("markerId") UUID markerId,

--- a/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
@@ -15,16 +15,18 @@ import java.util.UUID;
 public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
 
     @EntityGraph(attributePaths = {"mailAccount"})
-    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN :accountIds AND t.direction = 'INBOUND' AND t.deletedAt IS NULL ORDER BY t.lastMessageAt DESC")
+    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN :accountIds AND t.direction = 'INBOUND' AND t.deletedAt IS NULL AND (:markerId IS NULL OR t.lastMessageAt < (SELECT m.lastMessageAt FROM Thread m WHERE m.id = :markerId)) ORDER BY t.lastMessageAt DESC")
     Slice<Thread> findInboxByMailAccountIdInAndDeletedAtIsNull(
             @Param("accountIds") List<UUID> accountIds,
+            @Param("markerId") UUID markerId,
             Pageable pageable
     );
 
     @EntityGraph(attributePaths = {"mailAccount"})
-    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN :accountIds AND t.direction = 'OUTBOUND' AND t.deletedAt IS NULL ORDER BY t.lastMessageAt DESC")
+    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN :accountIds AND t.direction = 'OUTBOUND' AND t.deletedAt IS NULL AND (:markerId IS NULL OR t.lastMessageAt < (SELECT m.lastMessageAt FROM Thread m WHERE m.id = :markerId)) ORDER BY t.lastMessageAt DESC")
     Slice<Thread> findSentByMailAccountIdInAndDeletedAtIsNull(
             @Param("accountIds") List<UUID> accountIds,
+            @Param("markerId") UUID markerId,
             Pageable pageable
     );
 

--- a/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
@@ -8,24 +8,23 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
 
     @EntityGraph(attributePaths = {"mailAccount"})
-    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN :accountIds AND t.direction = 'INBOUND' AND t.deletedAt IS NULL AND (:markerId IS NULL OR t.lastMessageAt < (SELECT m.lastMessageAt FROM Thread m WHERE m.id = :markerId AND m.mailAccount.id IN :accountIds AND m.direction = 'INBOUND' AND m.deletedAt IS NULL)) ORDER BY t.lastMessageAt DESC")
-    Slice<Thread> findInboxByMailAccountIdInAndDeletedAtIsNull(
-            @Param("accountIds") List<UUID> accountIds,
+    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN (SELECT ma.id FROM MailAccount ma WHERE ma.user.id = :userId AND ma.deletedAt IS NULL) AND t.direction = 'INBOUND' AND t.deletedAt IS NULL AND (:markerId IS NULL OR t.lastMessageAt < (SELECT m.lastMessageAt FROM Thread m WHERE m.id = :markerId AND m.mailAccount.id IN (SELECT ma.id FROM MailAccount ma WHERE ma.user.id = :userId AND ma.deletedAt IS NULL) AND m.direction = 'INBOUND')) ORDER BY t.lastMessageAt DESC")
+    Slice<Thread> findInboxByUserIdAndDeletedAtIsNull(
+            @Param("userId") UUID userId,
             @Param("markerId") UUID markerId,
             Pageable pageable
     );
 
     @EntityGraph(attributePaths = {"mailAccount"})
-    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN :accountIds AND t.direction = 'OUTBOUND' AND t.deletedAt IS NULL AND (:markerId IS NULL OR t.lastMessageAt < (SELECT m.lastMessageAt FROM Thread m WHERE m.id = :markerId AND m.mailAccount.id IN :accountIds AND m.direction = 'OUTBOUND' AND m.deletedAt IS NULL)) ORDER BY t.lastMessageAt DESC")
-    Slice<Thread> findSentByMailAccountIdInAndDeletedAtIsNull(
-            @Param("accountIds") List<UUID> accountIds,
+    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN (SELECT ma.id FROM MailAccount ma WHERE ma.user.id = :userId AND ma.deletedAt IS NULL) AND t.direction = 'OUTBOUND' AND t.deletedAt IS NULL AND (:markerId IS NULL OR t.lastMessageAt < (SELECT m.lastMessageAt FROM Thread m WHERE m.id = :markerId AND m.mailAccount.id IN (SELECT ma.id FROM MailAccount ma WHERE ma.user.id = :userId AND ma.deletedAt IS NULL) AND m.direction = 'OUTBOUND')) ORDER BY t.lastMessageAt DESC")
+    Slice<Thread> findSentByUserIdAndDeletedAtIsNull(
+            @Param("userId") UUID userId,
             @Param("markerId") UUID markerId,
             Pageable pageable
     );

--- a/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
@@ -1,0 +1,37 @@
+package com.mailsangja.db.module.mail;
+
+import com.mailsangja.db.entity.mail.Thread;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
+
+    @EntityGraph(attributePaths = {"mailAccount"})
+    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN :accountIds AND t.direction = 'INBOUND' AND t.deletedAt IS NULL ORDER BY t.lastMessageAt DESC")
+    Slice<Thread> findInboxByMailAccountIdInAndDeletedAtIsNull(
+            @Param("accountIds") List<UUID> accountIds,
+            Pageable pageable
+    );
+
+    @EntityGraph(attributePaths = {"mailAccount"})
+    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN :accountIds AND t.direction = 'OUTBOUND' AND t.deletedAt IS NULL ORDER BY t.lastMessageAt DESC")
+    Slice<Thread> findSentByMailAccountIdInAndDeletedAtIsNull(
+            @Param("accountIds") List<UUID> accountIds,
+            Pageable pageable
+    );
+
+    @EntityGraph(attributePaths = {"mailAccount"})
+    Optional<Thread> findByIdAndDeletedAtIsNull(UUID id);
+
+    Optional<Thread> findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+            UUID mailAccountId, String gmailThreadId, com.mailsangja.db.entity.mail.Direction direction
+    );
+}

--- a/db/src/main/java/com/mailsangja/db/port/AttachmentRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/AttachmentRepositoryPort.java
@@ -1,0 +1,11 @@
+package com.mailsangja.db.port;
+
+import com.mailsangja.db.entity.mail.Attachment;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AttachmentRepositoryPort {
+    Attachment save(Attachment attachment);
+    List<Attachment> findAllByMessageId(UUID messageId);
+}

--- a/db/src/main/java/com/mailsangja/db/port/LabelRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/LabelRepositoryPort.java
@@ -1,0 +1,14 @@
+package com.mailsangja.db.port;
+
+import com.mailsangja.db.entity.mail.Label;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LabelRepositoryPort {
+    Label save(Label label);
+    List<Label> findAllByUserIdAndDeletedAtIsNull(UUID userId);
+    Optional<Label> findByIdAndDeletedAtIsNull(UUID id);
+    Optional<Label> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId);
+}

--- a/db/src/main/java/com/mailsangja/db/port/MailAccountRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/MailAccountRepositoryPort.java
@@ -9,11 +9,11 @@ import java.util.UUID;
 
 public interface MailAccountRepositoryPort {
     MailAccount save(MailAccount mailAccount);
-    Optional<MailAccount> findById(UUID id);
-    Optional<MailAccount> findByIdAndActive(UUID id, boolean active);
-    Optional<MailAccount> findByEmailAddress(String emailAddress);
-    Optional<MailAccount> findByUserIdAndProvider(UUID userId, MailProvider provider);
-    Optional<MailAccount> findByUserIdAndProviderAndEmailAddress(UUID userId, MailProvider provider, String emailAddress);
-    Optional<MailAccount> findByProviderAndEmailAddress(MailProvider provider, String emailAddress);
+    Optional<MailAccount> findByIdAndDeletedAtIsNull(UUID id);
+    Optional<MailAccount> findByIdAndActiveAndDeletedAtIsNull(UUID id, boolean active);
+    Optional<MailAccount> findByEmailAddressAndDeletedAtIsNull(String emailAddress);
+    Optional<MailAccount> findByUserIdAndProviderAndDeletedAtIsNull(UUID userId, MailProvider provider);
+    Optional<MailAccount> findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(UUID userId, MailProvider provider, String emailAddress);
+    Optional<MailAccount> findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress);
     List<MailAccount> findAllByUserIdAndDeletedAtIsNull(UUID userId);
 }

--- a/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
@@ -1,0 +1,13 @@
+package com.mailsangja.db.port;
+
+import com.mailsangja.db.entity.mail.Message;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface MessageRepositoryPort {
+    Message save(Message message);
+    List<Message> findAllByThreadIdAndDeletedAtIsNull(UUID threadId);
+    List<Message> findAllByThreadIdInAndDeletedAtIsNull(List<UUID> threadIds);
+    List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId);
+}

--- a/db/src/main/java/com/mailsangja/db/port/ThreadRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/ThreadRepositoryPort.java
@@ -13,6 +13,6 @@ public interface ThreadRepositoryPort {
     Thread save(Thread thread);
     Optional<Thread> findByIdAndDeletedAtIsNull(UUID id);
     Optional<Thread> findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId, Direction direction);
-    Slice<Thread> findInboxByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, Pageable pageable);
-    Slice<Thread> findSentByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, Pageable pageable);
+    Slice<Thread> findInboxByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, UUID markerId, Pageable pageable);
+    Slice<Thread> findSentByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, UUID markerId, Pageable pageable);
 }

--- a/db/src/main/java/com/mailsangja/db/port/ThreadRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/ThreadRepositoryPort.java
@@ -5,7 +5,6 @@ import com.mailsangja.db.entity.mail.Thread;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,6 +12,6 @@ public interface ThreadRepositoryPort {
     Thread save(Thread thread);
     Optional<Thread> findByIdAndDeletedAtIsNull(UUID id);
     Optional<Thread> findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId, Direction direction);
-    Slice<Thread> findInboxByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, UUID markerId, Pageable pageable);
-    Slice<Thread> findSentByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, UUID markerId, Pageable pageable);
+    Slice<Thread> findInboxByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable);
+    Slice<Thread> findSentByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable);
 }

--- a/db/src/main/java/com/mailsangja/db/port/ThreadRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/ThreadRepositoryPort.java
@@ -1,0 +1,18 @@
+package com.mailsangja.db.port;
+
+import com.mailsangja.db.entity.mail.Direction;
+import com.mailsangja.db.entity.mail.Thread;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ThreadRepositoryPort {
+    Thread save(Thread thread);
+    Optional<Thread> findByIdAndDeletedAtIsNull(UUID id);
+    Optional<Thread> findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId, Direction direction);
+    Slice<Thread> findInboxByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, Pageable pageable);
+    Slice<Thread> findSentByMailAccountIdInAndDeletedAtIsNull(List<UUID> accountIds, Pageable pageable);
+}

--- a/db/src/main/resources/schema.sql
+++ b/db/src/main/resources/schema.sql
@@ -5,31 +5,126 @@ CREATE TABLE IF NOT EXISTS users (
     password        VARCHAR(255) NOT NULL,
     plan            VARCHAR(20)  NOT NULL,
     role            VARCHAR(20)  NOT NULL,
-    credit_usage    INT         NOT NULL,
-    default_account CHAR(36)    NULL,
-    created_at      TIMESTAMP   NOT NULL,
-    modified_at     TIMESTAMP   NOT NULL,
-    deleted_at      TIMESTAMP   NULL,
+    credit_usage    INT          NOT NULL,
+    default_account CHAR(36)     NULL,
+    created_at      TIMESTAMP    NOT NULL,
+    modified_at     TIMESTAMP    NOT NULL,
+    deleted_at      TIMESTAMP    NULL,
 
     PRIMARY KEY (id)
 );
 
 CREATE TABLE IF NOT EXISTS mail_accounts (
-    id                      CHAR(36)                NOT NULL,
-    user_id                 CHAR(36)                NOT NULL,
-    provider                VARCHAR(50)             NOT NULL,
-    email_address           VARCHAR(255)            NOT NULL,
-    alias                   VARCHAR(255)            NOT NULL,
-    icon                    VARCHAR(255)            NOT NULL,
-    color                   VARCHAR(7)              NOT NULL,
-    access_token            TEXT                    NOT NULL,
-    access_token_expires_at TIMESTAMP               NOT NULL,
-    refresh_token           TEXT                    NULL,
-    is_active               BOOLEAN                 NOT NULL,
-    sync_history_id         VARCHAR(255)            NULL,
-    created_at              TIMESTAMP               NOT NULL,
-    modified_at             TIMESTAMP               NOT NULL,
-    deleted_at              TIMESTAMP               NULL,
+    id                      CHAR(36)     NOT NULL,
+    user_id                 CHAR(36)     NOT NULL,
+    provider                VARCHAR(50)  NOT NULL,
+    email_address           VARCHAR(255) NOT NULL,
+    alias                   VARCHAR(255) NOT NULL,
+    icon                    VARCHAR(255) NOT NULL,
+    color                   VARCHAR(7)   NOT NULL,
+    access_token            TEXT         NOT NULL,
+    access_token_expires_at TIMESTAMP    NOT NULL,
+    refresh_token           TEXT         NULL,
+    is_active               BOOLEAN      NOT NULL,
+    sync_history_id         VARCHAR(255) NULL,
+    created_at              TIMESTAMP    NOT NULL,
+    modified_at             TIMESTAMP    NOT NULL,
+    deleted_at              TIMESTAMP    NULL,
 
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    CONSTRAINT fk_mail_accounts_user FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+-- direction: INBOUND(받은 편지함) / OUTBOUND(보낸 편지함)
+-- 같은 gmail_thread_id라도 대화가 있으면 direction별로 최대 2개 row 존재
+CREATE TABLE IF NOT EXISTS threads (
+    id                         CHAR(36)     NOT NULL,
+    mail_account_id            CHAR(36)     NOT NULL,
+    gmail_thread_id            VARCHAR(255) NOT NULL,
+    direction                  VARCHAR(20)  NOT NULL,
+    history_id                 VARCHAR(255) NULL,
+    latest_subject             VARCHAR(500) NULL,
+    latest_snippet             VARCHAR(500) NULL,
+    latest_participant_address VARCHAR(255) NULL,
+    last_message_at            TIMESTAMP    NULL,
+    is_read                    BOOLEAN      NOT NULL DEFAULT FALSE,
+    message_count              INT          NOT NULL DEFAULT 0,
+    created_at                 TIMESTAMP    NOT NULL,
+    modified_at                TIMESTAMP    NOT NULL,
+    deleted_at                 TIMESTAMP    NULL,
+
+    PRIMARY KEY (id),
+    CONSTRAINT uq_threads_account_gmail_direction UNIQUE (mail_account_id, gmail_thread_id, direction),
+    CONSTRAINT fk_threads_account FOREIGN KEY (mail_account_id) REFERENCES mail_accounts (id)
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id               CHAR(36)     NOT NULL,
+    thread_id        CHAR(36)     NOT NULL,
+    gmail_message_id VARCHAR(255) NOT NULL,
+    direction        VARCHAR(20)  NOT NULL,
+    subject          VARCHAR(500) NULL,
+    from_address     VARCHAR(255) NOT NULL,
+    to_addresses     JSONB        NULL,
+    cc_addresses     JSONB        NULL,
+    snippet          VARCHAR(500) NULL,
+    is_read          BOOLEAN      NOT NULL DEFAULT FALSE,
+    sent_at          TIMESTAMP    NULL,
+    body_text        TEXT         NULL,
+    body_html        TEXT         NULL,
+    created_at       TIMESTAMP    NOT NULL,
+    modified_at      TIMESTAMP    NOT NULL,
+    deleted_at       TIMESTAMP    NULL,
+
+    PRIMARY KEY (id),
+    CONSTRAINT uq_messages_thread_gmail UNIQUE (thread_id, gmail_message_id),
+    CONSTRAINT fk_messages_thread FOREIGN KEY (thread_id) REFERENCES threads (id)
+);
+
+CREATE TABLE IF NOT EXISTS attachments (
+    id                  CHAR(36)     NOT NULL,
+    message_id          CHAR(36)     NOT NULL,
+    gmail_attachment_id VARCHAR(255) NULL,
+    filename            VARCHAR(255) NOT NULL,
+    mime_type           VARCHAR(255) NOT NULL,
+    size                INT          NULL,
+    created_at          TIMESTAMP    NOT NULL,
+    modified_at         TIMESTAMP    NOT NULL,
+    deleted_at          TIMESTAMP    NULL,
+
+    PRIMARY KEY (id),
+    CONSTRAINT fk_attachments_message FOREIGN KEY (message_id) REFERENCES messages (id)
+);
+
+CREATE TABLE IF NOT EXISTS labels (
+    id                   CHAR(36)     NOT NULL,
+    user_id              CHAR(36)     NOT NULL,
+    name                 VARCHAR(100) NOT NULL,
+    color_code           VARCHAR(7)   NOT NULL,
+    notification_enabled BOOLEAN      NOT NULL DEFAULT FALSE,
+    rule                 JSONB        NULL,
+    created_at           TIMESTAMP    NOT NULL,
+    modified_at          TIMESTAMP    NOT NULL,
+    deleted_at           TIMESTAMP    NULL,
+
+    PRIMARY KEY (id),
+    CONSTRAINT fk_labels_user FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE TABLE IF NOT EXISTS thread_labels (
+    thread_id CHAR(36) NOT NULL,
+    label_id  CHAR(36) NOT NULL,
+
+    PRIMARY KEY (thread_id, label_id),
+    CONSTRAINT fk_thread_labels_thread FOREIGN KEY (thread_id) REFERENCES threads (id),
+    CONSTRAINT fk_thread_labels_label  FOREIGN KEY (label_id)  REFERENCES labels (id)
+);
+
+CREATE TABLE IF NOT EXISTS message_labels (
+    message_id CHAR(36) NOT NULL,
+    label_id   CHAR(36) NOT NULL,
+
+    PRIMARY KEY (message_id, label_id),
+    CONSTRAINT fk_message_labels_message FOREIGN KEY (message_id) REFERENCES messages (id),
+    CONSTRAINT fk_message_labels_label   FOREIGN KEY (label_id)   REFERENCES labels (id)
 );

--- a/db/src/main/resources/schema.sql
+++ b/db/src/main/resources/schema.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS mail_accounts (
     refresh_token           TEXT         NULL,
     is_active               BOOLEAN      NOT NULL,
     sync_history_id         VARCHAR(255) NULL,
+    watch_expires_at        TIMESTAMP    NULL,
     created_at              TIMESTAMP    NOT NULL,
     modified_at             TIMESTAMP    NOT NULL,
     deleted_at              TIMESTAMP    NULL,


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#4

### 📌 Task
- Closes #19
- Closes #20 


## 💡 작업 내용

### 1. API 엔드포인트 구현
- API Path  
  - [x] `GET /api/v1/threads/inbox` : 받은 스레드 목록
  - [x] `GET /api/v1/threads/sent` : 보낸 스레드 목록
  - [x] `GET /api/v1/threads/{threadId}` : 스레드 상세(전체 대화)
- 상세 조회는 단일 Thread row가 아닌 **동일 gmailThreadId의 INBOUND/OUTBOUND 메시지 전체**를 합쳐 보여주는 모델
- Swagger 문서화
  - `InboxControllerDocs` 인터페이스에 `@Operation`, `@ApiResponses` 정의
  - 구현체 `InboxController`가 인터페이스를 구현

### 2. 페이지네이션
- 페이지네이션은 `SliceResponse`를 사용(무한 스크롤)
- 인박스 페이지 크기 외부화
  - `InboxProperties` (`mailsangja.inbox.page-size`)
  - `application.yaml`에 `INBOX_PAGE_SIZE` 환경변수 바인딩

### 3. 요청 처리 플로우
```mermaid
sequenceDiagram
    participant C as Client
    participant IC as InboxController
    participant IF as InboxFacade
    participant IQS as InboxQueryService
    participant MAPQS as MailAccountQueryService
    participant TRP as ThreadRepositoryPort
    participant MRP as MessageRepositoryPort

    C->>IC: GET /api/v1/threads/inbox?page=0
    IC->>IF: getInbox(user, page)
    IF->>MAPQS: findAllByUserId(userId)
    IF->>IQS: findInboxThreadsByAccountIds(accountIds, pageable)
    IQS->>TRP: findInboxByMailAccountIdInAndDeletedAtIsNull
    IF->>IQS: findAttachmentsByThreadIds(threadIds)
    IQS->>MRP: findAllByThreadIdInAndDeletedAtIsNull
    IF-->>IC: SliceResponse<ThreadSummaryResponse>
    IC-->>C: 200 OK
```

### 4. DB 스키마/엔티티 설계

#### 핵심 테이블
- `threads`
  - `mail_account_id`, `gmail_thread_id`, `direction` 유니크
  - 같은 gmail thread라도 방향별(INBOUND/OUTBOUND) 최대 2행 허용
- `messages`
  - `(thread_id, gmail_message_id)` 유니크
  - 수신/발신자/본문/snippet/주소목록(JSONB) 보관
- `attachments`
  - 메시지 단위 첨부파일 메타
- `labels`, `thread_labels`, `message_labels`
  - 라벨링 확장을 위한 M:N 구조

### 5. ERD

<img width="6048" height="3008" alt="image" src="https://github.com/user-attachments/assets/1f6ce7dd-6ef5-43c5-8c11-02653979b899" />

### 6. Repository 조회 최적화
- `ThreadJpaRepositoryModule`
  - `@EntityGraph(attributePaths = {"mailAccount"})`
  - 목록 조회 시 account lazy loading N+1 완화
- `MessageJpaRepositoryModule`
  - `@EntityGraph(attributePaths = {"attachments"})`
  - 메시지+첨부를 함께 로딩해 상세/목록 매핑 비용 감소
- `InboxQueryService.findAttachmentsByThreadIds(...)`
  - 여러 thread의 message/attachment를 한 번에 가져와 threadId 기준 group
  - 목록 API에서 첨부 조회 N+1 감소 목적

## 📝 추가 설명 : Thread Direction 설계

> `threads.direction`이 왜 필요한지, 같은 `gmail_thread_id`에 대해 왜 최대 2개의 `threads` row를 허용하는지, 현재 조회/상세 API에서 이를 어떻게 활용하는지, 그리고 신규 메일 도착 시 어떤 규칙으로 안전하게 처리해야 하는지를 상세히 설명합니다.

## 1. 문제 정의: Gmail의 Thread 모델 vs 서비스의 Inbox UX 모델

Gmail의 `gmail_thread_id`는 "대화 묶음"을 식별한다. 하지만 서비스 UX는 아래 두 개의 목록을 동시에 요구한다.

- 받은함 목록 (`INBOUND` 관점)
- 보낸함 목록 (`OUTBOUND` 관점)

한 개의 thread row만 두면 다음 문제가 발생한다.

1. 받은함 기준 최신 정보와 보낸함 기준 최신 정보가 서로 덮어쓴다.
2. `participant` 의미가 충돌한다. (받은함: 최근 발신자 / 보낸함: 최근 주 수신자)
3. 읽음 상태, 카운트, 정렬 기준을 양쪽 목록에서 동시에 일관되게 유지하기 어렵다.

따라서 이 서비스는 Gmail 원본 모델을 그대로 복사하지 않고, **목록 조회 최적화용 Projection 모델**로 `threads`를 방향별로 분리한다.

---

## 2. `threads.direction`의 역할

`direction`은 "이 row가 어떤 목록 관점의 요약 상태인지"를 나타낸다.

- `INBOUND`: 받은함 카드용 상태
- `OUTBOUND`: 보낸함 카드용 상태

즉 `threads`는 "대화 원본"이라기보다, **목록 카드 상태 저장소**에 가깝다.

### 2.1 핵심 유니크 제약

`threads`는 아래 키로 유니크하다.

- `(mail_account_id, gmail_thread_id, direction)`

의미:
- 같은 계정 + 같은 Gmail 대화 + 같은 방향 row는 1개만 존재
- 방향이 다르면(`INBOUND` vs `OUTBOUND`) 2개까지 허용

그래서 "같은 `gmail_thread_id`인데 row가 2개"가 비정상이 아니라, **양방향 활동이 발생한 정상 상태**다.

---

## 3. 왜 같은 `gmail_thread_id`에 최대 2개 row가 필요한가

## 3.1 정보 손실 방지
하나의 row만 쓰면 마지막 이벤트가 수신인지 발신인지에 따라 `latest_subject`, `latest_snippet`, `latest_participant_address`가 한쪽 의미로만 남는다.

방향별 2-row 구조는 다음을 보장한다.

- 받은함은 받은함 의미로만 최신화
- 보낸함은 보낸함 의미로만 최신화

## 3.2 조회 단순화 및 성능
`/threads/inbox`, `/threads/sent` 조회 시 direction 조건만 주면 된다.

- 받은함: `WHERE direction = 'INBOUND'`
- 보낸함: `WHERE direction = 'OUTBOUND'`

목록 API에서 추가 분류/집계를 최소화하여 응답 지연을 줄인다.

## 3.3 도메인 해석의 명확성
`latest_participant_address`를 문맥 없이 해석하면 모호하다.

- INBOUND row: 최근 발신자 주소
- OUTBOUND row: 최근 주 수신자 주소

direction 분리로 필드 의미가 명확해진다.

---

## 4. 현재 API에서의 활용 방식

- `GET /api/v1/threads/inbox`
  - `INBOUND` row만 조회해 받은함 목록 구성
- `GET /api/v1/threads/sent`
  - `OUTBOUND` row만 조회해 보낸함 목록 구성
- `GET /api/v1/threads/{threadId}`
  - 특정 row 접근 권한 검증 후,
  - 동일 `(mailAccountId, gmailThreadId)`의 메시지를 방향 무관하게 모두 조회
  - 즉 상세는 통합 대화, 목록은 방향 분리

```mermaid
sequenceDiagram
    participant Client
    participant Controller as InboxController
    participant Facade as InboxFacade
    participant Query as InboxQueryService
    participant TRepo as ThreadRepository
    participant MRepo as MessageRepository

    Client->>Controller: GET /api/v1/threads/{threadId}
    Controller->>Facade: getThreadDetail(user, threadId)
    Facade->>Query: findThreadById(threadId)
    Query->>TRepo: findByIdAndDeletedAtIsNull
    Facade->>Facade: 사용자-계정 접근권한 검증
    Facade->>Query: findAllMessagesByThread(mailAccountId, gmailThreadId)
    Query->>MRepo: findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull
    Query-->>Facade: 수신+발신 메시지 통합 목록
    Facade-->>Controller: ThreadDetailResponse
    Controller-->>Client: 200 OK
```

---

## 5. 신규 메일 도착 시 처리 규칙 (권장 처리 시나리오)

신규 이벤트(수신/발신 동기화)가 들어오면 아래 순서를 따른다.

1. 이벤트에서 `mailAccountId`, `gmailThreadId`, `gmailMessageId` 추출
2. 메시지 방향 판별 (`INBOUND`/`OUTBOUND`)
3. `(mailAccountId, gmailThreadId, direction)`으로 thread row 조회
4. 없으면 생성, 있으면 최신 정보 갱신
5. `messages`에 `(thread_id, gmail_message_id)` 기준으로 중복 방지 insert
6. 첨부 메타(`attachments`) 저장
7. 필요 시 카운트/읽음/history_id 업데이트

```mermaid
stateDiagram-v2
    [*] --> EventArrived
    EventArrived --> ResolveDirection
    ResolveDirection --> FindThreadRow

    FindThreadRow --> CreateThreadRow: row 없음
    FindThreadRow --> UpdateThreadRow: row 존재

    CreateThreadRow --> SaveMessage
    UpdateThreadRow --> SaveMessage

    SaveMessage --> SaveAttachments
    SaveAttachments --> [*]
```

---

## 6. "대화 기록이 존재하면 2개 row"의 정확한 해석

정확히는 아래가 맞다.

- 같은 대화(`gmail_thread_id`)에서 **수신 이벤트와 발신 이벤트가 모두 발생하면** 2개 row가 존재할 수 있다.
- 한쪽 이벤트만 존재하면 1개 row만 존재한다.

예시:
- 내가 받은 메일만 있고 답장 안 함 -> INBOUND row만 존재
- 내가 먼저 보낸 메일에 회신 없음 -> OUTBOUND row만 존재
- 주고받은 대화 -> INBOUND + OUTBOUND 둘 다 존재

---

## 7. N+1/성능 관점

- thread 목록 조회에서 `mailAccount`는 `EntityGraph`로 동시 로딩
- message 조회에서 `attachments`는 `EntityGraph`로 동시 로딩
- thread별 첨부를 개별 조회하지 않고 batch 조회 후 group-by로 묶어 N+1 감소

---

## 8. 결론

`threads.direction` 기반 2-row 모델은 단순 중복이 아니라,

1. 받은함/보낸함을 빠르고 명확하게 분리 조회하고,
2. 목록 카드 의미를 방향별로 정확히 유지하며,
3. 상세에서는 동일 `gmail_thread_id`의 대화를 다시 통합