### PR TITLE
[STORY-206] 신규 메일 감지를 위한 Webhook 구현

### DIFF
--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -25,7 +25,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         default_schema: public
-        format_sql: true
+        format_sql: false
 
   sql:
     init:

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
@@ -30,6 +30,11 @@ public class MessageRepositoryAdapter implements MessageRepositoryPort {
     }
 
     @Override
+    public Optional<Message> findByThreadIdAndGmailMessageId(UUID threadId, String gmailMessageId) {
+        return messageJpaRepositoryModule.findByThreadIdAndGmailMessageId(threadId, gmailMessageId);
+    }
+
+    @Override
     public Optional<Message> findByIdIncludingDeleted(UUID messageId) {
         return messageJpaRepositoryModule.findById(messageId);
     }

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/ThreadRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/ThreadRepositoryAdapter.java
@@ -85,6 +85,11 @@ public class ThreadRepositoryAdapter implements ThreadRepositoryPort {
     }
 
     @Override
+    public int bulkRestoreAndResetMessageCountByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
+        return threadJpaRepositoryModule.bulkRestoreAndResetMessageCountByMailAccountIdAndGmailThreadId(mailAccountId, gmailThreadId);
+    }
+
+    @Override
     public void hardDeleteAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
         List<Thread> threads = threadJpaRepositoryModule.findAllByMailAccountIdAndGmailThreadId(mailAccountId, gmailThreadId);
         threadJpaRepositoryModule.deleteAll(threads);

--- a/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
@@ -18,6 +18,8 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
 
     Optional<Message> findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(UUID threadId, String gmailMessageId);
 
