### PR TITLE
[STORY-201] 메일 주소록 정보 추가 및 Facade 및 Domain 구조 개선

### DIFF
--- a/core/src/main/java/com/mailsangja/core/dto/inbox/MailAddressResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/MailAddressResponse.java
@@ -1,0 +1,17 @@
+package com.mailsangja.core.dto.inbox;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Map;
+
+@Schema(description = "메일 주소 (이름 + 이메일)")
+public record MailAddressResponse(
+        @Schema(description = "발신자/수신자 이름 (주소록에 등록된 경우)", example = "김휘래", nullable = true)
+        String name,
+        @Schema(description = "이메일 주소", example = "hramst0618@gmail.com")
+        String email
+) {
+    public static MailAddressResponse of(String email, Map<String, String> contactNameByEmail) {
+        return new MailAddressResponse(contactNameByEmail.get(email), email);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/MessageResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/MessageResponse.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Schema(description = "메일 메시지 상세 정보")
@@ -18,12 +19,12 @@ public record MessageResponse(
         String subject,
         @Schema(description = "메시지 방향 (INBOUND: 수신, OUTBOUND: 발신)")
         Direction direction,
-        @Schema(description = "발신자 이메일", example = "hong@example.com")
-        String fromAddress,
-        @Schema(description = "수신자 목록", example = "[\"user@gmail.com\"]")
-        List<String> toAddresses,
-        @Schema(description = "CC 수신자 목록", example = "[]")
-        List<String> ccAddresses,
+        @Schema(description = "발신자")
+        MailAddressResponse from,
+        @Schema(description = "수신자 목록")
+        List<MailAddressResponse> to,
+        @Schema(description = "CC 수신자 목록")
+        List<MailAddressResponse> cc,
         @Schema(description = "메시지 스니펫 (미리보기)", example = "안녕하세요, 미팅 관련하여...")
         String snippet,
         @Schema(description = "읽음 여부", example = "true")
@@ -37,19 +38,29 @@ public record MessageResponse(
         @Schema(description = "첨부파일 목록")
         List<AttachmentResponse> attachments
 ) {
-    public static MessageResponse from(Message message) {
+    public static MessageResponse from(Message message, Map<String, String> contactNameByEmail) {
         List<AttachmentResponse> attachmentResponses = message.getAttachments().stream()
                 .map(AttachmentResponse::from)
                 .toList();
+
+        List<MailAddressResponse> toAddresses = message.getToAddresses() == null ? List.of() :
+                message.getToAddresses().stream()
+                        .map(email -> MailAddressResponse.of(email, contactNameByEmail))
+                        .toList();
+
+        List<MailAddressResponse> ccAddresses = message.getCcAddresses() == null ? List.of() :
+                message.getCcAddresses().stream()
+                        .map(email -> MailAddressResponse.of(email, contactNameByEmail))
+                        .toList();
 
         return new MessageResponse(
                 message.getId(),
                 message.getGmailMessageId(),
                 message.getSubject(),
                 message.getDirection(),
-                message.getFromAddress(),
-                message.getToAddresses(),
-                message.getCcAddresses(),
+                MailAddressResponse.of(message.getFromAddress(), contactNameByEmail),
+                toAddresses,
+                ccAddresses,
                 message.getSnippet(),
                 message.isRead(),
                 message.getSentAt(),

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadDetailResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadDetailResponse.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Schema(description = "메일 스레드 상세 응답")
@@ -25,9 +26,9 @@ public record ThreadDetailResponse(
         @Schema(description = "스레드 내 메시지 목록 (sentAt ASC 정렬)")
         List<MessageResponse> messages
 ) {
-    public static ThreadDetailResponse from(Thread thread, List<Message> messages) {
+    public static ThreadDetailResponse from(Thread thread, List<Message> messages, Map<String, String> contactNameByEmail) {
         List<MessageResponse> messageResponses = messages.stream()
-                .map(MessageResponse::from)
+                .map(message -> MessageResponse.from(message, contactNameByEmail))
                 .toList();
 
         return new ThreadDetailResponse(

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadDetailResult.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadDetailResult.java
@@ -1,0 +1,13 @@
+package com.mailsangja.core.dto.inbox;
+
+import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.entity.mail.Thread;
+
+import java.util.List;
+import java.util.Map;
+
+public record ThreadDetailResult(
+        Thread thread,
+        List<Message> messages,
+        Map<String, String> contactNameByEmail
+) {}

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadListResult.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadListResult.java
@@ -1,0 +1,15 @@
+package com.mailsangja.core.dto.inbox;
+
+import com.mailsangja.db.entity.mail.Attachment;
+import com.mailsangja.db.entity.mail.Thread;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record ThreadListResult(
+        Slice<Thread> threads,
+        Map<UUID, List<Attachment>> attachmentsByThreadId,
+        Map<String, String> contactNameByEmail
+) {}

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponse.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Schema(description = "통합 인박스 스레드 목록 항목")
@@ -18,8 +19,8 @@ public record ThreadSummaryResponse(
         UUID accountId,
         @Schema(description = "최신 메시지 제목", example = "프로젝트 미팅 일정 안내")
         String latestSubject,
-        @Schema(description = "INBOUND일 때 발신자 이메일, OUTBOUND일 때 주 수신자 이메일", example = "hong@example.com")
-        String participantAddress,
+        @Schema(description = "INBOUND일 때 발신자, OUTBOUND일 때 주 수신자")
+        MailAddressResponse participant,
         @Schema(description = "최신 메시지 미리보기 텍스트", example = "안녕하세요, 다음 주 미팅 일정을 안내드립니다...")
         String snippet,
         @Schema(description = "읽음 여부", example = "false")
@@ -29,7 +30,7 @@ public record ThreadSummaryResponse(
         @Schema(description = "스레드 내 첨부파일 목록")
         List<AttachmentResponse> attachments
 ) {
-    public static ThreadSummaryResponse from(Thread thread, List<Attachment> attachments) {
+    public static ThreadSummaryResponse from(Thread thread, List<Attachment> attachments, Map<String, String> contactNameByEmail) {
         List<AttachmentResponse> attachmentResponses = attachments.stream()
                 .map(AttachmentResponse::from)
                 .toList();
@@ -39,7 +40,7 @@ public record ThreadSummaryResponse(
                 thread.getGmailThreadId(),
                 thread.getMailAccount().getId(),
                 thread.getLatestSubject(),
-                thread.getLatestParticipantAddress(),
+                MailAddressResponse.of(thread.getLatestParticipantAddress(), contactNameByEmail),
                 thread.getLatestSnippet(),
                 thread.isRead(),
                 thread.getLastMessageAt(),

--- a/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
@@ -40,7 +40,7 @@ public class InboxFacade {
 
     public ThreadDetailResponse getThreadDetail(User user, UUID threadId) {
         Thread thread = inboxQueryService.findThreadById(threadId);
-        validateThreadAccess(mailAccountQueryService.findAllByUserId(user.getId()), thread);
+        validateThreadAccess(mailAccountQueryService.findAllActiveByUserId(user.getId()), thread);
         ThreadDetailResult result = inboxQueryService.findThreadDetailResult(thread);
         return ThreadDetailResponse.from(result.thread(), result.messages(), result.contactNameByEmail());
     }

--- a/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
@@ -6,20 +6,17 @@ import com.mailsangja.core.dto.common.MarkerSliceResponse;
 import com.mailsangja.core.dto.inbox.ThreadDetailResponse;
 import com.mailsangja.core.dto.inbox.ThreadSummaryResponse;
 import com.mailsangja.core.service.inbox.InboxQueryService;
+import com.mailsangja.core.dto.inbox.ThreadDetailResult;
+import com.mailsangja.core.dto.inbox.ThreadListResult;
 import com.mailsangja.core.service.mail.MailAccountQueryService;
-import com.mailsangja.db.entity.mail.Attachment;
 import com.mailsangja.db.entity.mail.MailAccount;
-import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.Thread;
 import com.mailsangja.db.entity.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -32,41 +29,31 @@ public class InboxFacade {
     private final MailAccountQueryService mailAccountQueryService;
 
     public MarkerSliceResponse<ThreadSummaryResponse> getInbox(User user, UUID marker, int size) {
-        return getThreadList(user, marker, size, false);
+        ThreadListResult result = inboxQueryService.findInboxThreadsResult(user.getId(), marker, PageRequest.of(0, size));
+        return toMarkerSlice(result);
     }
 
     public MarkerSliceResponse<ThreadSummaryResponse> getSent(User user, UUID marker, int size) {
-        return getThreadList(user, marker, size, true);
+        ThreadListResult result = inboxQueryService.findSentThreadsResult(user.getId(), marker, PageRequest.of(0, size));
+        return toMarkerSlice(result);
     }
 
     public ThreadDetailResponse getThreadDetail(User user, UUID threadId) {
-        List<MailAccount> userAccounts = mailAccountQueryService.findAllByUserId(user.getId());
         Thread thread = inboxQueryService.findThreadById(threadId);
-        validateThreadAccess(userAccounts, thread);
-
-        // 같은 gmail_thread_id의 INBOUND + OUTBOUND 메시지를 모두 반환 (전체 대화)
-        List<Message> messages = inboxQueryService.findAllMessagesByThread(
-                thread.getMailAccount().getId(),
-                thread.getGmailThreadId()
-        );
-        return ThreadDetailResponse.from(thread, messages);
+        validateThreadAccess(mailAccountQueryService.findAllByUserId(user.getId()), thread);
+        ThreadDetailResult result = inboxQueryService.findThreadDetailResult(thread);
+        return ThreadDetailResponse.from(result.thread(), result.messages(), result.contactNameByEmail());
     }
 
-    private MarkerSliceResponse<ThreadSummaryResponse> getThreadList(User user, UUID marker, int size, boolean isSent) {
-        Pageable pageable = PageRequest.of(0, size);
-        Slice<Thread> threads = isSent
-                ? inboxQueryService.findSentThreadsByUserId(user.getId(), marker, pageable)
-                : inboxQueryService.findInboxThreadsByUserId(user.getId(), marker, pageable);
-
-        List<UUID> threadIds = threads.getContent().stream().map(Thread::getId).toList();
-        Map<UUID, List<Attachment>> attachmentsByThreadId = inboxQueryService.findAttachmentsByThreadIds(threadIds);
-
-        List<ThreadSummaryResponse> content = threads.getContent().stream()
-                .map(thread -> ThreadSummaryResponse.from(thread, attachmentsByThreadId.getOrDefault(thread.getId(), List.of())))
+    private MarkerSliceResponse<ThreadSummaryResponse> toMarkerSlice(ThreadListResult result) {
+        List<ThreadSummaryResponse> content = result.threads().getContent().stream()
+                .map(thread -> ThreadSummaryResponse.from(
+                        thread,
+                        result.attachmentsByThreadId().getOrDefault(thread.getId(), List.of()),
+                        result.contactNameByEmail()))
                 .toList();
-
-        UUID nextMarker = threads.hasNext() ? threads.getContent().getLast().getId() : null;
-        return MarkerSliceResponse.of(content, nextMarker, threads.hasNext());
+        UUID nextMarker = result.threads().hasNext() ? result.threads().getContent().getLast().getId() : null;
+        return MarkerSliceResponse.of(content, nextMarker, result.threads().hasNext());
     }
 
     private void validateThreadAccess(List<MailAccount> userAccounts, Thread thread) {

--- a/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
@@ -4,6 +4,7 @@ import com.mailsangja.core.common.exception.inbox.InboxErrorCode;
 import com.mailsangja.core.common.exception.inbox.InboxException;
 import com.mailsangja.core.dto.inbox.ThreadDetailResult;
 import com.mailsangja.core.dto.inbox.ThreadListResult;
+import com.mailsangja.db.entity.contact.Contact;
 import com.mailsangja.db.entity.mail.Attachment;
 import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.Thread;
@@ -90,7 +91,7 @@ public class InboxQueryService {
                     if (m.getCcAddresses() != null) addrs.addAll(m.getCcAddresses());
                     return addrs.stream();
                 })
-                .filter(email -> !email.isBlank())
+                .filter(email -> email != null && !email.isBlank())
                 .distinct()
                 .toList();
     }
@@ -101,6 +102,6 @@ public class InboxQueryService {
         }
         return contactRepositoryPort.findAllByEmailInAndDeletedAtIsNull(emails)
                 .stream()
-                .collect(Collectors.toMap(com.mailsangja.db.entity.contact.Contact::getEmail, com.mailsangja.db.entity.contact.Contact::getName));
+                .collect(Collectors.toMap(Contact::getEmail, Contact::getName));
     }
 }

--- a/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
@@ -2,9 +2,12 @@ package com.mailsangja.core.service.inbox;
 
 import com.mailsangja.core.common.exception.inbox.InboxErrorCode;
 import com.mailsangja.core.common.exception.inbox.InboxException;
+import com.mailsangja.core.dto.inbox.ThreadDetailResult;
+import com.mailsangja.core.dto.inbox.ThreadListResult;
 import com.mailsangja.db.entity.mail.Attachment;
 import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.Thread;
+import com.mailsangja.db.port.ContactRepositoryPort;
 import com.mailsangja.db.port.MessageRepositoryPort;
 import com.mailsangja.db.port.ThreadRepositoryPort;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -24,27 +28,45 @@ public class InboxQueryService {
 
     private final ThreadRepositoryPort threadRepositoryPort;
     private final MessageRepositoryPort messageRepositoryPort;
-
-    public Slice<Thread> findInboxThreadsByUserId(UUID userId, UUID markerId, Pageable pageable) {
-        return threadRepositoryPort.findInboxByUserIdAndDeletedAtIsNull(userId, markerId, pageable);
-    }
-
-    public Slice<Thread> findSentThreadsByUserId(UUID userId, UUID markerId, Pageable pageable) {
-        return threadRepositoryPort.findSentByUserIdAndDeletedAtIsNull(userId, markerId, pageable);
-    }
+    private final ContactRepositoryPort contactRepositoryPort;
 
     public Thread findThreadById(UUID threadId) {
         return threadRepositoryPort.findByIdAndDeletedAtIsNull(threadId)
                 .orElseThrow(() -> new InboxException(InboxErrorCode.THREAD_NOT_FOUND));
     }
 
-    // 스레드 상세: INBOUND/OUTBOUND 두 행의 메시지를 모두 반환 (전체 대화)
-    public List<Message> findAllMessagesByThread(UUID mailAccountId, String gmailThreadId) {
-        return messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, gmailThreadId);
+    public ThreadListResult findInboxThreadsResult(UUID userId, UUID markerId, Pageable pageable) {
+        Slice<Thread> threads = threadRepositoryPort.findInboxByUserIdAndDeletedAtIsNull(userId, markerId, pageable);
+        return buildThreadListResult(threads);
     }
 
-    // 목록용: 여러 스레드의 첨부파일을 한 번에 조회 (N+1 방지)
-    public Map<UUID, List<Attachment>> findAttachmentsByThreadIds(List<UUID> threadIds) {
+    public ThreadListResult findSentThreadsResult(UUID userId, UUID markerId, Pageable pageable) {
+        Slice<Thread> threads = threadRepositoryPort.findSentByUserIdAndDeletedAtIsNull(userId, markerId, pageable);
+        return buildThreadListResult(threads);
+    }
+
+    public ThreadDetailResult findThreadDetailResult(Thread thread) {
+        List<Message> messages = messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
+                thread.getMailAccount().getId(), thread.getGmailThreadId());
+        Map<String, String> contactNameByEmail = findContactNamesByEmails(collectEmailsFromMessages(messages));
+        return new ThreadDetailResult(thread, messages, contactNameByEmail);
+    }
+
+    private ThreadListResult buildThreadListResult(Slice<Thread> threads) {
+        List<UUID> threadIds = threads.getContent().stream().map(Thread::getId).toList();
+        Map<UUID, List<Attachment>> attachmentsByThreadId = findAttachmentsByThreadIds(threadIds);
+
+        List<String> participantEmails = threads.getContent().stream()
+                .map(Thread::getLatestParticipantAddress)
+                .filter(email -> email != null && !email.isBlank())
+                .distinct()
+                .toList();
+        Map<String, String> contactNameByEmail = findContactNamesByEmails(participantEmails);
+
+        return new ThreadListResult(threads, attachmentsByThreadId, contactNameByEmail);
+    }
+
+    private Map<UUID, List<Attachment>> findAttachmentsByThreadIds(List<UUID> threadIds) {
         if (threadIds.isEmpty()) {
             return Map.of();
         }
@@ -57,5 +79,28 @@ public class InboxQueryService {
                         Map.Entry::getKey,
                         Collectors.mapping(Map.Entry::getValue, Collectors.toList())
                 ));
+    }
+
+    private List<String> collectEmailsFromMessages(List<Message> messages) {
+        return messages.stream()
+                .flatMap(m -> {
+                    List<String> addrs = new ArrayList<>();
+                    if (m.getFromAddress() != null) addrs.add(m.getFromAddress());
+                    if (m.getToAddresses() != null) addrs.addAll(m.getToAddresses());
+                    if (m.getCcAddresses() != null) addrs.addAll(m.getCcAddresses());
+                    return addrs.stream();
+                })
+                .filter(email -> !email.isBlank())
+                .distinct()
+                .toList();
+    }
+
+    private Map<String, String> findContactNamesByEmails(List<String> emails) {
+        if (emails.isEmpty()) {
+            return Map.of();
+        }
+        return contactRepositoryPort.findAllByEmailInAndDeletedAtIsNull(emails)
+                .stream()
+                .collect(Collectors.toMap(com.mailsangja.db.entity.contact.Contact::getEmail, com.mailsangja.db.entity.contact.Contact::getName));
     }
 }

--- a/core/src/main/java/com/mailsangja/core/service/mail/MailAccountQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/mail/MailAccountQueryService.java
@@ -39,4 +39,8 @@ public class MailAccountQueryService {
     public List<MailAccount> findAllByUserId(UUID userId) {
         return mailAccountRepositoryPort.findAllByUserIdAndDeletedAtIsNull(userId);
     }
+
+    public List<MailAccount> findAllActiveByUserId(UUID userId) {
+        return mailAccountRepositoryPort.findAllByUserIdAndActiveAndDeletedAtIsNull(userId, true);
+    }
 }

--- a/db/src/main/java/com/mailsangja/db/adapter/contact/ContactRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/contact/ContactRepositoryAdapter.java
@@ -1,0 +1,27 @@
+package com.mailsangja.db.adapter.contact;
+
+import com.mailsangja.db.entity.contact.Contact;
+import com.mailsangja.db.module.contact.ContactJpaRepositoryModule;
+import com.mailsangja.db.port.ContactRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ContactRepositoryAdapter implements ContactRepositoryPort {
+
+    private final ContactJpaRepositoryModule contactJpaRepositoryModule;
+
+    @Override
+    public Contact save(Contact contact) {
+        return contactJpaRepositoryModule.save(contact);
+    }
+
+    @Override
+    public List<Contact> findAllByEmailInAndDeletedAtIsNull(List<String> emails) {
+        return contactJpaRepositoryModule.findAllByEmailInAndDeletedAtIsNull(emails);
+    }
+}
+

--- a/db/src/main/java/com/mailsangja/db/adapter/label/LabelRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/label/LabelRepositoryAdapter.java
@@ -1,7 +1,7 @@
-package com.mailsangja.db.adapter.mail;
+package com.mailsangja.db.adapter.label;
 
-import com.mailsangja.db.entity.mail.Label;
-import com.mailsangja.db.module.mail.LabelJpaRepositoryModule;
+import com.mailsangja.db.entity.label.Label;
+import com.mailsangja.db.module.label.LabelJpaRepositoryModule;
 import com.mailsangja.db.port.LabelRepositoryPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/MailAccountRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/MailAccountRepositoryAdapter.java
@@ -56,4 +56,9 @@ public class MailAccountRepositoryAdapter implements MailAccountRepositoryPort {
     public List<MailAccount> findAllByUserIdAndDeletedAtIsNull(UUID userId) {
         return mailAccountJpaRepositoryModule.findAllByUserIdAndDeletedAtIsNull(userId);
     }
+
+    @Override
+    public List<MailAccount> findAllByUserIdAndActiveAndDeletedAtIsNull(UUID userId, boolean active) {
+        return mailAccountJpaRepositoryModule.findAllByUserIdAndActiveAndDeletedAtIsNull(userId, active);
+    }
 }

--- a/db/src/main/java/com/mailsangja/db/entity/contact/Contact.java
+++ b/db/src/main/java/com/mailsangja/db/entity/contact/Contact.java
@@ -1,0 +1,44 @@
+package com.mailsangja.db.entity.contact;
+
+import com.mailsangja.db.entity.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "contacts")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Contact extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "CHAR(36)")
+    @JdbcTypeCode(SqlTypes.CHAR)
+    private UUID id;
+
+    @Column(name = "name", nullable = false, length = 255)
+    private String name;
+
+    @Column(name = "email", nullable = false, unique = true, length = 255)
+    private String email;
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+}
+

--- a/db/src/main/java/com/mailsangja/db/entity/label/Label.java
+++ b/db/src/main/java/com/mailsangja/db/entity/label/Label.java
@@ -1,6 +1,8 @@
-package com.mailsangja.db.entity.mail;
+package com.mailsangja.db.entity.label;
 
 import com.mailsangja.db.entity.common.BaseEntity;
+import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.entity.mail.Thread;
 import com.mailsangja.db.entity.user.User;
 import jakarta.persistence.*;
 import lombok.*;

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
@@ -1,6 +1,7 @@
 package com.mailsangja.db.entity.mail;
 
 import com.mailsangja.db.entity.common.BaseEntity;
+import com.mailsangja.db.entity.label.Label;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Thread.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Thread.java
@@ -1,6 +1,7 @@
 package com.mailsangja.db.entity.mail;
 
 import com.mailsangja.db.entity.common.BaseEntity;
+import com.mailsangja.db.entity.label.Label;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;

--- a/db/src/main/java/com/mailsangja/db/module/contact/ContactJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/contact/ContactJpaRepositoryModule.java
@@ -1,0 +1,13 @@
+package com.mailsangja.db.module.contact;
+
+import com.mailsangja.db.entity.contact.Contact;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+public interface ContactJpaRepositoryModule extends JpaRepository<Contact, UUID> {
+    List<Contact> findAllByEmailInAndDeletedAtIsNull(Collection<String> emails);
+}
+

--- a/db/src/main/java/com/mailsangja/db/module/label/LabelJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/label/LabelJpaRepositoryModule.java
@@ -1,6 +1,6 @@
-package com.mailsangja.db.module.mail;
+package com.mailsangja.db.module.label;
 
-import com.mailsangja.db.entity.mail.Label;
+import com.mailsangja.db.entity.label.Label;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/db/src/main/java/com/mailsangja/db/module/mail/MailAccountJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MailAccountJpaRepositoryModule.java
@@ -31,4 +31,7 @@ public interface MailAccountJpaRepositoryModule extends JpaRepository<MailAccoun
 
     @EntityGraph(attributePaths = {"user"})
     List<MailAccount> findAllByUserIdAndDeletedAtIsNull(UUID userId);
+
+    @EntityGraph(attributePaths = {"user"})
+    List<MailAccount> findAllByUserIdAndActiveAndDeletedAtIsNull(UUID userId, boolean active);
 }

--- a/db/src/main/java/com/mailsangja/db/port/ContactRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/ContactRepositoryPort.java
@@ -1,0 +1,10 @@
+package com.mailsangja.db.port;
+
+import com.mailsangja.db.entity.contact.Contact;
+
+import java.util.List;
+
+public interface ContactRepositoryPort {
+    Contact save(Contact contact);
+    List<Contact> findAllByEmailInAndDeletedAtIsNull(List<String> emails);
+}

--- a/db/src/main/java/com/mailsangja/db/port/LabelRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/LabelRepositoryPort.java
@@ -1,6 +1,6 @@
 package com.mailsangja.db.port;
 
-import com.mailsangja.db.entity.mail.Label;
+import com.mailsangja.db.entity.label.Label;
 
 import java.util.List;
 import java.util.Optional;

--- a/db/src/main/java/com/mailsangja/db/port/MailAccountRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/MailAccountRepositoryPort.java
@@ -16,4 +16,5 @@ public interface MailAccountRepositoryPort {
     Optional<MailAccount> findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(UUID userId, MailProvider provider, String emailAddress);
     Optional<MailAccount> findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress);
     List<MailAccount> findAllByUserIdAndDeletedAtIsNull(UUID userId);
+    List<MailAccount> findAllByUserIdAndActiveAndDeletedAtIsNull(UUID userId, boolean active);
 }


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#4

### 📌 Task
- Closes #20 


## 💡 작업 내용

- 기존의 Facade 로직이 DTO를 조립하는데 있어 방대해져, 많은 수정이 읽어나지 않는 로직의 경우, Service에서 Result 객체를 조립하여 로직을 단순화 하여, 코드 가독성 향상
- 메일 주소록 관련 Entity, Repository, Service 코드를 생성합니다.
- 방대한 mail 도메인을 분리하였습니다.


## 📝 추가 설명

### 1. InboxFacade 로직 개선
- Result 객체를 만들어, Service에서 이를 조립하도록 개선
- InboxQeuryService가 thread, 첨부파일, 주소록 조립하여 Result 객체를 반환합니다.
- Facade에서는 전달받은 Result 객체를 통해 api Response를 조립 합니다.
- Facade의 비즈니스 로직을 확인할 수 있는 코드 가독성이 향상됩니다.

### 2. 메일 주소록 정보 추가
- 기존에는 api 응답에서 mail 주소만 전달하기에, 주소록의 정보를 Frontend 에서 조합해야 하는 부담이 존재했습니다.
- 이를 Contact 엔티티를 통해 백엔드에서 존재하는 주소록 정보를 조합하여 응답하도록 MailAdressResponse 객체를 전달합니다.

### 3. Domain 디렉토리 분리
- 기존에는 db 모듈의 mail 디렉토리 내에 label, contact 와 같은 mail과 관련되지 않은 도메인이 혼재되어 있었습니다.
- 이를 분리하여, thread, message와 label, contact를 분리하였습니다.