### PR TITLE
[STORY-201] Thread, Message, Attachment 엔티티 추출 및 저장

### DIFF
--- a/.claude/skills/spring-api-rules.md
+++ b/.claude/skills/spring-api-rules.md
@@ -131,6 +131,8 @@ com.mailsangja.{module}
 ├── service/{domain}/
 │   ├── {Domain}CommandService.java   # 쓰기 작업
 │   └── {Domain}QueryService.java     # 읽기 작업
+├── service/messaging/
+│   └── *PublisherService.java        # RabbitMQ 발행 전용 서비스
 ├── common/
 │   ├── dto/        # SliceResponse, PageResponse, ResponseDto
 │   ├── exception/
@@ -138,13 +140,17 @@ com.mailsangja.{module}
 ├── config/
 │   ├── SecurityConfig.java
 │   ├── AsyncConfig.java
+│   ├── RabbitMqConfig.java
 │   └── properties/
+│       └── *RabbitProperties.java
 ├── dto/{domain}/
 │   ├── *Result.java  # Service ↔ Facade 내부 전달 응답 DTO
 │   ├── *Command.java  # Service ↔ Facade 내부 전달 요청 DTO
 │   ├── *Request.java  # Controller ↔ Facade
 │   ├── *Response.java # Controller ↔ Facade
 │   └── properties/
+├── messaging/
+│   └── *Listener.java                # RabbitMQ 소비 진입점
 └── {domain}/
     ├── exception/
     └── config/     # 도메인 전용 Properties