+    Optional<Message> findByThreadIdAndGmailMessageId(UUID threadId, String gmailMessageId);
+
     @Query("""
             SELECT m
             FROM Message m

--- a/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
@@ -73,6 +73,13 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             @Param("gmailThreadId") String gmailThreadId
     );
 
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Thread t SET t.deletedAt = NULL, t.messageCount = 0 WHERE t.mailAccount.id = :mailAccountId AND t.gmailThreadId = :gmailThreadId AND t.deletedAt IS NOT NULL")
+    int bulkRestoreAndResetMessageCountByMailAccountIdAndGmailThreadId(
+            @Param("mailAccountId") UUID mailAccountId,
+            @Param("gmailThreadId") String gmailThreadId
+    );
+
     @EntityGraph(attributePaths = {"mailAccount"})
     @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN (SELECT ma.id FROM MailAccount ma WHERE ma.user.id = :userId AND ma.deletedAt IS NULL) AND t.deletedAt IS NOT NULL AND (:markerId IS NULL OR t.deletedAt < (SELECT m.deletedAt FROM Thread m WHERE m.id = :markerId)) ORDER BY t.deletedAt DESC")
     Slice<Thread> findTrashByUserId(

--- a/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 public interface MessageRepositoryPort {
     Message save(Message message);
     Optional<Message> findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(UUID threadId, String gmailMessageId);
+    Optional<Message> findByThreadIdAndGmailMessageId(UUID threadId, String gmailMessageId);
     Optional<Message> findByMailAccountIdAndGmailThreadIdAndGmailMessageIdAndDeletedAtIsNull(
             UUID mailAccountId,
             String gmailThreadId,

--- a/db/src/main/java/com/mailsangja/db/port/ThreadRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/ThreadRepositoryPort.java
@@ -24,5 +24,6 @@ public interface ThreadRepositoryPort {
     List<Thread> findAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId);
     int bulkSoftDeleteByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId, LocalDateTime deletedAt);
     int bulkRestoreByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId);
+    int bulkRestoreAndResetMessageCountByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId);
     void hardDeleteAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId);
 }

--- a/worker/src/main/java/com/mailsangja/worker/dto/gmail/history/GmailHistoryEventType.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/gmail/history/GmailHistoryEventType.java
@@ -1,6 +1,7 @@
 package com.mailsangja.worker.dto.gmail.history;
 
 public enum GmailHistoryEventType {
+    MESSAGE_ADDED,
     MESSAGE_READ,
     MESSAGE_UNREAD,
     MESSAGE_TRASHED,

--- a/worker/src/main/java/com/mailsangja/worker/dto/gmail/history/GoogleMailHistoryItemResponse.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/gmail/history/GoogleMailHistoryItemResponse.java
@@ -6,6 +6,7 @@ public record GoogleMailHistoryItemResponse(
         String id,
         List<GoogleMailHistoryLabelChangeResponse> labelsAdded,
         List<GoogleMailHistoryLabelChangeResponse> labelsRemoved,
-        List<GoogleMailHistoryLabelChangeResponse> messagesDeleted
+        List<GoogleMailHistoryLabelChangeResponse> messagesDeleted,
+        List<GoogleMailHistoryMessageAddedResponse> messagesAdded
 ) {
 }

--- a/worker/src/main/java/com/mailsangja/worker/dto/gmail/history/GoogleMailHistoryItemResult.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/gmail/history/GoogleMailHistoryItemResult.java
@@ -6,6 +6,7 @@ public record GoogleMailHistoryItemResult(
         String historyId,
         List<GoogleMailHistoryLabelChangeResult> labelsAdded,
         List<GoogleMailHistoryLabelChangeResult> labelsRemoved,
-        List<GoogleMailHistoryLabelChangeResult> messagesDeleted
+        List<GoogleMailHistoryLabelChangeResult> messagesDeleted,
+        List<GoogleMailHistoryMessageAddedResult> messagesAdded
 ) {
 }

--- a/worker/src/main/java/com/mailsangja/worker/dto/gmail/history/GoogleMailHistoryMessageAddedResponse.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/gmail/history/GoogleMailHistoryMessageAddedResponse.java
@@ -1,0 +1,6 @@
+package com.mailsangja.worker.dto.gmail.history;
+
+public record GoogleMailHistoryMessageAddedResponse(
+        GoogleMailHistoryMessageRefResponse message
+) {
+}

--- a/worker/src/main/java/com/mailsangja/worker/dto/gmail/history/GoogleMailHistoryMessageAddedResult.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/gmail/history/GoogleMailHistoryMessageAddedResult.java
@@ -1,0 +1,7 @@
+package com.mailsangja.worker.dto.gmail.history;
+
+public record GoogleMailHistoryMessageAddedResult(
+        String gmailMessageId,
+        String gmailThreadId
+) {
+}

--- a/worker/src/main/java/com/mailsangja/worker/handler/mail/GmailHistoryEventClassifier.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/mail/GmailHistoryEventClassifier.java
@@ -6,6 +6,7 @@ import com.mailsangja.worker.dto.gmail.history.GmailHistoryEventType;
 import com.mailsangja.worker.dto.gmail.history.GoogleMailHistoryItemResult;
 import com.mailsangja.worker.dto.gmail.history.GoogleMailHistoryLabelChangeResult;
 import com.mailsangja.worker.dto.gmail.history.GoogleMailHistoryListResult;
+import com.mailsangja.worker.dto.gmail.history.GoogleMailHistoryMessageAddedResult;
 import org.springframework.stereotype.Component;
 
 import java.util.LinkedHashMap;
@@ -29,13 +30,15 @@ public class GmailHistoryEventClassifier {
             String historyId = historyItem == null ? null : historyItem.historyId();
             List<GoogleMailHistoryLabelChangeResult> labelsAdded = historyItem == null ? List.of() : historyItem.labelsAdded();
             List<GoogleMailHistoryLabelChangeResult> labelsRemoved = historyItem == null ? List.of() : historyItem.labelsRemoved();
+            List<GoogleMailHistoryLabelChangeResult> messagesDeleted = historyItem == null ? List.of() : historyItem.messagesDeleted();
+            List<GoogleMailHistoryMessageAddedResult> messagesAdded = historyItem == null ? List.of() : historyItem.messagesAdded();
 
+            // 신규 메시지를 먼저 반영해 이후 READ/UNREAD 처리 시 불필요한 외부 재조회 가능성을 낮춘다.
+            classifyMessagesAdded(deduplicatedEvents, mailAccount, historyId, messagesAdded);
             classifyLabelChanges(deduplicatedEvents, mailAccount, historyId, labelsRemoved, GmailHistoryEventType.MESSAGE_READ, UNREAD_LABEL_ID);
             classifyLabelChanges(deduplicatedEvents, mailAccount, historyId, labelsAdded, GmailHistoryEventType.MESSAGE_UNREAD, UNREAD_LABEL_ID);
             classifyLabelChanges(deduplicatedEvents, mailAccount, historyId, labelsAdded, GmailHistoryEventType.MESSAGE_TRASHED, TRASH_LABEL_ID);
             classifyLabelChanges(deduplicatedEvents, mailAccount, historyId, labelsRemoved, GmailHistoryEventType.MESSAGE_RESTORED, TRASH_LABEL_ID);
-
-            List<GoogleMailHistoryLabelChangeResult> messagesDeleted = historyItem == null ? List.of() : historyItem.messagesDeleted();
             classifyPermanentlyDeletedMessages(deduplicatedEvents, mailAccount, historyId, messagesDeleted);
         }
 
@@ -96,6 +99,38 @@ public class GmailHistoryEventClassifier {
             );
             deduplicatedEvents.put(buildDeduplicationKey(event), event);
         }
+    }
+
+    private void classifyMessagesAdded(
+            Map<String, GmailHistoryEvent> deduplicatedEvents,
+            MailAccount mailAccount,
+            String historyId,
+            List<GoogleMailHistoryMessageAddedResult> messagesAdded
+    ) {
+        if (messagesAdded == null || messagesAdded.isEmpty()) {
+            return;
+        }
+
+        for (GoogleMailHistoryMessageAddedResult addedMessage : messagesAdded) {
+            if (!supportsMessageAdded(addedMessage)) {
+                continue;
+            }
+
+            GmailHistoryEvent event = new GmailHistoryEvent(
+                    GmailHistoryEventType.MESSAGE_ADDED,
+                    mailAccount.getId(),
+                    addedMessage.gmailMessageId(),
+                    addedMessage.gmailThreadId(),
+                    historyId
+            );
+            deduplicatedEvents.put(buildDeduplicationKey(event), event);
+        }
+    }
+
+    private boolean supportsMessageAdded(GoogleMailHistoryMessageAddedResult addedMessage) {
+        return addedMessage != null
+                && !isBlank(addedMessage.gmailMessageId())
+                && !isBlank(addedMessage.gmailThreadId());
     }
 
     private boolean supportsEvent(GoogleMailHistoryLabelChangeResult labelChange, String targetLabelId) {

--- a/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
@@ -1,0 +1,24 @@
+정package com.mailsangja.worker.handler.mail;
+
+import com.mailsangja.worker.dto.gmail.history.GmailHistoryEvent;
+import com.mailsangja.worker.dto.gmail.history.GmailHistoryEventType;
+import com.mailsangja.worker.service.mail.GmailNewMessageSyncCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MessageAddedHistoryEventHandler implements GmailHistoryEventHandler {
+
+    private final GmailNewMessageSyncCommandService gmailNewMessageSyncCommandService;
+
+    @Override
+    public GmailHistoryEventType supports() {
+        return GmailHistoryEventType.MESSAGE_ADDED;
+    }
+
+    @Override
+    public void handle(GmailHistoryEvent event) {
+        gmailNewMessageSyncCommandService.syncNewMessage(event);
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
@@ -1,4 +1,4 @@
-정package com.mailsangja.worker.handler.mail;
+package com.mailsangja.worker.handler.mail;
 
 import com.mailsangja.worker.dto.gmail.history.GmailHistoryEvent;
 import com.mailsangja.worker.dto.gmail.history.GmailHistoryEventType;

--- a/worker/src/main/java/com/mailsangja/worker/service/google/GoogleMailHistoryQueryService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/google/GoogleMailHistoryQueryService.java
@@ -8,6 +8,8 @@ import com.mailsangja.worker.dto.gmail.history.GoogleMailHistoryItemResult;
 import com.mailsangja.worker.dto.gmail.history.GoogleMailHistoryLabelChangeResponse;
 import com.mailsangja.worker.dto.gmail.history.GoogleMailHistoryLabelChangeResult;
 import com.mailsangja.worker.dto.gmail.history.GoogleMailHistoryListResult;
+import com.mailsangja.worker.dto.gmail.history.GoogleMailHistoryMessageAddedResponse;
+import com.mailsangja.worker.dto.gmail.history.GoogleMailHistoryMessageAddedResult;
 import com.mailsangja.worker.dto.gmail.history.GoogleMailHistoryResponse;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
@@ -89,14 +91,38 @@ public class GoogleMailHistoryQueryService {
 
     private GoogleMailHistoryItemResult mapHistoryItem(GoogleMailHistoryItemResponse historyItem) {
         if (historyItem == null) {
-            return new GoogleMailHistoryItemResult(null, List.of(), List.of(), List.of());
+            return new GoogleMailHistoryItemResult(null, List.of(), List.of(), List.of(), List.of());
         }
 
         return new GoogleMailHistoryItemResult(
                 historyItem.id(),
                 mapLabelChanges(historyItem.labelsAdded()),
                 mapLabelChanges(historyItem.labelsRemoved()),
-                mapLabelChanges(historyItem.messagesDeleted())
+                mapLabelChanges(historyItem.messagesDeleted()),
+                mapMessagesAdded(historyItem.messagesAdded())
+        );
+    }
+
+    private List<GoogleMailHistoryMessageAddedResult> mapMessagesAdded(
+            List<GoogleMailHistoryMessageAddedResponse> messagesAdded
+    ) {
+        if (messagesAdded == null || messagesAdded.isEmpty()) {
+            return List.of();
+        }
+
+        return messagesAdded.stream()
+                .map(this::mapMessageAdded)
+                .toList();
+    }
+
+    private GoogleMailHistoryMessageAddedResult mapMessageAdded(GoogleMailHistoryMessageAddedResponse addedMessage) {
+        if (addedMessage == null || addedMessage.message() == null) {
+            return new GoogleMailHistoryMessageAddedResult(null, null);
+        }
+
+        return new GoogleMailHistoryMessageAddedResult(
+                addedMessage.message().id(),
+                addedMessage.message().threadId()
         );
     }
 

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandService.java
@@ -3,7 +3,6 @@ package com.mailsangja.worker.service.mail;
 import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.Thread;
 import com.mailsangja.db.port.GmailThreadLockRepositoryPort;
-import com.mailsangja.db.port.MessageRepositoryPort;
 import com.mailsangja.db.port.ThreadRepositoryPort;
 import com.mailsangja.worker.dto.gmail.history.GmailHistoryEvent;
 import com.mailsangja.worker.dto.mail.sync.InitialMailSyncThreadSaveCommand;
@@ -19,7 +18,6 @@ public class GmailNewMessageApplyCommandService {
 
     private final GmailThreadLockRepositoryPort gmailThreadLockRepositoryPort;
     private final ThreadRepositoryPort threadRepositoryPort;
-    private final MessageRepositoryPort messageRepositoryPort;
     private final InitialMailSyncCommandService initialMailSyncCommandService;
 
     @Transactional
@@ -46,10 +44,9 @@ public class GmailNewMessageApplyCommandService {
             return;
         }
 
-        threadRepositoryPort.bulkRestoreByMailAccountIdAndGmailThreadId(
-                mailAccount.getId(), gmailThreadId
-        );
-        messageRepositoryPort.bulkRestoreByMailAccountIdAndGmailThreadId(
+        // Thread만 복구하고 messageCount를 0으로 초기화한다.
+        // 기존 soft-deleted 메시지는 복구하지 않으며, 이후 saveThreadBatch에서 신규 메시지만 삽입된다.
+        threadRepositoryPort.bulkRestoreAndResetMessageCountByMailAccountIdAndGmailThreadId(
                 mailAccount.getId(), gmailThreadId
         );
     }

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandService.java
@@ -28,7 +28,6 @@ public class GmailNewMessageApplyCommandService {
     ) {
         gmailThreadLockRepositoryPort.acquireThreadLock(mailAccount, event.gmailThreadId());
 
-        // 삭제된 Thread/Message가 존재하면 복구한다 (신규 메시지 수신 시 삭제 상태 해제)
         restoreIfDeleted(mailAccount, event.gmailThreadId());
 
         initialMailSyncCommandService.saveThreadBatch(mailAccount, List.of(syncCommand));

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandService.java
@@ -1,0 +1,56 @@
+package com.mailsangja.worker.service.mail;
+
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.Thread;
+import com.mailsangja.db.port.GmailThreadLockRepositoryPort;
+import com.mailsangja.db.port.MessageRepositoryPort;
+import com.mailsangja.db.port.ThreadRepositoryPort;
+import com.mailsangja.worker.dto.gmail.history.GmailHistoryEvent;
+import com.mailsangja.worker.dto.mail.sync.InitialMailSyncThreadSaveCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GmailNewMessageApplyCommandService {
+
+    private final GmailThreadLockRepositoryPort gmailThreadLockRepositoryPort;
+    private final ThreadRepositoryPort threadRepositoryPort;
+    private final MessageRepositoryPort messageRepositoryPort;
+    private final InitialMailSyncCommandService initialMailSyncCommandService;
+
+    @Transactional
+    public void applyNewMessageSync(
+            MailAccount mailAccount,
+            GmailHistoryEvent event,
+            InitialMailSyncThreadSaveCommand syncCommand
+    ) {
+        gmailThreadLockRepositoryPort.acquireThreadLock(mailAccount, event.gmailThreadId());
+
+        // 삭제된 Thread/Message가 존재하면 복구한다 (신규 메시지 수신 시 삭제 상태 해제)
+        restoreIfDeleted(mailAccount, event.gmailThreadId());
+
+        initialMailSyncCommandService.saveThreadBatch(mailAccount, List.of(syncCommand));
+    }
+
+    private void restoreIfDeleted(MailAccount mailAccount, String gmailThreadId) {
+        // 삭제 여부를 먼저 확인하여 불필요한 bulk UPDATE 및 JPA 캐시 초기화를 방지한다.
+        List<Thread> allThreads = threadRepositoryPort.findAllByMailAccountIdAndGmailThreadId(
+                mailAccount.getId(), gmailThreadId
+        );
+        boolean anyDeleted = allThreads.stream().anyMatch(Thread::isDeleted);
+        if (!anyDeleted) {
+            return;
+        }
+
+        threadRepositoryPort.bulkRestoreByMailAccountIdAndGmailThreadId(
+                mailAccount.getId(), gmailThreadId
+        );
+        messageRepositoryPort.bulkRestoreByMailAccountIdAndGmailThreadId(
+                mailAccount.getId(), gmailThreadId
+        );
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageSyncCommandService.java
@@ -1,0 +1,53 @@
+package com.mailsangja.worker.service.mail;
+
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
+import com.mailsangja.worker.common.exception.mail.MailPushException;
+import com.mailsangja.worker.dto.gmail.history.GmailHistoryEvent;
+import com.mailsangja.worker.dto.mail.sync.InitialMailSyncThreadResult;
+import com.mailsangja.worker.dto.mail.sync.InitialMailSyncThreadSaveCommand;
+import com.mailsangja.worker.service.google.GoogleMailMessageQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GmailNewMessageSyncCommandService {
+
+    private final MailAccountQueryService mailAccountQueryService;
+    private final GoogleMailMessageQueryService googleMailMessageQueryService;
+    private final GmailNewMessageApplyCommandService gmailNewMessageApplyCommandService;
+
+    public void syncNewMessage(GmailHistoryEvent event) {
+        validateEvent(event);
+
+        MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(event.mailAccountId());
+
+        List<InitialMailSyncThreadResult> threadResults = googleMailMessageQueryService.getThreads(
+                mailAccount.getAccessToken(),
+                List.of(event.gmailThreadId())
+        );
+
+        if (threadResults.isEmpty()) {
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
+        }
+
+        InitialMailSyncThreadSaveCommand syncCommand = InitialMailSyncThreadSaveCommand.from(threadResults.getFirst());
+        gmailNewMessageApplyCommandService.applyNewMessageSync(mailAccount, event, syncCommand);
+    }
+
+    private void validateEvent(GmailHistoryEvent event) {
+        if (event == null
+                || event.mailAccountId() == null
+                || isBlank(event.gmailThreadId())
+                || isBlank(event.gmailMessageId())) {
+            throw new MailPushException(MailPushErrorCode.INVALID_GMAIL_PUSH_NOTIFICATION);
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
@@ -142,23 +142,23 @@ public class InitialMailSyncCommandService {
     ) {
         validateThreadMessage(threadCommand, messageCommand);
 
-        Optional<Message> existingMessage = messageRepositoryPort.findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(
+        Optional<Message> anyMessage = messageRepositoryPort.findByThreadIdAndGmailMessageId(
                 thread.getId(),
                 messageCommand.gmailMessageId()
         );
-        boolean inserted = existingMessage.isEmpty();
 
-        if (!inserted) {
-            Message message = existingMessage.get();
-            message.updateFrom(messageCommand.toCreateValues());
-            message.replaceAttachments(createAttachments(message, messageCommand.attachments()));
-        } else {
+        if (anyMessage.isEmpty()) {
             Message message = Message.from(thread, messageCommand.toCreateValues());
             message.replaceAttachments(createAttachments(message, messageCommand.attachments()));
             messageRepositoryPort.save(message);
+            aggregate.merge(threadCommand, messageCommand, true);
+        } else if (!anyMessage.get().isDeleted()) {
+            Message message = anyMessage.get();
+            message.updateFrom(messageCommand.toCreateValues());
+            message.replaceAttachments(createAttachments(message, messageCommand.attachments()));
+            aggregate.merge(threadCommand, messageCommand, false);
         }
-
-        aggregate.merge(threadCommand, messageCommand, inserted);
+        // 소프트 삭제된 메시지는 건너뛴다 (의도적으로 삭제된 메시지는 재삽입하지 않는다)
     }
 
     private Thread findOrCreateThread(MailAccount mailAccount, String gmailThreadId, Direction direction) {

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
@@ -115,11 +115,12 @@ public class InitialMailSyncCommandService {
                 throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
             }
 
-            Optional<Message> existingMessage = messageRepositoryPort.findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(
+            Optional<Message> anyMessage = messageRepositoryPort.findByThreadIdAndGmailMessageId(
                     thread.getId(),
                     messageCommand.gmailMessageId()
             );
-            if (existingMessage.isPresent()) {
+            if (anyMessage.isPresent()) {
+                // 활성 메시지는 이미 존재, 소프트 삭제된 메시지는 재삽입하지 않고 skip
                 continue;
             }
 

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/MailAccountQueryService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/MailAccountQueryService.java
@@ -30,7 +30,7 @@ public class MailAccountQueryService {
     }
 
     public MailAccount findActiveMailAccountById(UUID id) {
-        MailAccount mailAccount = mailAccountRepositoryPort.findByIdAndActiveAndDeletedAtIsNull(id, true)
+        MailAccount mailAccount = mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new MailPushException(MailPushErrorCode.MAIL_ACCOUNT_NOT_FOUND));
 
         validateActiveMailAccount(mailAccount);

--- a/worker/src/main/resources/application.yaml
+++ b/worker/src/main/resources/application.yaml
@@ -24,7 +24,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         default_schema: public
-        format_sql: true
+        format_sql: false
 
   sql:
     init:

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandServiceTest.java
@@ -16,6 +16,7 @@ import com.mailsangja.worker.dto.mail.sync.InitialMailSyncThreadSaveCommand;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -377,7 +378,7 @@ class GmailNewMessageApplyCommandServiceTest {
 
         @Override
         public Slice<Message> findDeletedByUserId(UUID userId, UUID markerId, Pageable pageable) {
-            return null;
+            return new SliceImpl<>(List.of());
         }
 
         @Override

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandServiceTest.java
@@ -1,0 +1,407 @@
+package com.mailsangja.worker.service.mail;
+
+import com.mailsangja.db.entity.mail.Direction;
+import com.mailsangja.db.entity.mail.GmailThreadLock;
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.entity.mail.Thread;
+import com.mailsangja.db.port.GmailThreadLockRepositoryPort;
+import com.mailsangja.db.port.MessageRepositoryPort;
+import com.mailsangja.db.port.ThreadRepositoryPort;
+import com.mailsangja.worker.dto.gmail.history.GmailHistoryEvent;
+import com.mailsangja.worker.dto.gmail.history.GmailHistoryEventType;
+import com.mailsangja.worker.dto.mail.sync.InitialMailSyncAttachmentResult;
+import com.mailsangja.worker.dto.mail.sync.InitialMailSyncMessageSaveCommand;
+import com.mailsangja.worker.dto.mail.sync.InitialMailSyncThreadSaveCommand;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GmailNewMessageApplyCommandServiceTest {
+
+    @Test
+    void applyNewMessageSync_whenThreadIsDeleted_restoresOnlyThreadAndInsertsNewMessage() {
+        InMemoryThreadRepository threadRepository = new InMemoryThreadRepository();
+        InMemoryMessageRepository messageRepository = new InMemoryMessageRepository();
+        InitialMailSyncCommandService initialMailSyncCommandService =
+                new InitialMailSyncCommandService(threadRepository, messageRepository);
+        GmailNewMessageApplyCommandService service = new GmailNewMessageApplyCommandService(
+                new NoOpLockRepository(), threadRepository, initialMailSyncCommandService);
+
+        MailAccount mailAccount = MailAccount.builder()
+                .id(UUID.randomUUID())
+                .build();
+
+        Thread deletedThread = Thread.builder()
+                .mailAccount(mailAccount)
+                .gmailThreadId("thread-1")
+                .direction(Direction.INBOUND)
+                .read(false)
+                .messageCount(1)
+                .build();
+        deletedThread.delete();
+        threadRepository.savedThreads.add(deletedThread);
+
+        Message oldMessage = Message.from(deletedThread, new Message.CreateValues(
+                "message-old", Direction.INBOUND, "old subject", "sender@example.com",
+                List.of("me@example.com"), List.of(), "old snippet", false,
+                LocalDateTime.of(2026, 4, 10, 9, 0), null, null));
+        oldMessage.delete();
+        messageRepository.savedMessages.add(oldMessage);
+
+        GmailHistoryEvent event = new GmailHistoryEvent(
+                GmailHistoryEventType.MESSAGE_ADDED,
+                mailAccount.getId(),
+                "message-new",
+                "thread-1",
+                "history-2"
+        );
+
+        InitialMailSyncThreadSaveCommand syncCommand = new InitialMailSyncThreadSaveCommand(
+                "thread-1",
+                "history-2",
+                List.of(
+                        new InitialMailSyncMessageSaveCommand(
+                                "message-old", "history-1", Direction.INBOUND,
+                                "old subject", "sender@example.com", List.of("me@example.com"),
+                                List.of(), "old snippet", false,
+                                LocalDateTime.of(2026, 4, 10, 9, 0), null, null, List.of()),
+                        new InitialMailSyncMessageSaveCommand(
+                                "message-new", "history-2", Direction.INBOUND,
+                                "new subject", "sender@example.com", List.of("me@example.com"),
+                                List.of(), "new snippet", false,
+                                LocalDateTime.of(2026, 4, 14, 10, 0), null, null, List.of())
+                )
+        );
+
+        service.applyNewMessageSync(mailAccount, event, syncCommand);
+
+        // Thread는 복구되어야 한다
+        assertFalse(deletedThread.isDeleted(), "Thread should be restored");
+
+        // 기존 message는 여전히 삭제 상태여야 한다
+        assertTrue(oldMessage.isDeleted(), "Old message should remain soft-deleted");
+
+        // 신규 메시지만 삽입되어야 한다
+        long activeMessages = messageRepository.savedMessages.stream()
+                .filter(m -> !m.isDeleted())
+                .count();
+        assertEquals(1, activeMessages, "Only the new message should be active");
+
+        Message insertedMessage = messageRepository.savedMessages.stream()
+                .filter(m -> !m.isDeleted())
+                .findFirst()
+                .orElseThrow();
+        assertEquals("message-new", insertedMessage.getGmailMessageId());
+
+        // Thread의 messageCount는 신규 메시지 1건만 반영해야 한다
+        assertEquals(1, deletedThread.getMessageCount());
+
+        // Thread의 최신 정보는 신규 메시지로 업데이트되어야 한다
+        assertEquals("new subject", deletedThread.getLatestSubject());
+        assertEquals("new snippet", deletedThread.getLatestSnippet());
+        assertEquals(LocalDateTime.of(2026, 4, 14, 10, 0), deletedThread.getLastMessageAt());
+    }
+
+    @Test
+    void applyNewMessageSync_whenThreadIsNotDeleted_insertsNewMessageAndUpdatesThreadInfo() {
+        InMemoryThreadRepository threadRepository = new InMemoryThreadRepository();
+        InMemoryMessageRepository messageRepository = new InMemoryMessageRepository();
+        InitialMailSyncCommandService initialMailSyncCommandService =
+                new InitialMailSyncCommandService(threadRepository, messageRepository);
+        GmailNewMessageApplyCommandService service = new GmailNewMessageApplyCommandService(
+                new NoOpLockRepository(), threadRepository, initialMailSyncCommandService);
+
+        MailAccount mailAccount = MailAccount.builder()
+                .id(UUID.randomUUID())
+                .build();
+
+        Thread activeThread = Thread.builder()
+                .mailAccount(mailAccount)
+                .gmailThreadId("thread-2")
+                .direction(Direction.INBOUND)
+                .read(false)
+                .messageCount(1)
+                .build();
+        threadRepository.savedThreads.add(activeThread);
+
+        Message existingMessage = Message.from(activeThread, new Message.CreateValues(
+                "message-old", Direction.INBOUND, "old subject", "sender@example.com",
+                List.of("me@example.com"), List.of(), "old snippet", false,
+                LocalDateTime.of(2026, 4, 10, 9, 0), null, null));
+        messageRepository.savedMessages.add(existingMessage);
+
+        GmailHistoryEvent event = new GmailHistoryEvent(
+                GmailHistoryEventType.MESSAGE_ADDED,
+                mailAccount.getId(),
+                "message-new",
+                "thread-2",
+                "history-2"
+        );
+
+        InitialMailSyncThreadSaveCommand syncCommand = new InitialMailSyncThreadSaveCommand(
+                "thread-2",
+                "history-2",
+                List.of(
+                        new InitialMailSyncMessageSaveCommand(
+                                "message-old", "history-1", Direction.INBOUND,
+                                "old subject", "sender@example.com", List.of("me@example.com"),
+                                List.of(), "old snippet", false,
+                                LocalDateTime.of(2026, 4, 10, 9, 0), null, null, List.of()),
+                        new InitialMailSyncMessageSaveCommand(
+                                "message-new", "history-2", Direction.INBOUND,
+                                "new subject", "sender@example.com", List.of("me@example.com"),
+                                List.of(), "new snippet", false,
+                                LocalDateTime.of(2026, 4, 14, 10, 0), null, null, List.of())
+                )
+        );
+
+        service.applyNewMessageSync(mailAccount, event, syncCommand);
+
+        assertFalse(activeThread.isDeleted());
+        assertEquals(2, activeThread.getMessageCount());
+        assertEquals("new subject", activeThread.getLatestSubject());
+        assertEquals(LocalDateTime.of(2026, 4, 14, 10, 0), activeThread.getLastMessageAt());
+    }
+
+    private static final class NoOpLockRepository implements GmailThreadLockRepositoryPort {
+        @Override
+        public GmailThreadLock save(GmailThreadLock lock) {
+            return lock;
+        }
+
+        @Override
+        public void acquireThreadLock(MailAccount mailAccount, String gmailThreadId) {
+        }
+
+        @Override
+        public Optional<GmailThreadLock> findByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<GmailThreadLock> findByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullForUpdate(UUID mailAccountId, String gmailThreadId) {
+            return Optional.empty();
+        }
+    }
+
+    private static final class InMemoryThreadRepository implements ThreadRepositoryPort {
+        private final List<Thread> savedThreads = new ArrayList<>();
+
+        @Override
+        public Thread save(Thread thread) {
+            if (!savedThreads.contains(thread)) {
+                savedThreads.add(thread);
+            }
+            return thread;
+        }
+
+        @Override
+        public Optional<Thread> findByIdAndDeletedAtIsNull(UUID id) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Thread> findByIdIncludingDeleted(UUID id) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Thread> findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                UUID mailAccountId, String gmailThreadId, Direction direction) {
+            return savedThreads.stream()
+                    .filter(t -> t.getMailAccount() != null
+                            && mailAccountId.equals(t.getMailAccount().getId())
+                            && gmailThreadId.equals(t.getGmailThreadId())
+                            && direction == t.getDirection()
+                            && !t.isDeleted())
+                    .findFirst();
+        }
+
+        @Override
+        public List<Thread> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId) {
+            return savedThreads.stream()
+                    .filter(t -> t.getMailAccount() != null
+                            && mailAccountId.equals(t.getMailAccount().getId())
+                            && gmailThreadId.equals(t.getGmailThreadId())
+                            && !t.isDeleted())
+                    .toList();
+        }
+
+        @Override
+        public List<Thread> findAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
+            return savedThreads.stream()
+                    .filter(t -> t.getMailAccount() != null
+                            && mailAccountId.equals(t.getMailAccount().getId())
+                            && gmailThreadId.equals(t.getGmailThreadId()))
+                    .toList();
+        }
+
+        @Override
+        public int bulkSoftDeleteByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId, LocalDateTime deletedAt) {
+            return 0;
+        }
+
+        @Override
+        public int bulkRestoreByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
+            return 0;
+        }
+
+        @Override
+        public int bulkRestoreAndResetMessageCountByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
+            List<Thread> targets = savedThreads.stream()
+                    .filter(t -> t.getMailAccount() != null
+                            && mailAccountId.equals(t.getMailAccount().getId())
+                            && gmailThreadId.equals(t.getGmailThreadId())
+                            && t.isDeleted())
+                    .toList();
+            targets.forEach(t -> {
+                t.restore();
+                t.updateMessageCount(0);
+            });
+            return targets.size();
+        }
+
+        @Override
+        public Slice<Thread> findInboxByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Slice<Thread> findSentByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long countUnreadInboxByUserId(UUID userId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Slice<Thread> findTrashByUserId(UUID userId, UUID markerId, Pageable pageable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void hardDeleteAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
+        }
+    }
+
+    private static final class InMemoryMessageRepository implements MessageRepositoryPort {
+        private final List<Message> savedMessages = new ArrayList<>();
+
+        @Override
+        public Message save(Message message) {
+            if (!savedMessages.contains(message)) {
+                savedMessages.add(message);
+            }
+            return message;
+        }
+
+        @Override
+        public Optional<Message> findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(UUID threadId, String gmailMessageId) {
+            return savedMessages.stream()
+                    .filter(m -> m.getThread() != null
+                            && gmailMessageId.equals(m.getGmailMessageId())
+                            && (threadId == null || threadId.equals(m.getThread().getId()))
+                            && !m.isDeleted())
+                    .findFirst();
+        }
+
+        @Override
+        public Optional<Message> findByThreadIdAndGmailMessageId(UUID threadId, String gmailMessageId) {
+            return savedMessages.stream()
+                    .filter(m -> m.getThread() != null
+                            && gmailMessageId.equals(m.getGmailMessageId())
+                            && (threadId == null || threadId.equals(m.getThread().getId())))
+                    .findFirst();
+        }
+
+        @Override
+        public Optional<Message> findByMailAccountIdAndGmailThreadIdAndGmailMessageIdAndDeletedAtIsNull(
+                UUID mailAccountId, String gmailThreadId, String gmailMessageId) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Message> findByMailAccountIdAndGmailThreadIdAndGmailMessageId(
+                UUID mailAccountId, String gmailThreadId, String gmailMessageId) {
+            return Optional.empty();
+        }
+
+        @Override
+        public boolean existsByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullAndGmailMessageIdNot(
+                UUID mailAccountId, String gmailThreadId, String gmailMessageId) {
+            return false;
+        }
+
+        @Override
+        public Optional<Message> findByIdIncludingDeleted(UUID messageId) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<Message> findAllByThreadIdAndDeletedAtIsNull(UUID threadId) {
+            return List.of();
+        }
+
+        @Override
+        public List<Message> findAllByThreadIdIncludingDeleted(UUID threadId) {
+            return List.of();
+        }
+
+        @Override
+        public List<Message> findAllByThreadIdInAndDeletedAtIsNull(List<UUID> threadIds) {
+            return List.of();
+        }
+
+        @Override
+        public List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId) {
+            return List.of();
+        }
+
+        @Override
+        public List<Message> findAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
+            return List.of();
+        }
+
+        @Override
+        public Slice<Message> findDeletedByUserId(UUID userId, UUID markerId, Pageable pageable) {
+            return null;
+        }
+
+        @Override
+        public List<Message> findAllDeletedByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
+            return List.of();
+        }
+
+        @Override
+        public int bulkSoftDeleteByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId, LocalDateTime deletedAt) {
+            return 0;
+        }
+
+        @Override
+        public int bulkRestoreByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
+            return 0;
+        }
+
+        @Override
+        public void hardDelete(Message message) {
+        }
+
+        @Override
+        public boolean existsByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
+            return false;
+        }
+    }
+}

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
@@ -192,6 +192,15 @@ class InitialMailSyncCommandServiceTest {
         }
 
         @Override
+        public int bulkRestoreAndResetMessageCountByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
+            return 0;
+        }
+
+        @Override
+        public void hardDeleteAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
+        }
+
+        @Override
         public Slice<Thread> findInboxByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable) {
             throw new UnsupportedOperationException();
         }
@@ -225,6 +234,16 @@ class InitialMailSyncCommandServiceTest {
 
         @Override
         public Optional<Message> findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(UUID threadId, String gmailMessageId) {
+            return savedMessages.stream()
+                    .filter(message -> message.getThread() != null
+                            && gmailMessageId.equals(message.getGmailMessageId())
+                            && (threadId == null || threadId.equals(message.getThread().getId()))
+                            && !message.isDeleted())
+                    .findFirst();
+        }
+
+        @Override
+        public Optional<Message> findByThreadIdAndGmailMessageId(UUID threadId, String gmailMessageId) {
             return savedMessages.stream()
                     .filter(message -> message.getThread() != null
                             && gmailMessageId.equals(message.getGmailMessageId())
@@ -325,6 +344,15 @@ class InitialMailSyncCommandServiceTest {
         @Override
         public int bulkRestoreByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
             return 0;
+        }
+
+        @Override
+        public void hardDelete(Message message) {
+        }
+
+        @Override
+        public boolean existsByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
+            return false;
         }
     }
 }

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
@@ -11,6 +11,7 @@ import com.mailsangja.worker.dto.mail.sync.InitialMailSyncThreadSaveCommand;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -328,7 +329,7 @@ class InitialMailSyncCommandServiceTest {
 
         @Override
         public Slice<Message> findDeletedByUserId(UUID userId, UUID markerId, Pageable pageable) {
-            return null;
+            return new SliceImpl<>(List.of());
         }
 
         @Override


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#9

### 📌 Task
- Closes #45 


## 💡 작업 내용

- Gmail History 처리 경로에 `messagesAdded` 기반 신규 이벤트(`MESSAGE_ADDED`)를 추가
- 이벤트 분류 시 `MESSAGE_ADDED -> READ/UNREAD` 순서로 처리하도록 설정
- 신규 이벤트 전용 Handler/Service 구현
- 외부 Gmail 조회와 DB 반영 분리
- 신규 메시지 반영 시 `GmailThreadLockRepositoryPort` 락(`mailAccountId + gmailThreadId`)을 획득
- 신규 메일의 도착에 맞춰 삭제 상태 Thread/Message를 조건부 복구하고 저장
- 로그 가독성 개선을 위해 Hibernate `format_sql`을 `false`로 조정


## 📝 추가 설명

### 1. Thread가 삭제된 상태에서 신규 메일 도착 시

- restoreIfDeleted()
    → Thread 복구 (deletedAt = null) + messageCount = 0으로 초기화
    → Message는 그대로 soft-deleted 유지

- saveThreadBatch()
    → 스냅샷의 모든 메시지에 대해 saveMessage() 호출
       → findByThreadIdAndGmailMessageId (deleted 포함) 단건 조회
       → 기존 soft-deleted 메시지 → found + isDeleted() = true → skip
       → 신규 메시지 → not found → INSERT
    → Thread messageCount = 1 (신규 메시지만)
    → Thread 최신 정보 = 신규 메시지 기준으로 갱신

### 2. Thread가 삭제되지 않은 상태에서 메시지가 soft-deleted인 경우

- saveThreadBatch()
    → saveMessage()
      → findByThreadIdAndGmailMessageId (deleted 포함) 단건 조회
      → soft-deleted 메시지 → found + isDeleted() = true → skip (unique constraint 위반 없음)
      → 신규 메시지 → not found → INSERT

### 3. 핵심 변경 포인트 2가지                                                                                                                                                                                                                                                        

1. saveMessage() 쿼리 전략 변경

  before: findByThreadId...AndDeletedAtIsNull (active만 조회)
            → empty면 무조건 INSERT → soft-deleted 중복 시 crash

  after:  findByThreadIdAndGmailMessageId (deleted 포함, 쿼리 1번)
            → present + active  → update
            → present + deleted → skip
            → absent            → insert

2. restoreIfDeleted() 복구 범위 변경

  before: Thread 복구 + Message 전체 복구
            → 사용자가 의도적으로 지운 메시지까지 되살아남

  after:  Thread만 복구 + messageCount = 0 초기화
            → 기존 삭제 메시지는 유지, 신규 메시지만 새로 삽입됨

## ⚡️ Test 결과

| 신규 메일 도착 확인 (1) | 신규 메일 도착 확인 (2) |
| -- | -- |
| <img width="654" height="376" alt="Image" src="https://github.com/user-attachments/assets/c2e2043c-bdb6-4552-9447-f1a7a3312106" /> | <img width="1211" height="140" alt="Image" src="https://github.com/user-attachments/assets/32d8f121-ae28-4946-9c62-08cf544f4a04" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * Gmail 새로운 메시지 추가 감지 및 자동 동기화 지원
  * 삭제된 스레드로 새 메시지 도착 시 스레드 자동 복원 기능

* **Chores**
  * SQL 쿼리 포맷팅 설정 비활성화로 성능 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->