### PR TITLE
[STORY-201] 통합 인박스용 읽지 않음 개수 API 구현

### DIFF
--- a/core/src/main/java/com/mailsangja/core/controller/InboxController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/InboxController.java
@@ -5,6 +5,7 @@ import com.mailsangja.core.controller.docs.InboxControllerDocs;
 import com.mailsangja.core.dto.common.MarkerSliceResponse;
 import com.mailsangja.core.dto.inbox.ThreadDetailResponse;
 import com.mailsangja.core.dto.inbox.ThreadSummaryResponse;
+import com.mailsangja.core.dto.inbox.UnreadCountResponse;
 import com.mailsangja.core.facade.InboxFacade;
 import com.mailsangja.db.entity.user.User;
 import lombok.RequiredArgsConstructor;
@@ -46,5 +47,11 @@ public class InboxController implements InboxControllerDocs {
             @PathVariable UUID threadId
     ) {
         return ResponseEntity.ok(inboxFacade.getThreadDetail(user, threadId));
+    }
+
+    @Override
+    @GetMapping("/api/v1/threads/inbox/unread-count")
+    public ResponseEntity<UnreadCountResponse> getUnreadCount(@AuthUser User user) {
+        return ResponseEntity.ok(UnreadCountResponse.of(inboxFacade.getUnreadCount(user)));
     }
 }

--- a/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
@@ -4,6 +4,7 @@ import com.mailsangja.core.common.auth.AuthUser;
 import com.mailsangja.core.dto.common.MarkerSliceResponse;
 import com.mailsangja.core.dto.inbox.ThreadDetailResponse;
 import com.mailsangja.core.dto.inbox.ThreadSummaryResponse;
+import com.mailsangja.core.dto.inbox.UnreadCountResponse;
 import com.mailsangja.db.entity.user.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -86,5 +87,19 @@ public interface InboxControllerDocs {
             @Parameter(hidden = true) @AuthUser User user,
             @Parameter(description = "스레드 내부 ID", required = true)
             @PathVariable UUID threadId
+    );
+
+    @Operation(
+            summary = "읽지 않은 스레드 수 조회",
+            description = "로그인한 사용자의 모든 메일 계정에서 읽지 않은 수신 스레드 수를 반환합니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "읽지 않은 스레드 수 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<UnreadCountResponse> getUnreadCount(
+            @Parameter(hidden = true) @AuthUser User user
     );
 }

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/UnreadCountResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/UnreadCountResponse.java
@@ -1,0 +1,14 @@
+package com.mailsangja.core.dto.inbox;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "읽지 않은 수신 스레드 수 응답")
+public record UnreadCountResponse(
+        @Schema(description = "읽지 않은 수신 스레드 수", example = "5")
+        long unreadCount
+) {
+
+    public static UnreadCountResponse of(long unreadCount) {
+        return new UnreadCountResponse(unreadCount);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
@@ -52,6 +52,10 @@ public class InboxFacade {
         return ThreadDetailResponse.from(thread, messages);
     }
 
+    public long getUnreadCount(User user) {
+        return inboxQueryService.countUnreadInbox(user.getId());
+    }
+
     private MarkerSliceResponse<ThreadSummaryResponse> getThreadList(User user, UUID marker, int size, boolean isSent) {
         Pageable pageable = PageRequest.of(0, size);
         Slice<Thread> threads = isSent

--- a/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
@@ -58,4 +58,8 @@ public class InboxQueryService {
                         Collectors.mapping(Map.Entry::getValue, Collectors.toList())
                 ));
     }
+
+    public long countUnreadInbox(UUID userId) {
+        return threadRepositoryPort.countUnreadInboxByUserId(userId);
+    }
 }

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/ThreadRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/ThreadRepositoryAdapter.java
@@ -46,4 +46,9 @@ public class ThreadRepositoryAdapter implements ThreadRepositoryPort {
     public Slice<Thread> findSentByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable) {
         return threadJpaRepositoryModule.findSentByUserIdAndDeletedAtIsNull(userId, markerId, pageable);
     }
+
+    @Override
+    public long countUnreadInboxByUserId(UUID userId) {
+        return threadJpaRepositoryModule.countUnreadInboxByUserId(userId);
+    }
 }

--- a/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
@@ -35,4 +35,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
     Optional<Thread> findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
             UUID mailAccountId, String gmailThreadId, com.mailsangja.db.entity.mail.Direction direction
     );
+
+    @Query("SELECT COUNT(t) FROM Thread t WHERE t.mailAccount.id IN (SELECT ma.id FROM MailAccount ma WHERE ma.user.id = :userId AND ma.deletedAt IS NULL) AND t.direction = 'INBOUND' AND t.read = false AND t.deletedAt IS NULL")
+    long countUnreadInboxByUserId(@Param("userId") UUID userId);
 }

--- a/db/src/main/java/com/mailsangja/db/port/ThreadRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/ThreadRepositoryPort.java
@@ -14,4 +14,5 @@ public interface ThreadRepositoryPort {
     Optional<Thread> findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId, Direction direction);
     Slice<Thread> findInboxByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable);
     Slice<Thread> findSentByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable);
+    long countUnreadInboxByUserId(UUID userId);
 }


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#4

### 📌 Task
- Closes #21


## 💡 작업 내용

- 통합 인박스용 읽지 않음 개수 API를 구현합니다.


## 📝 추가 설명

### 1. 구현 내용
- ThreadJpaRepositoryModule : countUnreadInboxByUserId JPQL 쿼리 추가
- ThreadRepositoryPort : 인터페이스 메서드 추가
- ThreadRepositoryAdapter : 구현 추가
- InboxQueryService : countUnreadInbox(userId) 추가
- InboxFacade : getUnreadCount(user) 추가
- UnreadCountResponse : 새 DTO 생성 (record)
- InboxControllerDocs : Swagger 문서 추가

### 2. API 상세
- InboxController : `GET /api/v1/threads/inbox/unread-count` 엔드포인트 추가
   → { "unreadCount": 5 } 

### 3. 데이터베이스 쿼리
- 쿼리 조건: direction = INBOUND, is_read = false, deleted_at IS NULL, 사용자 소유 계정 기준