### PR TITLE
[STORY-201] Swagger 문서 개선

### DIFF
--- a/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
@@ -31,11 +31,7 @@ public interface InboxControllerDocs {
             security = @SecurityRequirement(name = "cookieAuth")
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "스레드 목록 조회 성공",
-                    content = @Content(schema = @Schema(implementation = MarkerSliceResponse.class))
-            ),
+            @ApiResponse(responseCode = "200", description = "스레드 목록 조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증 필요",
                     content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "400", description = "유효하지 않은 marker",
@@ -58,11 +54,7 @@ public interface InboxControllerDocs {
             security = @SecurityRequirement(name = "cookieAuth")
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "스레드 목록 조회 성공",
-                    content = @Content(schema = @Schema(implementation = MarkerSliceResponse.class))
-            ),
+            @ApiResponse(responseCode = "200", description = "스레드 목록 조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증 필요",
                     content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "400", description = "유효하지 않은 marker",
@@ -82,11 +74,7 @@ public interface InboxControllerDocs {
             security = @SecurityRequirement(name = "cookieAuth")
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "스레드 상세 조회 성공",
-                    content = @Content(schema = @Schema(implementation = ThreadDetailResponse.class))
-            ),
+            @ApiResponse(responseCode = "200", description = "스레드 상세 조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증 필요",
                     content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403", description = "스레드 접근 권한 없음",


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#4

### 📌 Task
- Closes #20 

## 💡 작업 내용

### 기존의 문제점
- `@ApiResponse의 content = @Content(schema = @Schema(implementation = MarkerSliceResponse.class))`처럼 raw 타입을 직접 지정하면, SpringDoc 이 메서드 시그니처에서 추론하던 제네릭 타입 정보(<ThreadSummaryResponse>)를 덮어써버립니다.
- 결과적으로 Swagger UI에서 content 필드가 object[]로만 표시됩니다.

### 수정 내역
- Inbox API의 세 메서드 모두 200 응답의 content 오버라이드를 제거했습니다.
- SpringDoc은 메서드 반환 타입(`ResponseEntity<MarkerSliceResponse<ThreadSummaryResponse>>, ResponseEntity<ThreadDetailResponse>`)에서 제네릭을 포함한 스키마를 자동으로 추론합니다.
- 이제 Swagger UI에서 응답 객체의 전체 구조가 올바르게 표시됩니다.

## 📝 추가 설명

- 이제 Swagger UI에서 응답 객체의 전체 구조가 올바르게 표시됩니다.
- 또한, `.codex` 와 같이 사용하지 않는 빈 파일을 제거하였습니다.