@@ -265,6 +271,132 @@ public class UserController implements UserControllerDocs {
 - 반환 타입은 반드시 `ResponseEntity<T>`
 - Service 직접 호출 금지 — Facade만 호출
 - `Principal` 사용 금지 — 반드시 `@AuthUser` / `@AuthAdmin` 애노테이션으로 `User` 객체를 직접 주입받을 것
+
+---
+
+## RabbitMQ / Async Messaging Rules
+
+RabbitMQ는 API 응답과 분리 가능한 비동기 후속 작업에만 사용한다.
+현재 프로젝트에서는 `core`가 작업을 발행하고 `worker`가 큐를 소비해 후속 메일 동기화, watch 갱신 등의 무거운 작업을 처리한다.
+
+### 역할 분리
+
+- HTTP 진입점의 계층 규칙과 별도로, 메시지 소비 진입점은 `messaging/*Listener`가 담당한다
+- Listener는 메시지를 직접 처리하지 않고 즉시 같은 모듈의 `Facade`로 위임한다
+- Producer는 `RabbitTemplate`을 직접 여기저기 주입하지 않고 `service/messaging/*PublisherService` 또는 `*MessageCommandService` 같은 전용 발행 서비스에서만 사용한다
+- 무거운 외부 API 호출, 대량 동기화, 배치성 작업, 재시도 가능한 후속 처리는 RabbitMQ로 분리한다
+
+### 패키지 / 클래스 배치
+
+- RabbitMQ 설정은 `config/RabbitMqConfig.java`에 둔다
+- 메시징 전용 설정값은 `config/properties/*RabbitProperties.java`에 둔다
+- 메시지 발행 서비스는 `service/messaging/`에 둔다
+- 메시지 소비자는 `messaging/*Listener.java`에 둔다
+- 메시지 payload는 `dto/{domain}/` 아래 Java `record`로 작성하고 `*Message` 이름을 사용한다
+
+### 설정 규칙
+
+- 브로커 접속 정보는 `spring.rabbitmq.*`에 둔다
+- 업무 큐/익스체인지/TTL/재시도/동시성 같은 애플리케이션 규칙은 반드시 `mailsangja.rabbitmq.*`에 둔다
+- RabbitMQ 설정값 하드코딩 금지 — 반드시 `@ConfigurationProperties`로 바인딩한다
+- 새 task를 추가할 때 queue 이름, routing key, dead letter queue/routing key는 개별 문자열을 흩뿌리지 말고 `taskName` 기반으로 파생한다
+
+```java
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "mailsangja.rabbitmq.watch-renewal")
+public class WatchRenewalRabbitProperties {
+
+    private String taskName;
+
+    public String getQueueName() {
+        return "mailsangja." + taskName;
+    }
+
+    public String getRoutingKey() {
+        return "mail." + taskName;
+    }
+
+    public String getDeadLetterQueueName() {
+        return getQueueName() + ".dlq";
+    }
+
+    public String getDeadLetterRoutingKey() {
+        return getRoutingKey() + ".dlq";
+    }
+}
+```
+
+### Exchange / Queue 컨벤션
+
+- 기본 exchange 타입은 `DirectExchange`를 사용한다
+- main exchange와 dead-letter exchange를 분리한다
+- 새 task를 추가할 때는 최소한 아래 요소를 함께 정의한다
+- main queue
+- main binding
+- dead-letter queue
+- dead-letter binding
+- queue 이름은 `mailsangja.{taskName}` 패턴을 사용한다
+- routing key는 `mail.{taskName}` 패턴을 사용한다
+- dead-letter queue와 routing key는 `.dlq` 접미사로 파생한다
+- task 이름은 도메인명이 아니라 작업 의미 중심으로 짓는다
+- 예: `sync.gmail.initial`, `sync.gmail.initial.thread-batch`, `watch.renewal.gmail`
+
+### Producer 규칙
+
+- 발행 전에 payload와 Rabbit 설정값을 private validation 메서드로 검증한다
+- 발행은 `rabbitTemplate.convertAndSend(exchange, routingKey, message, correlationData)`를 기본 형태로 사용한다
+- `CorrelationData`에는 `mailAccountId`, `userId`, 배치 식별자 등 추적 가능한 값을 넣는다
+- publish 실패 시 예외를 무시하지 말고 경고 로그를 남긴다
+- publisher confirm / return callback이 필요한 경우 `RabbitMqConfig`에서 일괄 설정한다
+
+### Consumer 규칙
+
+- `@RabbitListener`의 queue 값은 문자열 하드코딩 대신 Queue Bean 참조를 사용한다
+- 예: `queues = "#{@watchRenewalQueue.name}"`
+- 작업별 재시도 정책이나 동시성이 다르면 listener container factory를 분리한다
+- Listener 메서드는 메시지 역직렬화와 위임만 담당하고, 실제 비즈니스 판단은 Facade와 Service에서 수행한다
+
+```java
+@Component
+@RequiredArgsConstructor
+public class GmailWatchRenewalListener {
+
+    private final MailAccountFacade mailAccountFacade;
+
+    @RabbitListener(
+            queues = "#{@watchRenewalQueue.name}",
+            containerFactory = "watchRenewalRabbitListenerContainerFactory"
+    )
+    public void handle(WatchRenewalMessage message) {
+        mailAccountFacade.handleWatchRenewal(message);
+    }
+}
+```
+
+### Retry / DLQ 규칙
+
+- 메시지 처리 기본 보장은 at-least-once를 기준으로 설계한다
+- 소비 로직은 중복 수신에도 안전하도록 idempotent하게 작성한다
+- poison message의 무한 재적재를 막기 위해 `defaultRequeueRejected=false`를 기본으로 사용한다
+- 재시도 횟수 초과 시 `AmqpRejectAndDontRequeueException`으로 DLQ로 보낸다
+- task별 실패 처리 방식이 다르면 task 전용 `MessageRecoverer`, retry interceptor, listener container factory를 둔다
+- DLQ 적재 시 task 이름, routing key, 핵심 식별자를 로그에 남긴다
+
+### 트랜잭션 / 외부 I/O
+
+- RabbitMQ 발행은 DB 상태 변경 이후의 후속 비동기 작업 트리거 용도로 사용한다
+- 외부 MQ I/O를 긴 DB 트랜잭션 내부에 묶지 않는다
+- Listener 내부에서도 외부 API 호출과 DB 저장이 섞일 수 있으므로, 기존 트랜잭션 규칙을 그대로 적용한다
+
+### 메시지 DTO 규칙
+
+- 메시지 payload는 반드시 Java `record`
+- 외부 API raw response 전체를 그대로 메시지에 싣지 않는다
+- 메시지에는 식별자와 후속 처리에 필요한 최소 필드만 담는다
+- Producer와 Consumer 양쪽에서 필수값을 검증한다
+- 로그에는 message body 전체를 남기지 말고 식별 가능한 최소 정보만 남긴다
 
 ## 인증 파라미터 애노테이션
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ If guidance conflicts:
 - Shared persistence code lives in `db`.
 - Executable Spring Boot application code lives in feature modules such as `core`.
 - Root package convention: `com.mailsangja.{module}`.
-- Stack: Java 21, Spring Boot 4.0.5, MySQL, Spring Data JPA, Lombok.
+- Stack: Java 21, Spring Boot 4.0.5, PostgreSQL, Spring Data JPA, Lombok.
 
 ## Required Dependency Direction
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ mailsangja_server/
 └── src/
 ```
 
-**Tech stack**: Spring Boot 4.0.5, Java 21, Gradle 9.4.1, Spring MVC, Spring Data JPA, MySQL, Lombok
+**Tech stack**: Spring Boot 4.0.5, Java 21, Gradle 9.4.1, Spring MVC, Spring Data JPA, PostgreSQL, Lombok
 
 **빌드 명령 (각 모듈 디렉토리 내에서 실행):**
 ```bash

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
@@ -18,6 +19,11 @@ public class MessageRepositoryAdapter implements MessageRepositoryPort {
     @Override
     public Message save(Message message) {
         return messageJpaRepositoryModule.save(message);
+    }
+
+    @Override
+    public Optional<Message> findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(UUID threadId, String gmailMessageId) {
+        return messageJpaRepositoryModule.findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(threadId, gmailMessageId);
     }
 
     @Override

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
@@ -27,11 +27,6 @@ public class MessageRepositoryAdapter implements MessageRepositoryPort {
     }
 
     @Override
-    public long countByThreadIdAndDeletedAtIsNull(UUID threadId) {
-        return messageJpaRepositoryModule.countByThreadIdAndDeletedAtIsNull(threadId);
-    }
-
-    @Override
     public List<Message> findAllByThreadIdAndDeletedAtIsNull(UUID threadId) {
         return messageJpaRepositoryModule.findAllByThreadIdAndDeletedAtIsNull(threadId);
     }

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
@@ -27,6 +27,11 @@ public class MessageRepositoryAdapter implements MessageRepositoryPort {
     }
 
     @Override
+    public long countByThreadIdAndDeletedAtIsNull(UUID threadId) {
+        return messageJpaRepositoryModule.countByThreadIdAndDeletedAtIsNull(threadId);
+    }
+
+    @Override
     public List<Message> findAllByThreadIdAndDeletedAtIsNull(UUID threadId) {
         return messageJpaRepositoryModule.findAllByThreadIdAndDeletedAtIsNull(threadId);
     }

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Attachment.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Attachment.java
@@ -27,7 +27,7 @@ public class Attachment extends BaseEntity {
     private Message message;
 
     // Gmail attachment ID (다운로드 시 사용)
-    @Column(name = "gmail_attachment_id", length = 255)
+    @Column(name = "gmail_attachment_id", length = 1024)
     private String gmailAttachmentId;
 
     @Column(name = "filename", nullable = false, length = 255)

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
@@ -110,4 +110,16 @@ public class Message extends BaseEntity {
         this.read = read;
         this.sentAt = sentAt;
     }
+
+    public void updateBodyContent(String bodyText, String bodyHtml) {
+        this.bodyText = bodyText;
+        this.bodyHtml = bodyHtml;
+    }
+
+    public void replaceAttachments(List<Attachment> attachments) {
+        this.attachments.clear();
+        if (attachments != null) {
+            this.attachments.addAll(attachments);
+        }
+    }
 }

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
@@ -92,4 +92,22 @@ public class Message extends BaseEntity {
     public void markAsUnread() {
         this.read = false;
     }
+
+    public void updateBasicContent(
+            String subject,
+            String fromAddress,
+            List<String> toAddresses,
+            List<String> ccAddresses,
+            String snippet,
+            boolean read,
+            LocalDateTime sentAt
+    ) {
+        this.subject = subject;
+        this.fromAddress = fromAddress;
+        this.toAddresses = toAddresses == null ? List.of() : List.copyOf(toAddresses);
+        this.ccAddresses = ccAddresses == null ? List.of() : List.copyOf(ccAddresses);
+        this.snippet = snippet;
+        this.read = read;
+        this.sentAt = sentAt;
+    }
 }

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Thread.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Thread.java
@@ -94,7 +94,11 @@ public class Thread extends BaseEntity {
             LocalDateTime lastMessageAt,
             boolean read
     ) {
-        if (this.lastMessageAt != null && lastMessageAt != null && this.lastMessageAt.isAfter(lastMessageAt)) {
+        if (lastMessageAt == null) {
+            return;
+        }
+
+        if (this.lastMessageAt != null && this.lastMessageAt.isAfter(lastMessageAt)) {
             return;
         }
 
@@ -105,12 +109,6 @@ public class Thread extends BaseEntity {
     public void updateReadStatus(boolean read) {
         this.read = read;
     }
-
-
-    public void incrementMessageCount() {
-        this.messageCount++;
-    }
-
     public void updateMessageCount(int messageCount) {
         this.messageCount = Math.max(messageCount, 0);
     }

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Thread.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Thread.java
@@ -87,6 +87,21 @@ public class Thread extends BaseEntity {
         this.lastMessageAt = lastMessageAt;
     }
 
+    public void updateLatestMessageInfoIfNewer(
+            String subject,
+            String snippet,
+            String participantAddress,
+            LocalDateTime lastMessageAt,
+            boolean read
+    ) {
+        if (this.lastMessageAt != null && lastMessageAt != null && this.lastMessageAt.isAfter(lastMessageAt)) {
+            return;
+        }
+
+        updateLatestMessageInfo(subject, snippet, participantAddress, lastMessageAt);
+        this.read = read;
+    }
+
     public void updateReadStatus(boolean read) {
         this.read = read;
     }
@@ -94,6 +109,10 @@ public class Thread extends BaseEntity {
 
     public void incrementMessageCount() {
         this.messageCount++;
+    }
+
+    public void updateMessageCount(int messageCount) {
+        this.messageCount = Math.max(messageCount, 0);
     }
 
     public void updateHistoryId(String historyId) {

--- a/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
@@ -7,9 +7,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID> {
+
+    Optional<Message> findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(UUID threadId, String gmailMessageId);
 
     @EntityGraph(attributePaths = {"attachments"})
     @Query("SELECT m FROM Message m WHERE m.thread.id = :threadId AND m.deletedAt IS NULL ORDER BY m.sentAt ASC")

--- a/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
@@ -14,6 +14,8 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
 
     Optional<Message> findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(UUID threadId, String gmailMessageId);
 
+    long countByThreadIdAndDeletedAtIsNull(UUID threadId);
+
     @EntityGraph(attributePaths = {"attachments"})
     @Query("SELECT m FROM Message m WHERE m.thread.id = :threadId AND m.deletedAt IS NULL ORDER BY m.sentAt ASC")
     List<Message> findAllByThreadIdAndDeletedAtIsNull(@Param("threadId") UUID threadId);

--- a/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
@@ -14,8 +14,6 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
 
     Optional<Message> findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(UUID threadId, String gmailMessageId);
 
-    long countByThreadIdAndDeletedAtIsNull(UUID threadId);
-
     @EntityGraph(attributePaths = {"attachments"})
     @Query("SELECT m FROM Message m WHERE m.thread.id = :threadId AND m.deletedAt IS NULL ORDER BY m.sentAt ASC")
     List<Message> findAllByThreadIdAndDeletedAtIsNull(@Param("threadId") UUID threadId);

--- a/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 public interface MessageRepositoryPort {
     Message save(Message message);
     Optional<Message> findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(UUID threadId, String gmailMessageId);
+    long countByThreadIdAndDeletedAtIsNull(UUID threadId);
     List<Message> findAllByThreadIdAndDeletedAtIsNull(UUID threadId);
     List<Message> findAllByThreadIdInAndDeletedAtIsNull(List<UUID> threadIds);
     List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId);

--- a/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
@@ -3,10 +3,12 @@ package com.mailsangja.db.port;
 import com.mailsangja.db.entity.mail.Message;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface MessageRepositoryPort {
     Message save(Message message);
+    Optional<Message> findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(UUID threadId, String gmailMessageId);
     List<Message> findAllByThreadIdAndDeletedAtIsNull(UUID threadId);
     List<Message> findAllByThreadIdInAndDeletedAtIsNull(List<UUID> threadIds);
     List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId);

--- a/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 public interface MessageRepositoryPort {
     Message save(Message message);
     Optional<Message> findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(UUID threadId, String gmailMessageId);
-    long countByThreadIdAndDeletedAtIsNull(UUID threadId);
     List<Message> findAllByThreadIdAndDeletedAtIsNull(UUID threadId);
     List<Message> findAllByThreadIdInAndDeletedAtIsNull(List<UUID> threadIds);
     List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId);

--- a/db/src/main/resources/schema.sql
+++ b/db/src/main/resources/schema.sql
@@ -85,7 +85,7 @@ CREATE TABLE IF NOT EXISTS messages (
 CREATE TABLE IF NOT EXISTS attachments (
     id                  CHAR(36)     NOT NULL,
     message_id          CHAR(36)     NOT NULL,
-    gmail_attachment_id VARCHAR(255) NULL,
+    gmail_attachment_id VARCHAR(1024) NULL,
     filename            VARCHAR(255) NOT NULL,
     mime_type           VARCHAR(255) NOT NULL,
     size                INT          NULL,

--- a/worker/build.gradle
+++ b/worker/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'org.springframework.boot:spring-boot-jackson2'
     implementation 'org.springframework.security:spring-security-oauth2-jose'
+    implementation 'com.sun.mail:jakarta.mail:2.0.1'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-scalar:3.0.2'
     compileOnly 'org.projectlombok:lombok'

--- a/worker/src/main/java/com/mailsangja/worker/config/RabbitMqConfig.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/RabbitMqConfig.java
@@ -254,6 +254,34 @@ public class RabbitMqConfig {
     }
 
     @Bean
+    public MethodInterceptor initialMailSyncThreadBatchRetryInterceptor(
+            MailTaskRabbitProperties properties,
+            @Qualifier("initialMailSyncThreadBatchMessageRecoverer") MessageRecoverer initialMailSyncThreadBatchMessageRecoverer
+    ) {
+        return RetryInterceptorBuilder.stateless()
+                .maxRetries(properties.getRetryMaxAttempts())
+                .recoverer(initialMailSyncThreadBatchMessageRecoverer)
+                .build();
+    }
+
+    @Bean
+    public SimpleRabbitListenerContainerFactory initialMailSyncThreadBatchRabbitListenerContainerFactory(
+            ConnectionFactory connectionFactory,
+            MessageConverter rabbitMessageConverter,
+            @Qualifier("initialMailSyncThreadBatchRetryInterceptor") MethodInterceptor initialMailSyncThreadBatchRetryInterceptor,
+            MailTaskRabbitProperties properties
+    ) {
+        SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+        factory.setMessageConverter(rabbitMessageConverter);
+        factory.setConcurrentConsumers(properties.getConcurrency());
+        factory.setMaxConcurrentConsumers(properties.getConcurrency());
+        factory.setDefaultRequeueRejected(false);
+        factory.setAdviceChain(initialMailSyncThreadBatchRetryInterceptor);
+        return factory;
+    }
+
+    @Bean
     public MethodInterceptor watchRenewalRetryInterceptor(
             MailTaskRabbitProperties properties,
             @Qualifier("watchRenewalMessageRecoverer") MessageRecoverer watchRenewalMessageRecoverer

--- a/worker/src/main/java/com/mailsangja/worker/config/RabbitMqConfig.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/RabbitMqConfig.java
@@ -64,6 +64,26 @@ public class RabbitMqConfig {
     }
 
     @Bean
+    public Queue initialMailSyncThreadBatchQueue(
+            InitialMailSyncRabbitProperties properties,
+            MailTaskRabbitProperties mailTaskRabbitProperties
+    ) {
+        validateTaskName(properties.getThreadBatchTaskName(), "mailsangja.rabbitmq.initial-mail-sync.thread-batch-task-name");
+
+        return QueueBuilder.durable(properties.getThreadBatchQueueName())
+                .ttl(toQueueTtlMillis(mailTaskRabbitProperties.getTtl(), "mailsangja.rabbitmq.task.ttl"))
+                .deadLetterExchange(mailTaskRabbitProperties.getDeadLetterExchange())
+                .deadLetterRoutingKey(properties.getThreadBatchDeadLetterRoutingKey())
+                .build();
+    }
+
+    @Bean
+    public Queue initialMailSyncThreadBatchDeadLetterQueue(InitialMailSyncRabbitProperties properties) {
+        validateTaskName(properties.getThreadBatchTaskName(), "mailsangja.rabbitmq.initial-mail-sync.thread-batch-task-name");
+        return QueueBuilder.durable(properties.getThreadBatchDeadLetterQueueName()).build();
+    }
+
+    @Bean
     public Queue watchRenewalQueue(
             WatchRenewalRabbitProperties properties,
             MailTaskRabbitProperties mailTaskRabbitProperties
@@ -103,6 +123,28 @@ public class RabbitMqConfig {
         return BindingBuilder.bind(initialMailSyncDeadLetterQueue)
                 .to(mailTaskDeadLetterExchange)
                 .with(properties.getDeadLetterRoutingKey());
+    }
+
+    @Bean
+    public Binding initialMailSyncThreadBatchBinding(
+            @Qualifier("initialMailSyncThreadBatchQueue") Queue initialMailSyncThreadBatchQueue,
+            @Qualifier("mailTaskExchange") DirectExchange mailTaskExchange,
+            InitialMailSyncRabbitProperties properties
+    ) {
+        return BindingBuilder.bind(initialMailSyncThreadBatchQueue)
+                .to(mailTaskExchange)
+                .with(properties.getThreadBatchRoutingKey());
+    }
+
+    @Bean
+    public Binding initialMailSyncThreadBatchDeadLetterBinding(
+            @Qualifier("initialMailSyncThreadBatchDeadLetterQueue") Queue initialMailSyncThreadBatchDeadLetterQueue,
+            @Qualifier("mailTaskDeadLetterExchange") DirectExchange mailTaskDeadLetterExchange,
+            InitialMailSyncRabbitProperties properties
+    ) {
+        return BindingBuilder.bind(initialMailSyncThreadBatchDeadLetterQueue)
+                .to(mailTaskDeadLetterExchange)
+                .with(properties.getThreadBatchDeadLetterRoutingKey());
     }
 
     @Bean
@@ -167,6 +209,19 @@ public class RabbitMqConfig {
                     cause
             );
             throw new AmqpRejectAndDontRequeueException("Initial mail sync retries exhausted", cause);
+        };
+    }
+
+    @Bean
+    public MessageRecoverer initialMailSyncThreadBatchMessageRecoverer(InitialMailSyncRabbitProperties properties) {
+        return (message, cause) -> {
+            log.warn(
+                    "Initial mail sync thread batch retries exhausted. Sending to DLQ routingKey={} messageBody={}",
+                    properties.getThreadBatchDeadLetterRoutingKey(),
+                    new String(message.getBody()),
+                    cause
+            );
+            throw new AmqpRejectAndDontRequeueException("Initial mail sync thread batch retries exhausted", cause);
         };
     }
 

--- a/worker/src/main/java/com/mailsangja/worker/config/properties/GoogleMailInitialSyncProperties.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/properties/GoogleMailInitialSyncProperties.java
@@ -17,6 +17,7 @@ public class GoogleMailInitialSyncProperties {
     private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(5);
 
     private int maxResults = 20;
+    private int threadBatchSize = 5;
     private String messagesUri;
     private Duration connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     private Duration readTimeout = DEFAULT_READ_TIMEOUT;

--- a/worker/src/main/java/com/mailsangja/worker/config/properties/GoogleMailInitialSyncProperties.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/properties/GoogleMailInitialSyncProperties.java
@@ -19,6 +19,7 @@ public class GoogleMailInitialSyncProperties {
     private int maxResults = 20;
     private int threadBatchSize = 5;
     private String messagesUri;
+    private String threadsUri;
     private Duration connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     private Duration readTimeout = DEFAULT_READ_TIMEOUT;
 }

--- a/worker/src/main/java/com/mailsangja/worker/config/properties/InitialMailSyncRabbitProperties.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/properties/InitialMailSyncRabbitProperties.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 public class InitialMailSyncRabbitProperties {
 
     private String taskName;
+    private String threadBatchTaskName;
 
     public String getQueueName() {
         return "mailsangja." + taskName;
@@ -27,5 +28,21 @@ public class InitialMailSyncRabbitProperties {
 
     public String getDeadLetterRoutingKey() {
         return getRoutingKey() + ".dlq";
+    }
+
+    public String getThreadBatchQueueName() {
+        return "mailsangja." + threadBatchTaskName;
+    }
+
+    public String getThreadBatchRoutingKey() {
+        return "mail." + threadBatchTaskName;
+    }
+
+    public String getThreadBatchDeadLetterQueueName() {
+        return getThreadBatchQueueName() + ".dlq";
+    }
+
+    public String getThreadBatchDeadLetterRoutingKey() {
+        return getThreadBatchRoutingKey() + ".dlq";
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/dto/gmail/GoogleMailMessageListResult.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/gmail/GoogleMailMessageListResult.java
@@ -1,7 +1,12 @@
 package com.mailsangja.worker.dto.gmail;
 
+import java.util.List;
+
 public record GoogleMailMessageListResult(
-        int fetchedCount,
+        List<GoogleMailMessageResponse> messages,
         int resultSizeEstimate
 ) {
+    public int fetchedCount() {
+        return messages == null ? 0 : messages.size();
+    }
 }

--- a/worker/src/main/java/com/mailsangja/worker/dto/gmail/GoogleMailThreadResponse.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/gmail/GoogleMailThreadResponse.java
@@ -20,7 +20,18 @@ public record GoogleMailThreadResponse(
     }
 
     public record GoogleMailThreadPayloadResponse(
-            List<GoogleMailHeaderResponse> headers
+            String mimeType,
+            String filename,
+            GoogleMailThreadBodyResponse body,
+            List<GoogleMailHeaderResponse> headers,
+            List<GoogleMailThreadPayloadResponse> parts
+    ) {
+    }
+
+    public record GoogleMailThreadBodyResponse(
+            Integer size,
+            String data,
+            String attachmentId
     ) {
     }
 

--- a/worker/src/main/java/com/mailsangja/worker/dto/gmail/GoogleMailThreadResponse.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/gmail/GoogleMailThreadResponse.java
@@ -1,0 +1,32 @@
+package com.mailsangja.worker.dto.gmail;
+
+import java.util.List;
+
+public record GoogleMailThreadResponse(
+        String id,
+        String historyId,
+        List<GoogleMailThreadMessageResponse> messages
+) {
+
+    public record GoogleMailThreadMessageResponse(
+            String id,
+            String threadId,
+            List<String> labelIds,
+            String snippet,
+            String historyId,
+            String internalDate,
+            GoogleMailThreadPayloadResponse payload
+    ) {
+    }
+
+    public record GoogleMailThreadPayloadResponse(
+            List<GoogleMailHeaderResponse> headers
+    ) {
+    }
+
+    public record GoogleMailHeaderResponse(
+            String name,
+            String value
+    ) {
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/dto/mail/InitialMailSyncAttachmentResult.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/mail/InitialMailSyncAttachmentResult.java
@@ -1,0 +1,9 @@
+package com.mailsangja.worker.dto.mail;
+
+public record InitialMailSyncAttachmentResult(
+        String gmailAttachmentId,
+        String filename,
+        String mimeType,
+        Integer size
+) {
+}

--- a/worker/src/main/java/com/mailsangja/worker/dto/mail/InitialMailSyncMessageResult.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/mail/InitialMailSyncMessageResult.java
@@ -1,0 +1,24 @@
+package com.mailsangja.worker.dto.mail;
+
+import com.mailsangja.db.entity.mail.Direction;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record InitialMailSyncMessageResult(
+        String gmailMessageId,
+        String gmailThreadId,
+        String historyId,
+        Direction direction,
+        String subject,
+        String fromAddress,
+        List<String> toAddresses,
+        List<String> ccAddresses,
+        String snippet,
+        boolean read,
+        LocalDateTime sentAt,
+        String bodyText,
+        String bodyHtml,
+        List<InitialMailSyncAttachmentResult> attachments
+) {
+}

--- a/worker/src/main/java/com/mailsangja/worker/dto/mail/InitialMailSyncMessageSaveCommand.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/mail/InitialMailSyncMessageSaveCommand.java
@@ -1,0 +1,40 @@
+package com.mailsangja.worker.dto.mail;
+
+import com.mailsangja.db.entity.mail.Direction;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record InitialMailSyncMessageSaveCommand(
+        String gmailMessageId,
+        String historyId,
+        Direction direction,
+        String subject,
+        String fromAddress,
+        List<String> toAddresses,
+        List<String> ccAddresses,
+        String snippet,
+        boolean read,
+        LocalDateTime sentAt,
+        String bodyText,
+        String bodyHtml,
+        List<InitialMailSyncAttachmentResult> attachments
+) {
+    public static InitialMailSyncMessageSaveCommand from(InitialMailSyncMessageResult result) {
+        return new InitialMailSyncMessageSaveCommand(
+                result.gmailMessageId(),
+                result.historyId(),
+                result.direction(),
+                result.subject(),
+                result.fromAddress(),
+                result.toAddresses(),
+                result.ccAddresses(),
+                result.snippet(),
+                result.read(),
+                result.sentAt(),
+                result.bodyText(),
+                result.bodyHtml(),
+                result.attachments()
+        );
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/dto/mail/InitialMailSyncThreadBatchMessage.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/mail/InitialMailSyncThreadBatchMessage.java
@@ -1,0 +1,13 @@
+package com.mailsangja.worker.dto.mail;
+
+import java.util.List;
+import java.util.UUID;
+
+public record InitialMailSyncThreadBatchMessage(
+        UUID mailAccountId,
+        UUID userId,
+        String provider,
+        String emailAddress,
+        List<String> threadIds
+) {
+}

--- a/worker/src/main/java/com/mailsangja/worker/dto/mail/InitialMailSyncThreadResult.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/mail/InitialMailSyncThreadResult.java
@@ -1,0 +1,10 @@
+package com.mailsangja.worker.dto.mail;
+
+import java.util.List;
+
+public record InitialMailSyncThreadResult(
+        String gmailThreadId,
+        String historyId,
+        List<InitialMailSyncMessageResult> messages
+) {
+}

--- a/worker/src/main/java/com/mailsangja/worker/dto/mail/InitialMailSyncThreadSaveCommand.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/mail/InitialMailSyncThreadSaveCommand.java
@@ -1,0 +1,19 @@
+package com.mailsangja.worker.dto.mail;
+
+import java.util.List;
+
+public record InitialMailSyncThreadSaveCommand(
+        String gmailThreadId,
+        String historyId,
+        List<InitialMailSyncMessageSaveCommand> messages
+) {
+    public static InitialMailSyncThreadSaveCommand from(InitialMailSyncThreadResult result) {
+        return new InitialMailSyncThreadSaveCommand(
+                result.gmailThreadId(),
+                result.historyId(),
+                result.messages().stream()
+                        .map(InitialMailSyncMessageSaveCommand::from)
+                        .toList()
+        );
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/facade/InitialMailSyncFacade.java
+++ b/worker/src/main/java/com/mailsangja/worker/facade/InitialMailSyncFacade.java
@@ -6,9 +6,11 @@ import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
 import com.mailsangja.worker.common.exception.mail.MailPushException;
 import com.mailsangja.worker.config.properties.GoogleMailInitialSyncProperties;
 import com.mailsangja.worker.dto.gmail.GoogleMailMessageListResult;
+import com.mailsangja.worker.dto.gmail.GoogleMailThreadResponse;
 import com.mailsangja.worker.dto.mail.InitialMailSyncThreadBatchMessage;
 import com.mailsangja.worker.dto.mail.InitialMailSyncMessage;
 import com.mailsangja.worker.service.google.GoogleMailMessageQueryService;
+import com.mailsangja.worker.service.mail.InitialMailSyncCommandService;
 import com.mailsangja.worker.service.mail.MailAccountQueryService;
 import com.mailsangja.worker.service.messaging.MailTaskPublisherService;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,7 @@ public class InitialMailSyncFacade {
     private final GoogleMailMessageQueryService googleMailMessageQueryService;
     private final MailTaskPublisherService mailTaskPublisherService;
     private final GoogleMailInitialSyncProperties googleMailInitialSyncProperties;
+    private final InitialMailSyncCommandService initialMailSyncCommandService;
 
     public void handleInitialMailSync(InitialMailSyncMessage message) {
         validateMessage(message);
@@ -59,12 +62,49 @@ public class InitialMailSyncFacade {
         );
     }
 
+    public void handleInitialMailSyncThreadBatch(InitialMailSyncThreadBatchMessage message) {
+        validateThreadBatchMessage(message);
+
+        MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(message.mailAccountId());
+        List<GoogleMailThreadResponse> threadResponses = googleMailMessageQueryService.getThreads(
+                mailAccount.getAccessToken(),
+                message.threadIds()
+        );
+
+        initialMailSyncCommandService.saveThreadBatch(mailAccount, threadResponses);
+
+        log.info(
+                "Saved initial mail sync thread batch for mailAccountId={} userId={} emailAddress={} threadCount={}",
+                message.mailAccountId(),
+                message.userId(),
+                message.emailAddress(),
+                message.threadIds().size()
+        );
+    }
+
     private void validateMessage(InitialMailSyncMessage message) {
         if (message == null
                 || message.mailAccountId() == null
                 || message.userId() == null
                 || isBlank(message.provider())
                 || isBlank(message.emailAddress())) {
+            throw new MailPushException(MailPushErrorCode.INVALID_INITIAL_MAIL_SYNC_COMMAND);
+        }
+
+        if (!MailProvider.GMAIL.name().equals(message.provider())) {
+            throw new MailPushException(MailPushErrorCode.UNSUPPORTED_INITIAL_MAIL_SYNC_PROVIDER);
+        }
+    }
+
+    private void validateThreadBatchMessage(InitialMailSyncThreadBatchMessage message) {
+        if (message == null
+                || message.mailAccountId() == null
+                || message.userId() == null
+                || isBlank(message.provider())
+                || isBlank(message.emailAddress())
+                || message.threadIds() == null
+                || message.threadIds().isEmpty()
+                || message.threadIds().stream().anyMatch(this::isBlank)) {
             throw new MailPushException(MailPushErrorCode.INVALID_INITIAL_MAIL_SYNC_COMMAND);
         }
 

--- a/worker/src/main/java/com/mailsangja/worker/facade/InitialMailSyncFacade.java
+++ b/worker/src/main/java/com/mailsangja/worker/facade/InitialMailSyncFacade.java
@@ -4,13 +4,20 @@ import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.MailProvider;
 import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
 import com.mailsangja.worker.common.exception.mail.MailPushException;
+import com.mailsangja.worker.config.properties.GoogleMailInitialSyncProperties;
 import com.mailsangja.worker.dto.gmail.GoogleMailMessageListResult;
+import com.mailsangja.worker.dto.mail.InitialMailSyncThreadBatchMessage;
 import com.mailsangja.worker.dto.mail.InitialMailSyncMessage;
 import com.mailsangja.worker.service.google.GoogleMailMessageQueryService;
 import com.mailsangja.worker.service.mail.MailAccountQueryService;
+import com.mailsangja.worker.service.messaging.MailTaskPublisherService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
 
 @Slf4j
 @Component
@@ -19,19 +26,35 @@ public class InitialMailSyncFacade {
 
     private final MailAccountQueryService mailAccountQueryService;
     private final GoogleMailMessageQueryService googleMailMessageQueryService;
+    private final MailTaskPublisherService mailTaskPublisherService;
+    private final GoogleMailInitialSyncProperties googleMailInitialSyncProperties;
 
     public void handleInitialMailSync(InitialMailSyncMessage message) {
         validateMessage(message);
 
         MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(message.mailAccountId());
         GoogleMailMessageListResult result = googleMailMessageQueryService.getLatestMessages(mailAccount.getAccessToken());
+        List<String> threadIds = extractThreadIds(result);
+        List<List<String>> threadBatches = partitionThreadIds(threadIds);
+
+        for (List<String> threadBatch : threadBatches) {
+            mailTaskPublisherService.publishInitialMailSyncThreadBatch(new InitialMailSyncThreadBatchMessage(
+                    message.mailAccountId(),
+                    message.userId(),
+                    message.provider(),
+                    message.emailAddress(),
+                    threadBatch
+            ));
+        }
 
         log.info(
-                "Completed initial mail sync for mailAccountId={} userId={} emailAddress={} fetchedCount={} resultSizeEstimate={}",
+                "Prepared initial mail sync thread batches for mailAccountId={} userId={} emailAddress={} fetchedCount={} uniqueThreadCount={} publishedBatchCount={} resultSizeEstimate={}",
                 message.mailAccountId(),
                 message.userId(),
                 message.emailAddress(),
                 result.fetchedCount(),
+                threadIds.size(),
+                threadBatches.size(),
                 result.resultSizeEstimate()
         );
     }
@@ -48,6 +71,36 @@ public class InitialMailSyncFacade {
         if (!MailProvider.GMAIL.name().equals(message.provider())) {
             throw new MailPushException(MailPushErrorCode.UNSUPPORTED_INITIAL_MAIL_SYNC_PROVIDER);
         }
+    }
+
+    private List<String> extractThreadIds(GoogleMailMessageListResult result) {
+        if (result == null || result.messages() == null) {
+            return List.of();
+        }
+
+        LinkedHashSet<String> deduplicatedThreadIds = new LinkedHashSet<>();
+        result.messages().stream()
+                .filter(message -> message != null && !isBlank(message.threadId()))
+                .forEach(message -> deduplicatedThreadIds.add(message.threadId()));
+        return List.copyOf(deduplicatedThreadIds);
+    }
+
+    private List<List<String>> partitionThreadIds(List<String> threadIds) {
+        if (threadIds.isEmpty()) {
+            return List.of();
+        }
+
+        int threadBatchSize = googleMailInitialSyncProperties.getThreadBatchSize();
+        if (threadBatchSize <= 0) {
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_FETCH_FAILED);
+        }
+
+        List<List<String>> batches = new ArrayList<>();
+        for (int start = 0; start < threadIds.size(); start += threadBatchSize) {
+            int end = Math.min(start + threadBatchSize, threadIds.size());
+            batches.add(List.copyOf(threadIds.subList(start, end)));
+        }
+        return batches;
     }
 
     private boolean isBlank(String value) {

--- a/worker/src/main/java/com/mailsangja/worker/facade/InitialMailSyncFacade.java
+++ b/worker/src/main/java/com/mailsangja/worker/facade/InitialMailSyncFacade.java
@@ -6,9 +6,10 @@ import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
 import com.mailsangja.worker.common.exception.mail.MailPushException;
 import com.mailsangja.worker.config.properties.GoogleMailInitialSyncProperties;
 import com.mailsangja.worker.dto.gmail.GoogleMailMessageListResult;
-import com.mailsangja.worker.dto.gmail.GoogleMailThreadResponse;
 import com.mailsangja.worker.dto.mail.InitialMailSyncThreadBatchMessage;
 import com.mailsangja.worker.dto.mail.InitialMailSyncMessage;
+import com.mailsangja.worker.dto.mail.InitialMailSyncThreadResult;
+import com.mailsangja.worker.dto.mail.InitialMailSyncThreadSaveCommand;
 import com.mailsangja.worker.service.google.GoogleMailMessageQueryService;
 import com.mailsangja.worker.service.mail.InitialMailSyncCommandService;
 import com.mailsangja.worker.service.mail.MailAccountQueryService;
@@ -66,12 +67,15 @@ public class InitialMailSyncFacade {
         validateThreadBatchMessage(message);
 
         MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(message.mailAccountId());
-        List<GoogleMailThreadResponse> threadResponses = googleMailMessageQueryService.getThreads(
+        List<InitialMailSyncThreadResult> threadResults = googleMailMessageQueryService.getThreads(
                 mailAccount.getAccessToken(),
                 message.threadIds()
         );
+        List<InitialMailSyncThreadSaveCommand> commands = threadResults.stream()
+                .map(InitialMailSyncThreadSaveCommand::from)
+                .toList();
 
-        initialMailSyncCommandService.saveThreadBatch(mailAccount, threadResponses);
+        initialMailSyncCommandService.saveThreadBatch(mailAccount, commands);
 
         log.info(
                 "Saved initial mail sync thread batch for mailAccountId={} userId={} emailAddress={} threadCount={}",

--- a/worker/src/main/java/com/mailsangja/worker/messaging/InitialMailSyncListener.java
+++ b/worker/src/main/java/com/mailsangja/worker/messaging/InitialMailSyncListener.java
@@ -1,5 +1,6 @@
 package com.mailsangja.worker.messaging;
 
+import com.mailsangja.worker.dto.mail.InitialMailSyncThreadBatchMessage;
 import com.mailsangja.worker.dto.mail.InitialMailSyncMessage;
 import com.mailsangja.worker.facade.InitialMailSyncFacade;
 import lombok.RequiredArgsConstructor;
@@ -15,5 +16,10 @@ public class InitialMailSyncListener {
     @RabbitListener(queues = "#{@initialMailSyncQueue.name}")
     public void handle(InitialMailSyncMessage message) {
         initialMailSyncFacade.handleInitialMailSync(message);
+    }
+
+    @RabbitListener(queues = "#{@initialMailSyncThreadBatchQueue.name}")
+    public void handleThreadBatch(InitialMailSyncThreadBatchMessage message) {
+        initialMailSyncFacade.handleInitialMailSyncThreadBatch(message);
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/messaging/InitialMailSyncListener.java
+++ b/worker/src/main/java/com/mailsangja/worker/messaging/InitialMailSyncListener.java
@@ -18,7 +18,10 @@ public class InitialMailSyncListener {
         initialMailSyncFacade.handleInitialMailSync(message);
     }
 
-    @RabbitListener(queues = "#{@initialMailSyncThreadBatchQueue.name}")
+    @RabbitListener(
+            queues = "#{@initialMailSyncThreadBatchQueue.name}",
+            containerFactory = "initialMailSyncThreadBatchRabbitListenerContainerFactory"
+    )
     public void handleThreadBatch(InitialMailSyncThreadBatchMessage message) {
         initialMailSyncFacade.handleInitialMailSyncThreadBatch(message);
     }

--- a/worker/src/main/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryService.java
@@ -11,6 +11,7 @@ import com.mailsangja.worker.dto.mail.InitialMailSyncMessageResult;
 import com.mailsangja.worker.dto.mail.InitialMailSyncThreadResult;
 import jakarta.mail.internet.AddressException;
 import jakarta.mail.internet.InternetAddress;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -28,6 +29,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 
+@Slf4j
 @Service
 public class GoogleMailMessageQueryService {
 
@@ -208,6 +210,12 @@ public class GoogleMailMessageQueryService {
     ) {
         List<String> addresses = extractAddresses(messageResponse, headerName);
         if (addresses.isEmpty()) {
+            log.warn(
+                    "Failed to normalize required mail header. threadId={} gmailMessageId={} headerName={}",
+                    messageResponse.threadId(),
+                    messageResponse.id(),
+                    headerName
+            );
             throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
         }
         return addresses.getFirst();
@@ -250,6 +258,13 @@ public class GoogleMailMessageQueryService {
             }
             return List.copyOf(normalizedAddresses);
         } catch (AddressException e) {
+            log.warn(
+                    "Failed to normalize mail header. threadId={} gmailMessageId={} headerName={} headerValue={}",
+                    messageResponse.threadId(),
+                    messageResponse.id(),
+                    headerName,
+                    headerValue
+            );
             if ("From".equalsIgnoreCase(headerName)) {
                 throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
             }

--- a/worker/src/main/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryService.java
@@ -163,6 +163,7 @@ public class GoogleMailMessageQueryService {
             GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse
     ) {
         validateThreadMessage(threadResponse, messageResponse);
+        MimeBodyContent bodyContent = extractBodyContent(messageResponse.payload());
 
         return new InitialMailSyncMessageResult(
                 messageResponse.id(),
@@ -176,8 +177,8 @@ public class GoogleMailMessageQueryService {
                 messageResponse.snippet(),
                 isRead(messageResponse.labelIds()),
                 resolveSentAt(messageResponse),
-                extractBodyContent(messageResponse.payload()).text(),
-                extractBodyContent(messageResponse.payload()).html(),
+                bodyContent.text(),
+                bodyContent.html(),
                 createAttachments(messageResponse.payload())
         );
     }

--- a/worker/src/main/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryService.java
@@ -5,6 +5,7 @@ import com.mailsangja.worker.common.exception.mail.MailPushException;
 import com.mailsangja.worker.config.properties.GoogleMailInitialSyncProperties;
 import com.mailsangja.worker.dto.gmail.GoogleMailMessageListResponse;
 import com.mailsangja.worker.dto.gmail.GoogleMailMessageListResult;
+import com.mailsangja.worker.dto.gmail.GoogleMailThreadResponse;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -12,6 +13,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
 
 @Service
 public class GoogleMailMessageQueryService {
@@ -45,6 +48,14 @@ public class GoogleMailMessageQueryService {
         }
     }
 
+    public List<GoogleMailThreadResponse> getThreads(String accessToken, List<String> threadIds) {
+        validateThreadInput(accessToken, threadIds);
+
+        return threadIds.stream()
+                .map(threadId -> getThread(accessToken, threadId))
+                .toList();
+    }
+
     private void validateInput(String accessToken) {
         if (isBlank(accessToken)
                 || isBlank(googleMailInitialSyncProperties.getMessagesUri())
@@ -57,6 +68,29 @@ public class GoogleMailMessageQueryService {
     private String buildMessagesUri() {
         return UriComponentsBuilder.fromUriString(googleMailInitialSyncProperties.getMessagesUri())
                 .queryParam("maxResults", googleMailInitialSyncProperties.getMaxResults())
+                .build()
+                .toUriString();
+    }
+
+    private GoogleMailThreadResponse getThread(String accessToken, String threadId) {
+        try {
+            GoogleMailThreadResponse response = googleMailMessageRestClient
+                    .get()
+                    .uri(buildThreadUri(threadId))
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .body(GoogleMailThreadResponse.class);
+
+            return validateThreadResponse(response);
+        } catch (RestClientException e) {
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_FETCH_FAILED);
+        }
+    }
+
+    private String buildThreadUri(String threadId) {
+        return UriComponentsBuilder.fromUriString(googleMailInitialSyncProperties.getThreadsUri())
+                .pathSegment(threadId)
                 .build()
                 .toUriString();
     }
@@ -75,6 +109,27 @@ public class GoogleMailMessageQueryService {
         int resultSizeEstimate = response.resultSizeEstimate() == null ? fetchedCount : response.resultSizeEstimate();
 
         return new GoogleMailMessageListResult(response.messages(), resultSizeEstimate);
+    }
+
+    private void validateThreadInput(String accessToken, List<String> threadIds) {
+        if (isBlank(accessToken)
+                || isBlank(googleMailInitialSyncProperties.getThreadsUri())
+                || threadIds == null
+                || threadIds.isEmpty()
+                || threadIds.stream().anyMatch(this::isBlank)) {
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_FETCH_FAILED);
+        }
+    }
+
+    private GoogleMailThreadResponse validateThreadResponse(GoogleMailThreadResponse response) {
+        if (response == null
+                || isBlank(response.id())
+                || response.messages() == null
+                || response.messages().isEmpty()) {
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
+        }
+
+        return response;
     }
 
     private boolean isBlank(String value) {

--- a/worker/src/main/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryService.java
@@ -6,6 +6,11 @@ import com.mailsangja.worker.config.properties.GoogleMailInitialSyncProperties;
 import com.mailsangja.worker.dto.gmail.GoogleMailMessageListResponse;
 import com.mailsangja.worker.dto.gmail.GoogleMailMessageListResult;
 import com.mailsangja.worker.dto.gmail.GoogleMailThreadResponse;
+import com.mailsangja.worker.dto.mail.InitialMailSyncAttachmentResult;
+import com.mailsangja.worker.dto.mail.InitialMailSyncMessageResult;
+import com.mailsangja.worker.dto.mail.InitialMailSyncThreadResult;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -14,10 +19,19 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
 
 @Service
 public class GoogleMailMessageQueryService {
+
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
 
     private final GoogleMailInitialSyncProperties googleMailInitialSyncProperties;
     private final RestClient googleMailMessageRestClient;
@@ -48,11 +62,11 @@ public class GoogleMailMessageQueryService {
         }
     }
 
-    public List<GoogleMailThreadResponse> getThreads(String accessToken, List<String> threadIds) {
+    public List<InitialMailSyncThreadResult> getThreads(String accessToken, List<String> threadIds) {
         validateThreadInput(accessToken, threadIds);
 
         return threadIds.stream()
-                .map(threadId -> getThread(accessToken, threadId))
+                .map(threadId -> toThreadResult(getThread(accessToken, threadId)))
                 .toList();
     }
 
@@ -132,7 +146,228 @@ public class GoogleMailMessageQueryService {
         return response;
     }
 
+    private InitialMailSyncThreadResult toThreadResult(GoogleMailThreadResponse response) {
+        return new InitialMailSyncThreadResult(
+                response.id(),
+                response.historyId(),
+                response.messages().stream()
+                        .map(message -> toMessageResult(response, message))
+                        .toList()
+        );
+    }
+
+    private InitialMailSyncMessageResult toMessageResult(
+            GoogleMailThreadResponse threadResponse,
+            GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse
+    ) {
+        validateThreadMessage(threadResponse, messageResponse);
+
+        return new InitialMailSyncMessageResult(
+                messageResponse.id(),
+                messageResponse.threadId(),
+                firstNonBlank(messageResponse.historyId(), threadResponse.historyId()),
+                resolveDirection(messageResponse.labelIds()),
+                extractHeaderValue(messageResponse, "Subject"),
+                extractRequiredAddress(messageResponse, "From"),
+                extractAddresses(messageResponse, "To"),
+                extractAddresses(messageResponse, "Cc"),
+                messageResponse.snippet(),
+                isRead(messageResponse.labelIds()),
+                resolveSentAt(messageResponse),
+                extractBodyContent(messageResponse.payload()).text(),
+                extractBodyContent(messageResponse.payload()).html(),
+                createAttachments(messageResponse.payload())
+        );
+    }
+
+    private void validateThreadMessage(
+            GoogleMailThreadResponse threadResponse,
+            GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse
+    ) {
+        if (messageResponse == null
+                || isBlank(messageResponse.id())
+                || isBlank(messageResponse.threadId())
+                || !threadResponse.id().equals(messageResponse.threadId())) {
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
+        }
+    }
+
+    private com.mailsangja.db.entity.mail.Direction resolveDirection(List<String> labelIds) {
+        return labelIds != null && labelIds.contains("SENT")
+                ? com.mailsangja.db.entity.mail.Direction.OUTBOUND
+                : com.mailsangja.db.entity.mail.Direction.INBOUND;
+    }
+
+    private boolean isRead(List<String> labelIds) {
+        return labelIds == null || !labelIds.contains("UNREAD");
+    }
+
+    private String extractRequiredAddress(
+            GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse,
+            String headerName
+    ) {
+        List<String> addresses = extractAddresses(messageResponse, headerName);
+        if (addresses.isEmpty()) {
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
+        }
+        return addresses.getFirst();
+    }
+
+    private String extractHeaderValue(
+            GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse,
+            String headerName
+    ) {
+        if (messageResponse.payload() == null || messageResponse.payload().headers() == null) {
+            return null;
+        }
+
+        return messageResponse.payload().headers().stream()
+                .filter(header -> header != null
+                        && !isBlank(header.name())
+                        && headerName.equalsIgnoreCase(header.name()))
+                .map(GoogleMailThreadResponse.GoogleMailHeaderResponse::value)
+                .filter(value -> value != null && !value.isBlank())
+                .findFirst()
+                .orElse(null);
+    }
+
+    private List<String> extractAddresses(
+            GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse,
+            String headerName
+    ) {
+        String headerValue = extractHeaderValue(messageResponse, headerName);
+        if (isBlank(headerValue)) {
+            return Collections.emptyList();
+        }
+
+        try {
+            InternetAddress[] addresses = InternetAddress.parseHeader(headerValue, true);
+            List<String> normalizedAddresses = new ArrayList<>();
+            for (InternetAddress address : addresses) {
+                if (address != null && !isBlank(address.getAddress())) {
+                    normalizedAddresses.add(address.getAddress().trim().toLowerCase());
+                }
+            }
+            return List.copyOf(normalizedAddresses);
+        } catch (AddressException e) {
+            if ("From".equalsIgnoreCase(headerName)) {
+                throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
+            }
+            return Collections.emptyList();
+        }
+    }
+
+    private LocalDateTime resolveSentAt(GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse) {
+        if (isBlank(messageResponse.internalDate())) {
+            return null;
+        }
+
+        try {
+            return LocalDateTime.ofInstant(
+                    Instant.ofEpochMilli(Long.parseLong(messageResponse.internalDate())),
+                    KST_ZONE_ID
+            );
+        } catch (NumberFormatException e) {
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
+        }
+    }
+
+    private MimeBodyContent extractBodyContent(GoogleMailThreadResponse.GoogleMailThreadPayloadResponse payload) {
+        if (payload == null) {
+            return new MimeBodyContent(null, null);
+        }
+
+        String text = decodeBody(findBodyData(payload, "text/plain"));
+        String html = decodeBody(findBodyData(payload, "text/html"));
+        return new MimeBodyContent(text, html);
+    }
+
+    private String findBodyData(GoogleMailThreadResponse.GoogleMailThreadPayloadResponse payload, String mimeType) {
+        if (payload == null) {
+            return null;
+        }
+
+        if (mimeType.equalsIgnoreCase(payload.mimeType())
+                && payload.body() != null
+                && !isBlank(payload.body().data())) {
+            return payload.body().data();
+        }
+
+        if (payload.parts() == null || payload.parts().isEmpty()) {
+            return null;
+        }
+
+        for (GoogleMailThreadResponse.GoogleMailThreadPayloadResponse part : payload.parts()) {
+            String data = findBodyData(part, mimeType);
+            if (!isBlank(data)) {
+                return data;
+            }
+        }
+
+        return null;
+    }
+
+    private String decodeBody(String encodedData) {
+        if (isBlank(encodedData)) {
+            return null;
+        }
+
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(encodedData);
+            return new String(decoded, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
+        }
+    }
+
+    private List<InitialMailSyncAttachmentResult> createAttachments(
+            GoogleMailThreadResponse.GoogleMailThreadPayloadResponse payload
+    ) {
+        List<GoogleMailThreadResponse.GoogleMailThreadPayloadResponse> attachmentParts = new ArrayList<>();
+        collectAttachmentParts(payload, attachmentParts);
+
+        return attachmentParts.stream()
+                .map(part -> new InitialMailSyncAttachmentResult(
+                        part.body() == null ? null : part.body().attachmentId(),
+                        part.filename(),
+                        part.mimeType(),
+                        part.body() == null ? null : part.body().size()
+                ))
+                .toList();
+    }
+
+    private void collectAttachmentParts(
+            GoogleMailThreadResponse.GoogleMailThreadPayloadResponse payload,
+            List<GoogleMailThreadResponse.GoogleMailThreadPayloadResponse> attachmentParts
+    ) {
+        if (payload == null) {
+            return;
+        }
+
+        if (!isBlank(payload.filename())
+                && payload.body() != null
+                && !isBlank(payload.body().attachmentId())) {
+            attachmentParts.add(payload);
+        }
+
+        if (payload.parts() == null || payload.parts().isEmpty()) {
+            return;
+        }
+
+        payload.parts().forEach(part -> collectAttachmentParts(part, attachmentParts));
+    }
+
+    private String firstNonBlank(String primary, String secondary) {
+        return !isBlank(primary) ? primary : secondary;
+    }
+
     private boolean isBlank(String value) {
         return value == null || value.isBlank();
+    }
+
+    private record MimeBodyContent(
+            String text,
+            String html
+    ) {
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryService.java
@@ -48,7 +48,8 @@ public class GoogleMailMessageQueryService {
     private void validateInput(String accessToken) {
         if (isBlank(accessToken)
                 || isBlank(googleMailInitialSyncProperties.getMessagesUri())
-                || googleMailInitialSyncProperties.getMaxResults() <= 0) {
+                || googleMailInitialSyncProperties.getMaxResults() <= 0
+                || googleMailInitialSyncProperties.getThreadBatchSize() <= 0) {
             throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_FETCH_FAILED);
         }
     }
@@ -65,10 +66,15 @@ public class GoogleMailMessageQueryService {
             throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
         }
 
+        if (response.messages() != null && response.messages().stream()
+                .anyMatch(message -> message == null || isBlank(message.id()))) {
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
+        }
+
         int fetchedCount = response.messages() == null ? 0 : response.messages().size();
         int resultSizeEstimate = response.resultSizeEstimate() == null ? fetchedCount : response.resultSizeEstimate();
 
-        return new GoogleMailMessageListResult(fetchedCount, resultSizeEstimate);
+        return new GoogleMailMessageListResult(response.messages(), resultSizeEstimate);
     }
 
     private boolean isBlank(String value) {

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
@@ -13,7 +13,6 @@ import com.mailsangja.worker.dto.mail.InitialMailSyncAttachmentResult;
 import com.mailsangja.worker.dto.mail.InitialMailSyncMessageSaveCommand;
 import com.mailsangja.worker.dto.mail.InitialMailSyncThreadSaveCommand;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,8 +21,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class InitialMailSyncCommandService {
@@ -47,47 +46,63 @@ public class InitialMailSyncCommandService {
             throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
         }
 
-        for (InitialMailSyncMessageSaveCommand messageCommand : command.messages()) {
-            saveMessage(mailAccount, command, messageCommand);
+        command.messages().stream()
+                .collect(Collectors.groupingBy(InitialMailSyncMessageSaveCommand::direction))
+                .forEach((direction, messageCommands) -> saveThreadDirection(mailAccount, command, direction, messageCommands));
+    }
+
+    private void saveThreadDirection(
+            MailAccount mailAccount,
+            InitialMailSyncThreadSaveCommand threadCommand,
+            Direction direction,
+            List<InitialMailSyncMessageSaveCommand> messageCommands
+    ) {
+        if (direction == null || messageCommands == null || messageCommands.isEmpty()) {
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
         }
+
+        Thread thread = findOrCreateThread(mailAccount, threadCommand.gmailThreadId(), direction);
+        ThreadAggregate aggregate = ThreadAggregate.from(thread);
+
+        for (InitialMailSyncMessageSaveCommand messageCommand : messageCommands) {
+            saveMessage(thread, threadCommand, messageCommand, aggregate);
+        }
+
+        thread.updateHistoryId(aggregate.historyId());
+        thread.updateLatestMessageInfoIfNewer(
+                aggregate.latestSubject(),
+                aggregate.latestSnippet(),
+                aggregate.latestParticipantAddress(),
+                aggregate.lastMessageAt(),
+                aggregate.read()
+        );
+        thread.updateMessageCount(aggregate.messageCount());
     }
 
     private void saveMessage(
-            MailAccount mailAccount,
+            Thread thread,
             InitialMailSyncThreadSaveCommand threadCommand,
-            InitialMailSyncMessageSaveCommand messageCommand
+            InitialMailSyncMessageSaveCommand messageCommand,
+            ThreadAggregate aggregate
     ) {
         validateThreadMessage(threadCommand, messageCommand);
-
-        Direction direction = messageCommand.direction();
-        boolean read = messageCommand.read();
-        String fromAddress = messageCommand.fromAddress();
-        String subject = messageCommand.subject();
-        List<String> toAddresses = messageCommand.toAddresses();
-        List<String> ccAddresses = messageCommand.ccAddresses();
-        LocalDateTime sentAt = messageCommand.sentAt();
-
-        Thread thread = findOrCreateThread(
-                mailAccount,
-                threadCommand.gmailThreadId(),
-                direction
-        );
 
         Optional<Message> existingMessage = messageRepositoryPort.findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(
                 thread.getId(),
                 messageCommand.gmailMessageId()
         );
+        boolean inserted = existingMessage.isEmpty();
 
-        if (existingMessage.isPresent()) {
+        if (!inserted) {
             Message message = existingMessage.get();
             message.updateBasicContent(
-                    subject,
-                    fromAddress,
-                    toAddresses,
-                    ccAddresses,
+                    messageCommand.subject(),
+                    messageCommand.fromAddress(),
+                    messageCommand.toAddresses(),
+                    messageCommand.ccAddresses(),
                     messageCommand.snippet(),
-                    read,
-                    sentAt
+                    messageCommand.read(),
+                    messageCommand.sentAt()
             );
             message.updateBodyContent(messageCommand.bodyText(), messageCommand.bodyHtml());
             message.replaceAttachments(createAttachments(message, messageCommand.attachments()));
@@ -95,14 +110,14 @@ public class InitialMailSyncCommandService {
             Message message = Message.builder()
                     .thread(thread)
                     .gmailMessageId(messageCommand.gmailMessageId())
-                    .direction(direction)
-                    .subject(subject)
-                    .fromAddress(fromAddress)
-                    .toAddresses(toAddresses)
-                    .ccAddresses(ccAddresses)
+                    .direction(messageCommand.direction())
+                    .subject(messageCommand.subject())
+                    .fromAddress(messageCommand.fromAddress())
+                    .toAddresses(messageCommand.toAddresses())
+                    .ccAddresses(messageCommand.ccAddresses())
                     .snippet(messageCommand.snippet())
-                    .read(read)
-                    .sentAt(sentAt)
+                    .read(messageCommand.read())
+                    .sentAt(messageCommand.sentAt())
                     .bodyText(messageCommand.bodyText())
                     .bodyHtml(messageCommand.bodyHtml())
                     .attachments(new ArrayList<>())
@@ -112,15 +127,7 @@ public class InitialMailSyncCommandService {
             messageRepositoryPort.save(message);
         }
 
-        thread.updateHistoryId(firstNonBlank(messageCommand.historyId(), threadCommand.historyId()));
-        thread.updateLatestMessageInfoIfNewer(
-                subject,
-                messageCommand.snippet(),
-                resolveLatestParticipantAddress(direction, fromAddress, toAddresses),
-                sentAt,
-                read
-        );
-        thread.updateMessageCount((int) messageRepositoryPort.countByThreadIdAndDeletedAtIsNull(thread.getId()));
+        aggregate.merge(threadCommand, messageCommand, inserted);
     }
 
     private Thread findOrCreateThread(MailAccount mailAccount, String gmailThreadId, Direction direction) {
@@ -169,21 +176,6 @@ public class InitialMailSyncCommandService {
                 .toList();
     }
 
-    private LocalDateTime resolveSentAt(GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse) {
-        if (isBlank(messageResponse.internalDate())) {
-            return null;
-        }
-
-        try {
-            return LocalDateTime.ofInstant(
-                    Instant.ofEpochMilli(Long.parseLong(messageResponse.internalDate())),
-                    KST_ZONE_ID
-            );
-        } catch (NumberFormatException e) {
-            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
-        }
-    }
-
     private String resolveLatestParticipantAddress(Direction direction, String fromAddress, List<String> toAddresses) {
         if (direction == Direction.OUTBOUND) {
             return toAddresses.isEmpty() ? null : toAddresses.getFirst();
@@ -197,5 +189,107 @@ public class InitialMailSyncCommandService {
 
     private boolean isBlank(String value) {
         return value == null || value.isBlank();
+    }
+
+    private static final class ThreadAggregate {
+        private String historyId;
+        private String latestSubject;
+        private String latestSnippet;
+        private String latestParticipantAddress;
+        private LocalDateTime lastMessageAt;
+        private boolean read;
+        private int messageCount;
+
+        private static ThreadAggregate from(Thread thread) {
+            ThreadAggregate aggregate = new ThreadAggregate();
+            aggregate.historyId = thread.getHistoryId();
+            aggregate.latestSubject = thread.getLatestSubject();
+            aggregate.latestSnippet = thread.getLatestSnippet();
+            aggregate.latestParticipantAddress = thread.getLatestParticipantAddress();
+            aggregate.lastMessageAt = thread.getLastMessageAt();
+            aggregate.read = thread.isRead();
+            aggregate.messageCount = thread.getMessageCount();
+            return aggregate;
+        }
+
+        private void merge(
+                InitialMailSyncThreadSaveCommand threadCommand,
+                InitialMailSyncMessageSaveCommand messageCommand,
+                boolean inserted
+        ) {
+            historyId = firstNonBlank(messageCommand.historyId(), threadCommand.historyId(), historyId);
+            if (inserted) {
+                messageCount++;
+            }
+
+            LocalDateTime candidateSentAt = messageCommand.sentAt();
+            if (shouldReplaceLatest(candidateSentAt)) {
+                latestSubject = messageCommand.subject();
+                latestSnippet = messageCommand.snippet();
+                latestParticipantAddress = resolveLatestParticipantAddress(
+                        messageCommand.direction(),
+                        messageCommand.fromAddress(),
+                        messageCommand.toAddresses()
+                );
+                lastMessageAt = candidateSentAt;
+                read = messageCommand.read();
+            }
+        }
+
+        private boolean shouldReplaceLatest(LocalDateTime candidateSentAt) {
+            if (candidateSentAt == null) {
+                return lastMessageAt == null && latestSubject == null && latestSnippet == null;
+            }
+
+            return lastMessageAt == null || !lastMessageAt.isAfter(candidateSentAt);
+        }
+
+        private String historyId() {
+            return historyId;
+        }
+
+        private String latestSubject() {
+            return latestSubject;
+        }
+
+        private String latestSnippet() {
+            return latestSnippet;
+        }
+
+        private String latestParticipantAddress() {
+            return latestParticipantAddress;
+        }
+
+        private LocalDateTime lastMessageAt() {
+            return lastMessageAt;
+        }
+
+        private boolean read() {
+            return read;
+        }
+
+        private int messageCount() {
+            return messageCount;
+        }
+
+        private String firstNonBlank(String... values) {
+            for (String value : values) {
+                if (!isBlank(value)) {
+                    return value;
+                }
+            }
+            return null;
+        }
+
+        private String resolveLatestParticipantAddress(Direction direction, String fromAddress, List<String> toAddresses) {
+            if (direction == Direction.OUTBOUND) {
+                return toAddresses == null || toAddresses.isEmpty() ? null : toAddresses.getFirst();
+            }
+            return fromAddress;
+        }
+
+        private boolean isBlank(String value) {
+            return value == null || value.isBlank();
+        }
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
@@ -115,17 +115,17 @@ public class InitialMailSyncCommandService {
                     .build();
             message.replaceAttachments(createAttachments(message, messageResponse.payload()));
             messageRepositoryPort.save(message);
-            thread.incrementMessageCount();
         }
 
         thread.updateHistoryId(firstNonBlank(messageResponse.historyId(), threadResponse.historyId()));
-        thread.updateReadStatus(read);
-        thread.updateLatestMessageInfo(
+        thread.updateLatestMessageInfoIfNewer(
                 subject,
                 messageResponse.snippet(),
                 resolveLatestParticipantAddress(direction, fromAddress, toAddresses),
-                sentAt
+                sentAt,
+                read
         );
+        thread.updateMessageCount((int) messageRepositoryPort.countByThreadIdAndDeletedAtIsNull(thread.getId()));
     }
 
     private Thread findOrCreateThread(MailAccount mailAccount, String gmailThreadId, Direction direction) {

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
@@ -9,78 +9,73 @@ import com.mailsangja.db.port.MessageRepositoryPort;
 import com.mailsangja.db.port.ThreadRepositoryPort;
 import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
 import com.mailsangja.worker.common.exception.mail.MailPushException;
-import com.mailsangja.worker.dto.gmail.GoogleMailThreadResponse;
+import com.mailsangja.worker.dto.mail.InitialMailSyncAttachmentResult;
+import com.mailsangja.worker.dto.mail.InitialMailSyncMessageSaveCommand;
+import com.mailsangja.worker.dto.mail.InitialMailSyncThreadSaveCommand;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class InitialMailSyncCommandService {
 
-    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
-
     private final ThreadRepositoryPort threadRepositoryPort;
     private final MessageRepositoryPort messageRepositoryPort;
 
     @Transactional
-    public void saveThreadBatch(MailAccount mailAccount, List<GoogleMailThreadResponse> threadResponses) {
-        if (mailAccount == null || threadResponses == null || threadResponses.isEmpty()) {
+    public void saveThreadBatch(MailAccount mailAccount, List<InitialMailSyncThreadSaveCommand> commands) {
+        if (mailAccount == null || commands == null || commands.isEmpty()) {
             throw new MailPushException(MailPushErrorCode.INVALID_INITIAL_MAIL_SYNC_COMMAND);
         }
 
-        for (GoogleMailThreadResponse threadResponse : threadResponses) {
-            saveThread(mailAccount, threadResponse);
+        for (InitialMailSyncThreadSaveCommand command : commands) {
+            saveThread(mailAccount, command);
         }
     }
 
-    private void saveThread(MailAccount mailAccount, GoogleMailThreadResponse threadResponse) {
-        if (threadResponse == null || isBlank(threadResponse.id()) || threadResponse.messages() == null) {
+    private void saveThread(MailAccount mailAccount, InitialMailSyncThreadSaveCommand command) {
+        if (command == null || isBlank(command.gmailThreadId()) || command.messages() == null) {
             throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
         }
 
-        for (GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse : threadResponse.messages()) {
-            saveMessage(mailAccount, threadResponse, messageResponse);
+        for (InitialMailSyncMessageSaveCommand messageCommand : command.messages()) {
+            saveMessage(mailAccount, command, messageCommand);
         }
     }
 
     private void saveMessage(
             MailAccount mailAccount,
-            GoogleMailThreadResponse threadResponse,
-            GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse
+            InitialMailSyncThreadSaveCommand threadCommand,
+            InitialMailSyncMessageSaveCommand messageCommand
     ) {
-        validateThreadMessage(threadResponse, messageResponse);
+        validateThreadMessage(threadCommand, messageCommand);
 
-        Direction direction = resolveDirection(messageResponse.labelIds());
-        boolean read = isRead(messageResponse.labelIds());
-        String fromAddress = extractRequiredHeaderValue(messageResponse, "From");
-        String subject = extractHeaderValue(messageResponse, "Subject");
-        List<String> toAddresses = extractAddresses(messageResponse, "To");
-        List<String> ccAddresses = extractAddresses(messageResponse, "Cc");
-        LocalDateTime sentAt = resolveSentAt(messageResponse);
-        MimeBodyContent bodyContent = extractBodyContent(messageResponse.payload());
+        Direction direction = messageCommand.direction();
+        boolean read = messageCommand.read();
+        String fromAddress = messageCommand.fromAddress();
+        String subject = messageCommand.subject();
+        List<String> toAddresses = messageCommand.toAddresses();
+        List<String> ccAddresses = messageCommand.ccAddresses();
+        LocalDateTime sentAt = messageCommand.sentAt();
 
         Thread thread = findOrCreateThread(
                 mailAccount,
-                threadResponse.id(),
+                threadCommand.gmailThreadId(),
                 direction
         );
 
         Optional<Message> existingMessage = messageRepositoryPort.findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(
                 thread.getId(),
-                messageResponse.id()
+                messageCommand.gmailMessageId()
         );
 
         if (existingMessage.isPresent()) {
@@ -90,37 +85,37 @@ public class InitialMailSyncCommandService {
                     fromAddress,
                     toAddresses,
                     ccAddresses,
-                    messageResponse.snippet(),
+                    messageCommand.snippet(),
                     read,
                     sentAt
             );
-            message.updateBodyContent(bodyContent.text(), bodyContent.html());
-            message.replaceAttachments(createAttachments(message, messageResponse.payload()));
+            message.updateBodyContent(messageCommand.bodyText(), messageCommand.bodyHtml());
+            message.replaceAttachments(createAttachments(message, messageCommand.attachments()));
         } else {
             Message message = Message.builder()
                     .thread(thread)
-                    .gmailMessageId(messageResponse.id())
+                    .gmailMessageId(messageCommand.gmailMessageId())
                     .direction(direction)
                     .subject(subject)
                     .fromAddress(fromAddress)
                     .toAddresses(toAddresses)
                     .ccAddresses(ccAddresses)
-                    .snippet(messageResponse.snippet())
+                    .snippet(messageCommand.snippet())
                     .read(read)
                     .sentAt(sentAt)
-                    .bodyText(bodyContent.text())
-                    .bodyHtml(bodyContent.html())
+                    .bodyText(messageCommand.bodyText())
+                    .bodyHtml(messageCommand.bodyHtml())
                     .attachments(new ArrayList<>())
                     .labels(Collections.emptyList())
                     .build();
-            message.replaceAttachments(createAttachments(message, messageResponse.payload()));
+            message.replaceAttachments(createAttachments(message, messageCommand.attachments()));
             messageRepositoryPort.save(message);
         }
 
-        thread.updateHistoryId(firstNonBlank(messageResponse.historyId(), threadResponse.historyId()));
+        thread.updateHistoryId(firstNonBlank(messageCommand.historyId(), threadCommand.historyId()));
         thread.updateLatestMessageInfoIfNewer(
                 subject,
-                messageResponse.snippet(),
+                messageCommand.snippet(),
                 resolveLatestParticipantAddress(direction, fromAddress, toAddresses),
                 sentAt,
                 read
@@ -144,160 +139,34 @@ public class InitialMailSyncCommandService {
     }
 
     private void validateThreadMessage(
-            GoogleMailThreadResponse threadResponse,
-            GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse
+            InitialMailSyncThreadSaveCommand threadCommand,
+            InitialMailSyncMessageSaveCommand messageCommand
     ) {
-        if (messageResponse == null
-                || isBlank(messageResponse.id())
-                || isBlank(messageResponse.threadId())
-                || !threadResponse.id().equals(messageResponse.threadId())) {
-            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
-        }
-    }
-
-    private Direction resolveDirection(List<String> labelIds) {
-        return labelIds != null && labelIds.contains("SENT") ? Direction.OUTBOUND : Direction.INBOUND;
-    }
-
-    private boolean isRead(List<String> labelIds) {
-        return labelIds == null || !labelIds.contains("UNREAD");
-    }
-
-    private String extractRequiredHeaderValue(
-            GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse,
-            String headerName
-    ) {
-        String headerValue = extractHeaderValue(messageResponse, headerName);
-        if (isBlank(headerValue)) {
-            log.warn(
-                    "Initial mail sync message is missing required header. threadId={} gmailMessageId={} headerName={}",
-                    messageResponse.threadId(),
-                    messageResponse.id(),
-                    headerName
-            );
-            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
-        }
-        return headerValue;
-    }
-
-    private String extractHeaderValue(
-            GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse,
-            String headerName
-    ) {
-        if (messageResponse.payload() == null || messageResponse.payload().headers() == null) {
-            return null;
-        }
-
-        return messageResponse.payload().headers().stream()
-                .filter(header -> header != null
-                        && !isBlank(header.name())
-                        && headerName.equalsIgnoreCase(header.name()))
-                .map(GoogleMailThreadResponse.GoogleMailHeaderResponse::value)
-                .filter(value -> value != null && !value.isBlank())
-                .findFirst()
-                .orElse(null);
-    }
-
-    private List<String> extractAddresses(
-            GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse,
-            String headerName
-    ) {
-        String headerValue = extractHeaderValue(messageResponse, headerName);
-        if (isBlank(headerValue)) {
-            return Collections.emptyList();
-        }
-
-        return List.of(headerValue.split(",")).stream()
-                .map(String::trim)
-                .filter(value -> !value.isBlank())
-                .toList();
-    }
-
-    private MimeBodyContent extractBodyContent(GoogleMailThreadResponse.GoogleMailThreadPayloadResponse payload) {
-        if (payload == null) {
-            return new MimeBodyContent(null, null);
-        }
-
-        String text = decodeBody(findBodyData(payload, "text/plain"));
-        String html = decodeBody(findBodyData(payload, "text/html"));
-        return new MimeBodyContent(text, html);
-    }
-
-    private String findBodyData(GoogleMailThreadResponse.GoogleMailThreadPayloadResponse payload, String mimeType) {
-        if (payload == null) {
-            return null;
-        }
-
-        if (mimeType.equalsIgnoreCase(payload.mimeType())
-                && payload.body() != null
-                && !isBlank(payload.body().data())) {
-            return payload.body().data();
-        }
-
-        if (payload.parts() == null || payload.parts().isEmpty()) {
-            return null;
-        }
-
-        for (GoogleMailThreadResponse.GoogleMailThreadPayloadResponse part : payload.parts()) {
-            String data = findBodyData(part, mimeType);
-            if (!isBlank(data)) {
-                return data;
-            }
-        }
-
-        return null;
-    }
-
-    private String decodeBody(String encodedData) {
-        if (isBlank(encodedData)) {
-            return null;
-        }
-
-        try {
-            byte[] decoded = Base64.getUrlDecoder().decode(encodedData);
-            return new String(decoded, StandardCharsets.UTF_8);
-        } catch (IllegalArgumentException e) {
+        if (messageCommand == null
+                || isBlank(threadCommand.gmailThreadId())
+                || isBlank(messageCommand.gmailMessageId())
+                || isBlank(messageCommand.fromAddress())) {
             throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
         }
     }
 
     private List<Attachment> createAttachments(
             Message message,
-            GoogleMailThreadResponse.GoogleMailThreadPayloadResponse payload
+            List<InitialMailSyncAttachmentResult> attachments
     ) {
-        List<GoogleMailThreadResponse.GoogleMailThreadPayloadResponse> attachmentParts = new ArrayList<>();
-        collectAttachmentParts(payload, attachmentParts);
+        if (attachments == null || attachments.isEmpty()) {
+            return List.of();
+        }
 
-        return attachmentParts.stream()
-                .map(part -> Attachment.builder()
+        return attachments.stream()
+                .map(attachment -> Attachment.builder()
                         .message(message)
-                        .gmailAttachmentId(part.body() == null ? null : part.body().attachmentId())
-                        .filename(part.filename())
-                        .mimeType(part.mimeType())
-                        .size(part.body() == null ? null : part.body().size())
+                        .gmailAttachmentId(attachment.gmailAttachmentId())
+                        .filename(attachment.filename())
+                        .mimeType(attachment.mimeType())
+                        .size(attachment.size())
                         .build())
                 .toList();
-    }
-
-    private void collectAttachmentParts(
-            GoogleMailThreadResponse.GoogleMailThreadPayloadResponse payload,
-            List<GoogleMailThreadResponse.GoogleMailThreadPayloadResponse> attachmentParts
-    ) {
-        if (payload == null) {
-            return;
-        }
-
-        if (!isBlank(payload.filename())
-                && payload.body() != null
-                && !isBlank(payload.body().attachmentId())) {
-            attachmentParts.add(payload);
-        }
-
-        if (payload.parts() == null || payload.parts().isEmpty()) {
-            return;
-        }
-
-        payload.parts().forEach(part -> collectAttachmentParts(part, attachmentParts));
     }
 
     private LocalDateTime resolveSentAt(GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse) {
@@ -328,11 +197,5 @@ public class InitialMailSyncCommandService {
 
     private boolean isBlank(String value) {
         return value == null || value.isBlank();
-    }
-
-    private record MimeBodyContent(
-            String text,
-            String html
-    ) {
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
@@ -176,17 +176,6 @@ public class InitialMailSyncCommandService {
                 .toList();
     }
 
-    private String resolveLatestParticipantAddress(Direction direction, String fromAddress, List<String> toAddresses) {
-        if (direction == Direction.OUTBOUND) {
-            return toAddresses.isEmpty() ? null : toAddresses.getFirst();
-        }
-        return fromAddress;
-    }
-
-    private String firstNonBlank(String primary, String secondary) {
-        return !isBlank(primary) ? primary : secondary;
-    }
-
     private boolean isBlank(String value) {
         return value == null || value.isBlank();
     }

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
@@ -1,5 +1,6 @@
 package com.mailsangja.worker.service.mail;
 
+import com.mailsangja.db.entity.mail.Attachment;
 import com.mailsangja.db.entity.mail.Direction;
 import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.Message;
@@ -17,9 +18,12 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Service
@@ -66,6 +70,7 @@ public class InitialMailSyncCommandService {
         List<String> toAddresses = extractAddresses(messageResponse, "To");
         List<String> ccAddresses = extractAddresses(messageResponse, "Cc");
         LocalDateTime sentAt = resolveSentAt(messageResponse);
+        MimeBodyContent bodyContent = extractBodyContent(messageResponse.payload());
 
         Thread thread = findOrCreateThread(
                 mailAccount,
@@ -89,6 +94,8 @@ public class InitialMailSyncCommandService {
                     read,
                     sentAt
             );
+            message.updateBodyContent(bodyContent.text(), bodyContent.html());
+            message.replaceAttachments(createAttachments(message, messageResponse.payload()));
         } else {
             Message message = Message.builder()
                     .thread(thread)
@@ -101,11 +108,12 @@ public class InitialMailSyncCommandService {
                     .snippet(messageResponse.snippet())
                     .read(read)
                     .sentAt(sentAt)
-                    .bodyText(null)
-                    .bodyHtml(null)
-                    .attachments(Collections.emptyList())
+                    .bodyText(bodyContent.text())
+                    .bodyHtml(bodyContent.html())
+                    .attachments(new ArrayList<>())
                     .labels(Collections.emptyList())
                     .build();
+            message.replaceAttachments(createAttachments(message, messageResponse.payload()));
             messageRepositoryPort.save(message);
             thread.incrementMessageCount();
         }
@@ -205,6 +213,93 @@ public class InitialMailSyncCommandService {
                 .toList();
     }
 
+    private MimeBodyContent extractBodyContent(GoogleMailThreadResponse.GoogleMailThreadPayloadResponse payload) {
+        if (payload == null) {
+            return new MimeBodyContent(null, null);
+        }
+
+        String text = decodeBody(findBodyData(payload, "text/plain"));
+        String html = decodeBody(findBodyData(payload, "text/html"));
+        return new MimeBodyContent(text, html);
+    }
+
+    private String findBodyData(GoogleMailThreadResponse.GoogleMailThreadPayloadResponse payload, String mimeType) {
+        if (payload == null) {
+            return null;
+        }
+
+        if (mimeType.equalsIgnoreCase(payload.mimeType())
+                && payload.body() != null
+                && !isBlank(payload.body().data())) {
+            return payload.body().data();
+        }
+
+        if (payload.parts() == null || payload.parts().isEmpty()) {
+            return null;
+        }
+
+        for (GoogleMailThreadResponse.GoogleMailThreadPayloadResponse part : payload.parts()) {
+            String data = findBodyData(part, mimeType);
+            if (!isBlank(data)) {
+                return data;
+            }
+        }
+
+        return null;
+    }
+
+    private String decodeBody(String encodedData) {
+        if (isBlank(encodedData)) {
+            return null;
+        }
+
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(encodedData);
+            return new String(decoded, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
+        }
+    }
+
+    private List<Attachment> createAttachments(
+            Message message,
+            GoogleMailThreadResponse.GoogleMailThreadPayloadResponse payload
+    ) {
+        List<GoogleMailThreadResponse.GoogleMailThreadPayloadResponse> attachmentParts = new ArrayList<>();
+        collectAttachmentParts(payload, attachmentParts);
+
+        return attachmentParts.stream()
+                .map(part -> Attachment.builder()
+                        .message(message)
+                        .gmailAttachmentId(part.body() == null ? null : part.body().attachmentId())
+                        .filename(part.filename())
+                        .mimeType(part.mimeType())
+                        .size(part.body() == null ? null : part.body().size())
+                        .build())
+                .toList();
+    }
+
+    private void collectAttachmentParts(
+            GoogleMailThreadResponse.GoogleMailThreadPayloadResponse payload,
+            List<GoogleMailThreadResponse.GoogleMailThreadPayloadResponse> attachmentParts
+    ) {
+        if (payload == null) {
+            return;
+        }
+
+        if (!isBlank(payload.filename())
+                && payload.body() != null
+                && !isBlank(payload.body().attachmentId())) {
+            attachmentParts.add(payload);
+        }
+
+        if (payload.parts() == null || payload.parts().isEmpty()) {
+            return;
+        }
+
+        payload.parts().forEach(part -> collectAttachmentParts(part, attachmentParts));
+    }
+
     private LocalDateTime resolveSentAt(GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse) {
         if (isBlank(messageResponse.internalDate())) {
             return null;
@@ -233,5 +328,11 @@ public class InitialMailSyncCommandService {
 
     private boolean isBlank(String value) {
         return value == null || value.isBlank();
+    }
+
+    private record MimeBodyContent(
+            String text,
+            String html
+    ) {
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
@@ -1,0 +1,237 @@
+package com.mailsangja.worker.service.mail;
+
+import com.mailsangja.db.entity.mail.Direction;
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.entity.mail.Thread;
+import com.mailsangja.db.port.MessageRepositoryPort;
+import com.mailsangja.db.port.ThreadRepositoryPort;
+import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
+import com.mailsangja.worker.common.exception.mail.MailPushException;
+import com.mailsangja.worker.dto.gmail.GoogleMailThreadResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InitialMailSyncCommandService {
+
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    private final ThreadRepositoryPort threadRepositoryPort;
+    private final MessageRepositoryPort messageRepositoryPort;
+
+    @Transactional
+    public void saveThreadBatch(MailAccount mailAccount, List<GoogleMailThreadResponse> threadResponses) {
+        if (mailAccount == null || threadResponses == null || threadResponses.isEmpty()) {
+            throw new MailPushException(MailPushErrorCode.INVALID_INITIAL_MAIL_SYNC_COMMAND);
+        }
+
+        for (GoogleMailThreadResponse threadResponse : threadResponses) {
+            saveThread(mailAccount, threadResponse);
+        }
+    }
+
+    private void saveThread(MailAccount mailAccount, GoogleMailThreadResponse threadResponse) {
+        if (threadResponse == null || isBlank(threadResponse.id()) || threadResponse.messages() == null) {
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
+        }
+
+        for (GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse : threadResponse.messages()) {
+            saveMessage(mailAccount, threadResponse, messageResponse);
+        }
+    }
+
+    private void saveMessage(
+            MailAccount mailAccount,
+            GoogleMailThreadResponse threadResponse,
+            GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse
+    ) {
+        validateThreadMessage(threadResponse, messageResponse);
+
+        Direction direction = resolveDirection(messageResponse.labelIds());
+        boolean read = isRead(messageResponse.labelIds());
+        String fromAddress = extractRequiredHeaderValue(messageResponse, "From");
+        String subject = extractHeaderValue(messageResponse, "Subject");
+        List<String> toAddresses = extractAddresses(messageResponse, "To");
+        List<String> ccAddresses = extractAddresses(messageResponse, "Cc");
+        LocalDateTime sentAt = resolveSentAt(messageResponse);
+
+        Thread thread = findOrCreateThread(
+                mailAccount,
+                threadResponse.id(),
+                direction
+        );
+
+        Optional<Message> existingMessage = messageRepositoryPort.findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(
+                thread.getId(),
+                messageResponse.id()
+        );
+
+        if (existingMessage.isPresent()) {
+            Message message = existingMessage.get();
+            message.updateBasicContent(
+                    subject,
+                    fromAddress,
+                    toAddresses,
+                    ccAddresses,
+                    messageResponse.snippet(),
+                    read,
+                    sentAt
+            );
+        } else {
+            Message message = Message.builder()
+                    .thread(thread)
+                    .gmailMessageId(messageResponse.id())
+                    .direction(direction)
+                    .subject(subject)
+                    .fromAddress(fromAddress)
+                    .toAddresses(toAddresses)
+                    .ccAddresses(ccAddresses)
+                    .snippet(messageResponse.snippet())
+                    .read(read)
+                    .sentAt(sentAt)
+                    .bodyText(null)
+                    .bodyHtml(null)
+                    .attachments(Collections.emptyList())
+                    .labels(Collections.emptyList())
+                    .build();
+            messageRepositoryPort.save(message);
+            thread.incrementMessageCount();
+        }
+
+        thread.updateHistoryId(firstNonBlank(messageResponse.historyId(), threadResponse.historyId()));
+        thread.updateReadStatus(read);
+        thread.updateLatestMessageInfo(
+                subject,
+                messageResponse.snippet(),
+                resolveLatestParticipantAddress(direction, fromAddress, toAddresses),
+                sentAt
+        );
+    }
+
+    private Thread findOrCreateThread(MailAccount mailAccount, String gmailThreadId, Direction direction) {
+        return threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                        mailAccount.getId(),
+                        gmailThreadId,
+                        direction
+                )
+                .orElseGet(() -> threadRepositoryPort.save(Thread.builder()
+                        .mailAccount(mailAccount)
+                        .gmailThreadId(gmailThreadId)
+                        .direction(direction)
+                        .read(true)
+                        .messageCount(0)
+                        .build()));
+    }
+
+    private void validateThreadMessage(
+            GoogleMailThreadResponse threadResponse,
+            GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse
+    ) {
+        if (messageResponse == null
+                || isBlank(messageResponse.id())
+                || isBlank(messageResponse.threadId())
+                || !threadResponse.id().equals(messageResponse.threadId())) {
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
+        }
+    }
+
+    private Direction resolveDirection(List<String> labelIds) {
+        return labelIds != null && labelIds.contains("SENT") ? Direction.OUTBOUND : Direction.INBOUND;
+    }
+
+    private boolean isRead(List<String> labelIds) {
+        return labelIds == null || !labelIds.contains("UNREAD");
+    }
+
+    private String extractRequiredHeaderValue(
+            GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse,
+            String headerName
+    ) {
+        String headerValue = extractHeaderValue(messageResponse, headerName);
+        if (isBlank(headerValue)) {
+            log.warn(
+                    "Initial mail sync message is missing required header. threadId={} gmailMessageId={} headerName={}",
+                    messageResponse.threadId(),
+                    messageResponse.id(),
+                    headerName
+            );
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
+        }
+        return headerValue;
+    }
+
+    private String extractHeaderValue(
+            GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse,
+            String headerName
+    ) {
+        if (messageResponse.payload() == null || messageResponse.payload().headers() == null) {
+            return null;
+        }
+
+        return messageResponse.payload().headers().stream()
+                .filter(header -> header != null
+                        && !isBlank(header.name())
+                        && headerName.equalsIgnoreCase(header.name()))
+                .map(GoogleMailThreadResponse.GoogleMailHeaderResponse::value)
+                .filter(value -> value != null && !value.isBlank())
+                .findFirst()
+                .orElse(null);
+    }
+
+    private List<String> extractAddresses(
+            GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse,
+            String headerName
+    ) {
+        String headerValue = extractHeaderValue(messageResponse, headerName);
+        if (isBlank(headerValue)) {
+            return Collections.emptyList();
+        }
+
+        return List.of(headerValue.split(",")).stream()
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .toList();
+    }
+
+    private LocalDateTime resolveSentAt(GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse) {
+        if (isBlank(messageResponse.internalDate())) {
+            return null;
+        }
+
+        try {
+            return LocalDateTime.ofInstant(
+                    Instant.ofEpochMilli(Long.parseLong(messageResponse.internalDate())),
+                    KST_ZONE_ID
+            );
+        } catch (NumberFormatException e) {
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
+        }
+    }
+
+    private String resolveLatestParticipantAddress(Direction direction, String fromAddress, List<String> toAddresses) {
+        if (direction == Direction.OUTBOUND) {
+            return toAddresses.isEmpty() ? null : toAddresses.getFirst();
+        }
+        return fromAddress;
+    }
+
+    private String firstNonBlank(String primary, String secondary) {
+        return !isBlank(primary) ? primary : secondary;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
@@ -227,7 +227,7 @@ public class InitialMailSyncCommandService {
 
         private boolean shouldReplaceLatest(LocalDateTime candidateSentAt) {
             if (candidateSentAt == null) {
-                return lastMessageAt == null && latestSubject == null && latestSnippet == null;
+                return false;
             }
 
             return lastMessageAt == null || !lastMessageAt.isAfter(candidateSentAt);

--- a/worker/src/main/java/com/mailsangja/worker/service/messaging/MailTaskPublisherService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/messaging/MailTaskPublisherService.java
@@ -140,6 +140,7 @@ public class MailTaskPublisherService {
 
     private void validateInitialMailSyncThreadBatchProperties() {
         if (isBlank(mailTaskRabbitProperties.getExchange())
+                || isBlank(initialMailSyncRabbitProperties.getThreadBatchTaskName())
                 || isBlank(initialMailSyncRabbitProperties.getThreadBatchQueueName())
                 || isBlank(initialMailSyncRabbitProperties.getThreadBatchRoutingKey())
                 || isBlank(mailTaskRabbitProperties.getDeadLetterExchange())

--- a/worker/src/main/java/com/mailsangja/worker/service/messaging/MailTaskPublisherService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/messaging/MailTaskPublisherService.java
@@ -5,8 +5,10 @@ import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
 import com.mailsangja.worker.common.exception.mail.MailPushException;
 import com.mailsangja.worker.common.exception.mq.MqErrorCode;
 import com.mailsangja.worker.common.exception.mq.MqException;
+import com.mailsangja.worker.config.properties.InitialMailSyncRabbitProperties;
 import com.mailsangja.worker.config.properties.MailTaskRabbitProperties;
 import com.mailsangja.worker.config.properties.WatchRenewalRabbitProperties;
+import com.mailsangja.worker.dto.mail.InitialMailSyncThreadBatchMessage;
 import com.mailsangja.worker.dto.mail.WatchRenewalMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +16,8 @@ import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -23,6 +27,38 @@ public class MailTaskPublisherService {
     private final RabbitTemplate rabbitTemplate;
     private final MailTaskRabbitProperties mailTaskRabbitProperties;
     private final WatchRenewalRabbitProperties watchRenewalRabbitProperties;
+    private final InitialMailSyncRabbitProperties initialMailSyncRabbitProperties;
+
+    public void publishInitialMailSyncThreadBatch(InitialMailSyncThreadBatchMessage message) {
+        validateInitialMailSyncThreadBatchProperties();
+        validateInitialMailSyncThreadBatchMessage(message);
+
+        try {
+            rabbitTemplate.convertAndSend(
+                    mailTaskRabbitProperties.getExchange(),
+                    initialMailSyncRabbitProperties.getThreadBatchRoutingKey(),
+                    message,
+                    new CorrelationData(message.mailAccountId() + ":" + message.threadIds().hashCode())
+            );
+
+            log.info(
+                    "Published initial mail sync thread batch for mailAccountId={} userId={} emailAddress={} threadCount={}",
+                    message.mailAccountId(),
+                    message.userId(),
+                    message.emailAddress(),
+                    message.threadIds().size()
+            );
+        } catch (AmqpException e) {
+            log.warn(
+                    "Failed to publish initial mail sync thread batch for mailAccountId={} userId={} emailAddress={} threadCount={}",
+                    message.mailAccountId(),
+                    message.userId(),
+                    message.emailAddress(),
+                    message.threadIds().size(),
+                    e
+            );
+        }
+    }
 
     public void publishWatchRenewal(WatchRenewalMessage message) {
         validateWatchRenewalProperties();
@@ -69,6 +105,21 @@ public class MailTaskPublisherService {
         }
     }
 
+    private void validateInitialMailSyncThreadBatchMessage(InitialMailSyncThreadBatchMessage message) {
+        if (message == null
+                || message.mailAccountId() == null
+                || message.userId() == null
+                || isBlank(message.provider())
+                || isBlank(message.emailAddress())
+                || !MailProvider.GMAIL.name().equals(message.provider())
+                || hasBlankThreadId(message.threadIds())
+                || isBlank(initialMailSyncRabbitProperties.getThreadBatchTaskName())
+                || isBlank(mailTaskRabbitProperties.getExchange())
+                || isBlank(initialMailSyncRabbitProperties.getThreadBatchRoutingKey())) {
+            throw new MailPushException(MailPushErrorCode.INVALID_INITIAL_MAIL_SYNC_COMMAND);
+        }
+    }
+
     private void validateWatchRenewalProperties() {
         if (isBlank(mailTaskRabbitProperties.getExchange())
                 || isBlank(watchRenewalRabbitProperties.getQueueName())
@@ -85,6 +136,30 @@ public class MailTaskPublisherService {
                     "mailsangja.rabbitmq.task or mailsangja.rabbitmq.watch-renewal properties are invalid."
             );
         }
+    }
+
+    private void validateInitialMailSyncThreadBatchProperties() {
+        if (isBlank(mailTaskRabbitProperties.getExchange())
+                || isBlank(initialMailSyncRabbitProperties.getThreadBatchQueueName())
+                || isBlank(initialMailSyncRabbitProperties.getThreadBatchRoutingKey())
+                || isBlank(mailTaskRabbitProperties.getDeadLetterExchange())
+                || isBlank(initialMailSyncRabbitProperties.getThreadBatchDeadLetterQueueName())
+                || isBlank(initialMailSyncRabbitProperties.getThreadBatchDeadLetterRoutingKey())
+                || mailTaskRabbitProperties.getRetryMaxAttempts() == null
+                || mailTaskRabbitProperties.getRetryMaxAttempts() < 0
+                || mailTaskRabbitProperties.getConcurrency() == null
+                || mailTaskRabbitProperties.getConcurrency() <= 0) {
+            throw new MqException(
+                    MqErrorCode.INVALID_RABBITMQ_QUEUE_TTL,
+                    "mailsangja.rabbitmq.task or mailsangja.rabbitmq.initial-mail-sync properties are invalid."
+            );
+        }
+    }
+
+    private boolean hasBlankThreadId(List<String> threadIds) {
+        return threadIds == null
+                || threadIds.isEmpty()
+                || threadIds.stream().anyMatch(this::isBlank);
     }
 
     private boolean isBlank(String value) {

--- a/worker/src/main/resources/application.yaml
+++ b/worker/src/main/resources/application.yaml
@@ -80,6 +80,7 @@ mailsangja:
       max-results: ${GOOGLE_GMAIL_INITIAL_SYNC_MAX_RESULTS:20}
       thread-batch-size: ${GOOGLE_GMAIL_INITIAL_SYNC_THREAD_BATCH_SIZE:5}
       messages-uri: ${GOOGLE_GMAIL_MESSAGES_URI:https://gmail.googleapis.com/gmail/v1/users/me/messages}
+      threads-uri: ${GOOGLE_GMAIL_THREADS_URI:https://gmail.googleapis.com/gmail/v1/users/me/threads}
       connect-timeout: ${GOOGLE_GMAIL_MESSAGES_CONNECT_TIMEOUT:3s}
       read-timeout: ${GOOGLE_GMAIL_MESSAGES_READ_TIMEOUT:5s}
     google-history:

--- a/worker/src/main/resources/application.yaml
+++ b/worker/src/main/resources/application.yaml
@@ -53,6 +53,7 @@ mailsangja:
       publisher-mandatory: ${MAIL_TASK_PUBLISHER_MANDATORY:true}
     initial-mail-sync:
       task-name: ${MAIL_SYNC_TASK_NAME:sync.gmail.initial}
+      thread-batch-task-name: ${MAIL_SYNC_THREAD_BATCH_TASK_NAME:sync.gmail.initial.thread-batch}
     watch-renewal:
       task-name: ${MAIL_WATCH_RENEWAL_TASK_NAME:watch.renewal.gmail}
   gmail:
@@ -77,6 +78,7 @@ mailsangja:
         allowed-service-account-email: ${GOOGLE_PUBSUB_PUSH_OIDC_ALLOWED_SERVICE_ACCOUNT_EMAIL:}
     initial-sync:
       max-results: ${GOOGLE_GMAIL_INITIAL_SYNC_MAX_RESULTS:20}
+      thread-batch-size: ${GOOGLE_GMAIL_INITIAL_SYNC_THREAD_BATCH_SIZE:5}
       messages-uri: ${GOOGLE_GMAIL_MESSAGES_URI:https://gmail.googleapis.com/gmail/v1/users/me/messages}
       connect-timeout: ${GOOGLE_GMAIL_MESSAGES_CONNECT_TIMEOUT:3s}
       read-timeout: ${GOOGLE_GMAIL_MESSAGES_READ_TIMEOUT:5s}

--- a/worker/src/test/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryServiceTest.java
@@ -1,0 +1,88 @@
+package com.mailsangja.worker.service.google;
+
+import com.mailsangja.db.entity.mail.Direction;
+import com.mailsangja.worker.config.properties.GoogleMailInitialSyncProperties;
+import com.mailsangja.worker.dto.gmail.GoogleMailThreadResponse;
+import com.mailsangja.worker.dto.mail.InitialMailSyncThreadResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GoogleMailMessageQueryServiceTest {
+
+    @Test
+    void getThreads_normalizesMailAddressesFromHeaders() {
+        GoogleMailInitialSyncProperties properties = new GoogleMailInitialSyncProperties();
+        properties.setThreadsUri("https://gmail.googleapis.com/gmail/v1/users/me/threads");
+
+        RestClient restClient = RestClient.builder()
+                .requestFactory(new StubClientHttpRequestFactory("""
+                        {
+                          "id": "thread-1",
+                          "historyId": "history-1",
+                          "messages": [
+                            {
+                              "id": "message-1",
+                              "threadId": "thread-1",
+                              "labelIds": ["INBOX"],
+                              "snippet": "snippet",
+                              "historyId": "history-1",
+                              "internalDate": "1712822400000",
+                              "payload": {
+                                "mimeType": "multipart/alternative",
+                                "headers": [
+                                  {"name": "Subject", "value": "subject"},
+                                  {"name": "From", "value": "Alice Kim <alice@example.com>"},
+                                  {"name": "To", "value": "Bob <bob@example.com>, carol@example.com"},
+                                  {"name": "Cc", "value": "\\"Dave, Jr.\\" <dave@example.com>"}
+                                ],
+                                "parts": [
+                                  {
+                                    "mimeType": "text/plain",
+                                    "body": {"data": "aGVsbG8"}
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                        """))
+                .build();
+
+        GoogleMailMessageQueryService service = new GoogleMailMessageQueryService(properties, restClient);
+
+        List<InitialMailSyncThreadResult> results = service.getThreads("token", List.of("thread-1"));
+
+        assertEquals(1, results.size());
+        assertEquals(1, results.getFirst().messages().size());
+        assertEquals("alice@example.com", results.getFirst().messages().getFirst().fromAddress());
+        assertEquals(List.of("bob@example.com", "carol@example.com"), results.getFirst().messages().getFirst().toAddresses());
+        assertEquals(List.of("dave@example.com"), results.getFirst().messages().getFirst().ccAddresses());
+        assertEquals(Direction.INBOUND, results.getFirst().messages().getFirst().direction());
+        assertEquals("hello", results.getFirst().messages().getFirst().bodyText());
+    }
+
+    private static final class StubClientHttpRequestFactory extends org.springframework.http.client.SimpleClientHttpRequestFactory {
+        private final String responseBody;
+
+        private StubClientHttpRequestFactory(String responseBody) {
+            this.responseBody = responseBody;
+        }
+
+        @Override
+        public org.springframework.http.client.ClientHttpRequest createRequest(java.net.URI uri, org.springframework.http.HttpMethod httpMethod) {
+            return new org.springframework.mock.http.client.MockClientHttpRequest(httpMethod, uri) {
+                @Override
+                protected org.springframework.http.client.ClientHttpResponse executeInternal() {
+                    return new org.springframework.mock.http.client.MockClientHttpResponse(
+                            responseBody.getBytes(java.nio.charset.StandardCharsets.UTF_8),
+                            org.springframework.http.HttpStatus.OK
+                    );
+                }
+            };
+        }
+    }
+}

--- a/worker/src/test/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryServiceTest.java
@@ -5,8 +5,17 @@ import com.mailsangja.worker.config.properties.GoogleMailInitialSyncProperties;
 import com.mailsangja.worker.dto.gmail.GoogleMailThreadResponse;
 import com.mailsangja.worker.dto.mail.InitialMailSyncThreadResult;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.mock.http.client.MockClientHttpResponse;
 import org.springframework.web.client.RestClient;
 
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -65,7 +74,7 @@ class GoogleMailMessageQueryServiceTest {
         assertEquals("hello", results.getFirst().messages().getFirst().bodyText());
     }
 
-    private static final class StubClientHttpRequestFactory extends org.springframework.http.client.SimpleClientHttpRequestFactory {
+    private static final class StubClientHttpRequestFactory extends SimpleClientHttpRequestFactory {
         private final String responseBody;
 
         private StubClientHttpRequestFactory(String responseBody) {
@@ -73,13 +82,13 @@ class GoogleMailMessageQueryServiceTest {
         }
 
         @Override
-        public org.springframework.http.client.ClientHttpRequest createRequest(java.net.URI uri, org.springframework.http.HttpMethod httpMethod) {
-            return new org.springframework.mock.http.client.MockClientHttpRequest(httpMethod, uri) {
+        public ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod) {
+            return new MockClientHttpRequest(httpMethod, uri) {
                 @Override
-                protected org.springframework.http.client.ClientHttpResponse executeInternal() {
-                    return new org.springframework.mock.http.client.MockClientHttpResponse(
-                            responseBody.getBytes(java.nio.charset.StandardCharsets.UTF_8),
-                            org.springframework.http.HttpStatus.OK
+                protected ClientHttpResponse executeInternal() {
+                    return new MockClientHttpResponse(
+                            responseBody.getBytes(StandardCharsets.UTF_8),
+                            HttpStatus.OK
                     );
                 }
             };

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
@@ -9,6 +9,8 @@ import com.mailsangja.db.port.ThreadRepositoryPort;
 import com.mailsangja.worker.dto.mail.InitialMailSyncMessageSaveCommand;
 import com.mailsangja.worker.dto.mail.InitialMailSyncThreadSaveCommand;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -161,12 +163,12 @@ class InitialMailSyncCommandServiceTest {
         }
 
         @Override
-        public org.springframework.data.domain.Slice<Thread> findInboxByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, org.springframework.data.domain.Pageable pageable) {
+        public Slice<Thread> findInboxByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public org.springframework.data.domain.Slice<Thread> findSentByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, org.springframework.data.domain.Pageable pageable) {
+        public Slice<Thread> findSentByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable) {
             throw new UnsupportedOperationException();
         }
 

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
@@ -1,0 +1,214 @@
+package com.mailsangja.worker.service.mail;
+
+import com.mailsangja.db.entity.mail.Direction;
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.entity.mail.Thread;
+import com.mailsangja.db.port.MessageRepositoryPort;
+import com.mailsangja.db.port.ThreadRepositoryPort;
+import com.mailsangja.worker.dto.mail.InitialMailSyncMessageSaveCommand;
+import com.mailsangja.worker.dto.mail.InitialMailSyncThreadSaveCommand;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class InitialMailSyncCommandServiceTest {
+
+    @Test
+    void saveThreadBatch_doesNotIncreaseMessageCountForUpdatedMessages() {
+        InMemoryThreadRepository threadRepository = new InMemoryThreadRepository();
+        InMemoryMessageRepository messageRepository = new InMemoryMessageRepository();
+        InitialMailSyncCommandService service = new InitialMailSyncCommandService(threadRepository, messageRepository);
+
+        MailAccount mailAccount = MailAccount.builder()
+                .id(UUID.randomUUID())
+                .build();
+
+        service.saveThreadBatch(mailAccount, List.of(new InitialMailSyncThreadSaveCommand(
+                "thread-1",
+                "history-1",
+                List.of(new InitialMailSyncMessageSaveCommand(
+                        "message-1",
+                        "history-1",
+                        Direction.INBOUND,
+                        "subject",
+                        "alice@example.com",
+                        List.of("bob@example.com"),
+                        List.of(),
+                        "snippet",
+                        false,
+                        LocalDateTime.of(2026, 4, 11, 10, 0),
+                        "body",
+                        null,
+                        List.of()
+                ))
+        )));
+
+        service.saveThreadBatch(mailAccount, List.of(new InitialMailSyncThreadSaveCommand(
+                "thread-1",
+                "history-2",
+                List.of(new InitialMailSyncMessageSaveCommand(
+                        "message-1",
+                        "history-2",
+                        Direction.INBOUND,
+                        "updated subject",
+                        "alice@example.com",
+                        List.of("bob@example.com"),
+                        List.of(),
+                        "updated snippet",
+                        true,
+                        LocalDateTime.of(2026, 4, 11, 11, 0),
+                        "updated body",
+                        null,
+                        List.of()
+                ))
+        )));
+
+        Thread savedThread = threadRepository.savedThreads.getFirst();
+        assertEquals(1, savedThread.getMessageCount());
+        assertEquals("updated subject", savedThread.getLatestSubject());
+        assertEquals("updated snippet", savedThread.getLatestSnippet());
+    }
+
+    @Test
+    void saveThreadBatch_doesNotReplaceLatestMessageWhenSentAtIsNull() {
+        InMemoryThreadRepository threadRepository = new InMemoryThreadRepository();
+        InMemoryMessageRepository messageRepository = new InMemoryMessageRepository();
+        InitialMailSyncCommandService service = new InitialMailSyncCommandService(threadRepository, messageRepository);
+
+        MailAccount mailAccount = MailAccount.builder()
+                .id(UUID.randomUUID())
+                .build();
+
+        service.saveThreadBatch(mailAccount, List.of(new InitialMailSyncThreadSaveCommand(
+                "thread-1",
+                "history-1",
+                List.of(new InitialMailSyncMessageSaveCommand(
+                        "message-1",
+                        "history-1",
+                        Direction.INBOUND,
+                        "subject-1",
+                        "alice@example.com",
+                        List.of(),
+                        List.of(),
+                        "snippet-1",
+                        false,
+                        LocalDateTime.of(2026, 4, 11, 10, 0),
+                        null,
+                        null,
+                        List.of()
+                ))
+        )));
+
+        service.saveThreadBatch(mailAccount, List.of(new InitialMailSyncThreadSaveCommand(
+                "thread-1",
+                "history-2",
+                List.of(new InitialMailSyncMessageSaveCommand(
+                        "message-2",
+                        "history-2",
+                        Direction.INBOUND,
+                        "subject-2",
+                        "carol@example.com",
+                        List.of(),
+                        List.of(),
+                        "snippet-2",
+                        true,
+                        null,
+                        null,
+                        null,
+                        List.of()
+                ))
+        )));
+
+        Thread savedThread = threadRepository.savedThreads.getFirst();
+        assertEquals("subject-1", savedThread.getLatestSubject());
+        assertEquals("snippet-1", savedThread.getLatestSnippet());
+        assertEquals(LocalDateTime.of(2026, 4, 11, 10, 0), savedThread.getLastMessageAt());
+        assertEquals(2, savedThread.getMessageCount());
+    }
+
+    private static final class InMemoryThreadRepository implements ThreadRepositoryPort {
+        private final List<Thread> savedThreads = new ArrayList<>();
+
+        @Override
+        public Thread save(Thread thread) {
+            if (!savedThreads.contains(thread)) {
+                savedThreads.add(thread);
+            }
+            return thread;
+        }
+
+        @Override
+        public Optional<Thread> findByIdAndDeletedAtIsNull(UUID id) {
+            return savedThreads.stream().filter(thread -> id.equals(thread.getId())).findFirst();
+        }
+
+        @Override
+        public Optional<Thread> findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId, Direction direction) {
+            return savedThreads.stream()
+                    .filter(thread -> thread.getMailAccount() != null
+                            && mailAccountId.equals(thread.getMailAccount().getId())
+                            && gmailThreadId.equals(thread.getGmailThreadId())
+                            && direction == thread.getDirection())
+                    .findFirst();
+        }
+
+        @Override
+        public org.springframework.data.domain.Slice<Thread> findInboxByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, org.springframework.data.domain.Pageable pageable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public org.springframework.data.domain.Slice<Thread> findSentByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, org.springframework.data.domain.Pageable pageable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long countUnreadInboxByUserId(UUID userId) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final class InMemoryMessageRepository implements MessageRepositoryPort {
+        private final List<Message> savedMessages = new ArrayList<>();
+
+        @Override
+        public Message save(Message message) {
+            if (!savedMessages.contains(message)) {
+                savedMessages.add(message);
+            }
+            return message;
+        }
+
+        @Override
+        public Optional<Message> findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(UUID threadId, String gmailMessageId) {
+            return savedMessages.stream()
+                    .filter(message -> message.getThread() != null
+                            && gmailMessageId.equals(message.getGmailMessageId())
+                            && (threadId == null || threadId.equals(message.getThread().getId())))
+                    .findFirst();
+        }
+
+        @Override
+        public List<Message> findAllByThreadIdAndDeletedAtIsNull(UUID threadId) {
+            return List.of();
+        }
+
+        @Override
+        public List<Message> findAllByThreadIdInAndDeletedAtIsNull(List<UUID> threadIds) {
+            return List.of();
+        }
+
+        @Override
+        public List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId) {
+            return List.of();
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 작업

  ### 👤 User Story
  - mailsangja/docs4capstone#4

  ### 📌 Task
  - Closes #23


  ## 💡 작업 내용

  - Gmail 초기 동기화 시 스레드 단위 배치를 MQ로 발행하고, worker가 이를 수신해 thread/message/attachment 메타데이터를 저장하는 경로를 구현했습니다.
  - 초기 동기화 저장 흐름을 결과(`*Result`)와 저장 명령(`*SaveCommand`) 구조로 분리하고, 재시도 및 스레드 집계 규칙을 정리해 저장 안정성을 보강했습니다.
  - 첨부파일 메타데이터 저장 중 실제 Gmail attachment id가 `VARCHAR(255)`를 초과하는 케이스를 반영해 `attachments.gmail_attachment_id` 컬럼 길이를 `1024`로 확장했습
  니다.
  - 주소 파싱 및 초기 동기화 저장 경로에 대한 회귀 테스트를 추가했습니다.


  ## 📝 추가 설명

  ### 1. 각 구현과 설계에 대해서 왜 그렇게 설계했고 설정했는지
  - 초기 동기화는 한 번에 많은 메시지와 스레드를 다루기 때문에, 동기 HTTP 요청 안에서 직접 전부 저장하지 않고 MQ 기반 비동기 배치 구조로 분리했습니다. 이 방식은 사용
  자 응답 지연을 줄이고, 동기화 작업 실패 시 재시도와 DLQ 처리를 붙이기 쉽다는 장점이 있습니다.
  - 배치 단위를 “메시지 리스트 전체”가 아니라 “스레드 배치”로 나눈 이유는 저장 책임을 더 작은 단위로 쪼개기 위해서입니다. 스레드 단위로 쪼개면 장애가 발생해도 실패
  범위를 제한할 수 있고, 재처리도 더 명확해집니다.
  - 저장 흐름에서 `GoogleMailMessageQueryService`가 외부 응답을 곧바로 엔티티로 만들지 않고, `InitialMailSyncMessageResult`, `InitialMailSyncThreadResult`,
  `InitialMailSyncMessageSaveCommand`, `InitialMailSyncThreadSaveCommand` 같은 내부 DTO 계층을 둔 이유는 외부 응답 구조와 내부 저장 구조를 분리하기 위해서입니다. 이
  렇게 해야 파싱 책임과 저장 책임이 섞이지 않고, 테스트와 후속 변경도 쉬워집니다.
  - `InitialMailSyncCommandService`에 스레드 집계 로직을 둔 이유는 thread/message/attachment 저장 후 최신 메시지 정보, 읽음 상태, 메시지 수, history id 같은 파생 데
  이터를 일관되게 계산하기 위해서입니다. 이 값을 메시지 저장 중간중간 흩어서 계산하면 규칙이 깨지기 쉽기 때문에, 집계 객체를 통해 한곳에서 정리하는 구조를 택했습니
  다.
  - 재시도 안정성을 위해 listener와 RabbitMQ 설정 쪽에서 retry 및 recoverer 경로를 보강한 이유는, Gmail 초기 동기화는 외부 응답 품질과 데이터 편차 영향을 크게 받기
  때문입니다. 단발성 저장 실패를 바로 유실시키지 않고, 정해진 횟수만큼 재시도 후 DLQ로 넘겨 운영자가 후속 조치할 수 있게 했습니다.
  - 마지막으로 `attachments.gmail_attachment_id`를 `255`에서 `1024`로 확장한 이유는, 실제 동기화 도중 attachment id가 255자를 초과하는 사례가 확인되었기 때문입니다.
  이 값은 외부 시스템이 결정하므로 애플리케이션 내부에서 길이를 임의로 줄이는 것보다, 스키마가 실제 데이터를 수용할 수 있게 확장하는 쪽이 더 맞다고 판단했습니다.

  ### 2. 각 로직의 흐름과 개발자나 관리자가 추가 판단해야 하는 부분
  - 전체 흐름은 다음과 같습니다.

  ```mermaid
  flowchart TD
      A[초기 동기화 시작] --> B[Facade가 Gmail 메시지 목록 조회]
      B --> C[메시지를 스레드 기준으로 그룹화]
      C --> D[스레드 배치 메시지 MQ 발행]
      D --> E[RabbitMQ Queue]
      E --> F[InitialMailSyncListener 수신]
      F --> G[InitialMailSyncFacade]
      G --> H[InitialMailSyncCommandService.saveThreadBatch]

      H --> I[Thread 조회 또는 생성]
      I --> J[Message 조회 또는 생성/갱신]
      J --> K[본문/첨부 메타데이터 구성]
      K --> L[Attachment 포함 Message 저장]
      L --> M[ThreadAggregate 집계 갱신]
      M --> N[최신 메시지 정보, messageCount, historyId 반영]

      N --> O{저장 성공 여부}
      O -- 성공 --> P[ACK]
      O -- 실패 --> Q[Retry]
      Q --> R{재시도 소진 여부}
      R -- 아니오 --> F
      R -- 예 --> S[DLQ 전송]
```

  - 개발자가 추가로 판단해야 할 부분은 다음과 같습니다.
  - 현재 배치 단위가 스레드 기준으로 적절한지, 실제 운영 트래픽과 Gmail 응답량 기준으로 배치 크기와 동시성 값을 조정할 필요가 있는지 확인이 필요합니다.
  - attachment id처럼 외부 응답 필드 길이가 예상보다 길 수 있으므로, 다른 외부 식별자 컬럼도 동일한 리스크가 없는지 점검할 필요가 있습니다.
  - 재시도 후 DLQ로 이동한 메시지를 어떤 기준으로 수동 재처리할지 운영 정책이 필요합니다.
  - 주소 파싱이나 본문 파싱에서 Gmail 포맷 변형이 더 있는지, 현재 테스트 커버리지로 충분한지 추가 판단이 필요합니다.

  ### 3. 개발자나 관리자가 꼭 알아야 하는 부분

  - 이번 PR은 초기 동기화 전체 파이프라인을 포함합니다. 단순 저장 로직 한두 개가 아니라, 발행 구조, worker 저장 경로, 내부 DTO 분리, 재시도 보강, 테스트, 스키마 확장
    까지 한 흐름으로 연결된 작업입니다.
  - 테스트는 회귀 방지용으로 추가됐지만, MQ 재시도와 DLQ 운영은 결국 실제 환경 설정의 영향을 받기 때문에 application 설정값 검토가 함께 필요합니다.

  ### 4. MQ 관련이나 로직에 대한 도식

  - MQ 관점의 흐름은 다음과 같습니다.
  
  ```mermaid
  sequenceDiagram
      participant CoreFacade as Initial Sync Facade
      participant Publisher as MailTaskPublisherService
      participant MQ as RabbitMQ
      participant Listener as InitialMailSyncListener
      participant WorkerFacade as InitialMailSyncFacade
      participant Command as InitialMailSyncCommandService
      participant DB as PostgreSQL

      CoreFacade->>Publisher: 스레드 배치 발행 요청
      Publisher->>MQ: InitialMailSyncThreadBatchMessage publish
      MQ->>Listener: 배치 메시지 전달
      Listener->>WorkerFacade: handleInitialMailSyncThreadBatch(...)
      WorkerFacade->>Command: saveThreadBatch(...)
      Command->>DB: Thread/Message/Attachment 저장
      DB-->>Command: 성공 또는 제약조건 예외
      Command-->>WorkerFacade: 처리 결과 반환
      WorkerFacade-->>Listener: 정상 종료 또는 예외 전달
      Listener->>MQ: 성공 시 ACK / 실패 시 Retry
      MQ->>MQ: 재시도 소진 시 DLQ 라우팅
```

  - 저장 로직 관점의 핵심 판단 포인트는 다음과 같습니다.
  - 스레드가 없으면 생성하고, 있으면 같은 mailAccountId + gmailThreadId + direction 기준으로 재사용합니다.
  - 메시지는 같은 threadId + gmailMessageId 기준으로 중복 저장을 피하고, 이미 있으면 본문/첨부/읽음 상태를 갱신합니다.
  - 첨부파일은 메시지 저장 시점에 함께 반영되며, 외부 메타데이터 길이 제한은 DB 스키마가 수용 가능해야 합니다.
  - 스레드 집계는 메시지 저장과 별개가 아니라 저장 결과를 기반으로 최신 제목, 스니펫, 참여자, 읽음 여부, 메시지 수를 다시 정리하는 역할을 합니다.

  ## ⚡️ Test 결과

  | thread 저장 | message 저장 | attachment 저장 |
  | -- | -- | -- |
  | <img width="1609" height="804" alt="image" src="https://github.com/user-attachments/assets/04c73d51-3518-4994-ae55-bbb0e9918099" /> | <img width="1783" height="821" alt="image" src="https://github.com/user-attachments/assets/414f304d-edea-4dfd-a9d1-de9f8533e5cc" /> | <img width="1699" height="334" alt="image" src="https://github.com/user-attachments/assets/6f320cee-ed2a-47e7-a529-ef68dbb43b00" /> |