### PR TITLE
[STORY-201] Message/Thread Name 필드 저장

### DIFF
--- a/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponse.java
@@ -40,7 +40,7 @@ public record ThreadSummaryResponse(
                 thread.getGmailThreadId(),
                 thread.getMailAccount().getId(),
                 thread.getLatestSubject(),
-                MailAddressResponse.of(thread.getLatestParticipantAddress(), contactNameByEmail),
+                MailAddressResponse.of(thread.getLatestParticipantName(), thread.getLatestParticipantAddress(), contactNameByEmail),
                 thread.getLatestSnippet(),
                 thread.isRead(),
                 thread.getLastMessageAt(),

--- a/core/src/main/java/com/mailsangja/core/dto/mail/MailSendPersistCommand.java
+++ b/core/src/main/java/com/mailsangja/core/dto/mail/MailSendPersistCommand.java
@@ -46,6 +46,24 @@ public record MailSendPersistCommand(
         return null;
     }
 
+    public String latestParticipantName() {
+        if (messageResult.toAddresses() != null && !messageResult.toAddresses().isEmpty()) {
+            return resolveFirstName(
+                    messageResult.toAddresses(),
+                    resolveNames(messageResult.toAddresses(), sendCommand.to(), messageResult.toNames())
+            );
+        }
+
+        if (messageResult.ccAddresses() != null && !messageResult.ccAddresses().isEmpty()) {
+            return resolveFirstName(
+                    messageResult.ccAddresses(),
+                    resolveNames(messageResult.ccAddresses(), sendCommand.cc(), messageResult.ccNames())
+            );
+        }
+
+        return null;
+    }
+
     private String resolveFromName() {
         if (sendCommand.from() != null
                 && sendCommand.from().address() != null
@@ -92,5 +110,18 @@ public record MailSendPersistCommand(
 
         String fallbackName = fallbackNames.get(index);
         return fallbackName == null || fallbackName.isBlank() ? address : fallbackName;
+    }
+
+    private String resolveFirstName(List<String> addresses, List<String> names) {
+        if (addresses == null || addresses.isEmpty()) {
+            return null;
+        }
+
+        if (names == null || names.isEmpty()) {
+            return addresses.getFirst();
+        }
+
+        String firstName = names.getFirst();
+        return firstName == null || firstName.isBlank() ? addresses.getFirst() : firstName;
     }
 }

--- a/core/src/main/java/com/mailsangja/core/service/google/GoogleMailMessageQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/google/GoogleMailMessageQueryService.java
@@ -143,8 +143,9 @@ public class GoogleMailMessageQueryService {
             List<String> names = new ArrayList<>();
             for (InternetAddress address : addresses) {
                 if (address != null && !isBlank(address.getAddress())) {
-                    normalizedAddresses.add(address.getAddress().trim().toLowerCase());
-                    names.add(normalizePersonalName(address.getPersonal()));
+                    String normalizedAddress = address.getAddress().trim().toLowerCase();
+                    normalizedAddresses.add(normalizedAddress);
+                    names.add(normalizePersonalName(address.getPersonal(), normalizedAddress));
                 }
             }
             return ParsedMailAddresses.of(normalizedAddresses, names);
@@ -260,9 +261,9 @@ public class GoogleMailMessageQueryService {
         return value == null || value.isBlank();
     }
 
-    private String normalizePersonalName(String personalName) {
+    private String normalizePersonalName(String personalName, String address) {
         if (personalName == null || personalName.isBlank()) {
-            return null;
+            return address;
         }
         return personalName.trim();
     }

--- a/core/src/main/java/com/mailsangja/core/service/mail/MailCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/mail/MailCommandService.java
@@ -72,6 +72,7 @@ public class MailCommandService {
                 command.messageResult().subject(),
                 command.messageResult().snippet(),
                 command.latestParticipantAddress(),
+                command.latestParticipantName(),
                 command.messageResult().sentAt(),
                 true
         );

--- a/core/src/test/java/com/mailsangja/core/dto/mail/MailSendPersistCommandTest.java
+++ b/core/src/test/java/com/mailsangja/core/dto/mail/MailSendPersistCommandTest.java
@@ -97,4 +97,40 @@ class MailSendPersistCommandTest {
 
         assertEquals("cc@example.com", command.latestParticipantAddress());
     }
+
+    @Test
+    void latestParticipantName_to가없으면cc의이름을대표참여자로사용한다() {
+        MailSendPersistCommand command = new MailSendPersistCommand(
+                MailAccount.builder().id(UUID.randomUUID()).build(),
+                new GoogleMailMessageResult(
+                        "gmail-message-id",
+                        "gmail-thread-id",
+                        "history-id",
+                        "제목",
+                        "sender@example.com",
+                        "sender@example.com",
+                        List.of(),
+                        List.of(),
+                        List.of("cc@example.com"),
+                        List.of("참조사람"),
+                        "snippet",
+                        LocalDateTime.of(2026, 4, 16, 18, 0),
+                        "본문",
+                        null,
+                        List.of()
+                ),
+                new MailSendCommand(
+                        UUID.randomUUID(),
+                        new MailAddressCommand("sender@example.com", "sender@example.com"),
+                        List.of(),
+                        List.of(new MailAddressCommand("참조사람", "cc@example.com")),
+                        List.of(),
+                        "제목",
+                        "본문",
+                        List.of()
+                )
+        );
+
+        assertEquals("참조사람", command.latestParticipantName());
+    }
 }

--- a/core/src/test/java/com/mailsangja/core/facade/MailFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/MailFacadeTest.java
@@ -483,6 +483,7 @@ class MailFacadeTest {
                     .latestSubject(thread.getLatestSubject())
                     .latestSnippet(thread.getLatestSnippet())
                     .latestParticipantAddress(thread.getLatestParticipantAddress())
+                    .latestParticipantName(thread.getLatestParticipantName())
                     .lastMessageAt(thread.getLastMessageAt())
                     .read(thread.isRead())
                     .messageCount(thread.getMessageCount())

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
@@ -239,8 +239,11 @@ public class Message extends BaseEntity {
     }
 
     private static String normalizeSingleName(String name, String address) {
-        if (name != null && !name.isBlank()) {
-            return name;
+        if (name != null) {
+            String trimmedName = name.trim();
+            if (!trimmedName.isBlank()) {
+                return trimmedName;
+            }
         }
         return address;
     }

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
@@ -98,22 +98,23 @@ public class Message extends BaseEntity {
     private List<Label> labels = new ArrayList<>();
 
     public static Message from(Thread thread, CreateValues values) {
+        CreateValues normalizedValues = values.normalizeNames();
         return Message.builder()
                 .thread(thread)
-                .gmailMessageId(values.gmailMessageId())
-                .direction(values.direction())
-                .subject(values.subject())
-                .fromAddress(values.fromAddress())
-                .fromName(values.fromName())
-                .toAddresses(copyList(values.toAddresses()))
-                .toNames(copyList(values.toNames()))
-                .ccAddresses(copyList(values.ccAddresses()))
-                .ccNames(copyList(values.ccNames()))
-                .snippet(values.snippet())
-                .read(values.read())
-                .sentAt(values.sentAt())
-                .bodyText(values.bodyText())
-                .bodyHtml(values.bodyHtml())
+                .gmailMessageId(normalizedValues.gmailMessageId())
+                .direction(normalizedValues.direction())
+                .subject(normalizedValues.subject())
+                .fromAddress(normalizedValues.fromAddress())
+                .fromName(normalizedValues.fromName())
+                .toAddresses(copyList(normalizedValues.toAddresses()))
+                .toNames(copyList(normalizedValues.toNames()))
+                .ccAddresses(copyList(normalizedValues.ccAddresses()))
+                .ccNames(copyList(normalizedValues.ccNames()))
+                .snippet(normalizedValues.snippet())
+                .read(normalizedValues.read())
+                .sentAt(normalizedValues.sentAt())
+                .bodyText(normalizedValues.bodyText())
+                .bodyHtml(normalizedValues.bodyHtml())
                 .attachments(new ArrayList<>())
                 .labels(Collections.emptyList())
                 .build();
@@ -135,6 +136,24 @@ public class Message extends BaseEntity {
             String bodyText,
             String bodyHtml
     ) {
+        public CreateValues normalizeNames() {
+            return new CreateValues(
+                    gmailMessageId,
+                    direction,
+                    subject,
+                    fromAddress,
+                    normalizeSingleName(fromName, fromAddress),
+                    copyList(toAddresses),
+                    normalizeAddressNames(toNames, toAddresses),
+                    copyList(ccAddresses),
+                    normalizeAddressNames(ccNames, ccAddresses),
+                    snippet,
+                    read,
+                    sentAt,
+                    bodyText,
+                    bodyHtml
+            );
+        }
     }
 
     public void markAsRead() {
@@ -146,19 +165,20 @@ public class Message extends BaseEntity {
     }
 
     public void updateFrom(CreateValues values) {
+        CreateValues normalizedValues = values.normalizeNames();
         updateBasicContent(
-                values.subject(),
-                values.fromAddress(),
-                values.fromName(),
-                values.toAddresses(),
-                values.toNames(),
-                values.ccAddresses(),
-                values.ccNames(),
-                values.snippet(),
-                values.read(),
-                values.sentAt()
+                normalizedValues.subject(),
+                normalizedValues.fromAddress(),
+                normalizedValues.fromName(),
+                normalizedValues.toAddresses(),
+                normalizedValues.toNames(),
+                normalizedValues.ccAddresses(),
+                normalizedValues.ccNames(),
+                normalizedValues.snippet(),
+                normalizedValues.read(),
+                normalizedValues.sentAt()
         );
-        updateBodyContent(values.bodyText(), values.bodyHtml());
+        updateBodyContent(normalizedValues.bodyText(), normalizedValues.bodyHtml());
     }
 
     public void updateBasicContent(
@@ -202,5 +222,26 @@ public class Message extends BaseEntity {
             return List.of();
         }
         return Collections.unmodifiableList(new ArrayList<>(values));
+    }
+
+    private static List<String> normalizeAddressNames(List<String> names, List<String> addresses) {
+        if (addresses == null || addresses.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> normalizedNames = new ArrayList<>(addresses.size());
+        for (int index = 0; index < addresses.size(); index++) {
+            String address = addresses.get(index);
+            String name = names != null && index < names.size() ? names.get(index) : null;
+            normalizedNames.add(normalizeSingleName(name, address));
+        }
+        return Collections.unmodifiableList(normalizedNames);
+    }
+
+    private static String normalizeSingleName(String name, String address) {
+        if (name != null && !name.isBlank()) {
+            return name;
+        }
+        return address;
     }
 }

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Thread.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Thread.java
@@ -53,6 +53,9 @@ public class Thread extends BaseEntity {
     @Column(name = "latest_participant_address", length = 255)
     private String latestParticipantAddress;
 
+    @Column(name = "latest_participant_name", length = 255)
+    private String latestParticipantName;
+
     @Column(name = "last_message_at")
     private LocalDateTime lastMessageAt;
 
@@ -79,11 +82,13 @@ public class Thread extends BaseEntity {
             String subject,
             String snippet,
             String participantAddress,
+            String participantName,
             LocalDateTime lastMessageAt
     ) {
         this.latestSubject = subject;
         this.latestSnippet = snippet;
         this.latestParticipantAddress = participantAddress;
+        this.latestParticipantName = participantName;
         this.lastMessageAt = lastMessageAt;
     }
 
@@ -91,6 +96,7 @@ public class Thread extends BaseEntity {
             String subject,
             String snippet,
             String participantAddress,
+            String participantName,
             LocalDateTime lastMessageAt,
             boolean read
     ) {
@@ -102,7 +108,7 @@ public class Thread extends BaseEntity {
             return;
         }
 
-        updateLatestMessageInfo(subject, snippet, participantAddress, lastMessageAt);
+        updateLatestMessageInfo(subject, snippet, participantAddress, participantName, lastMessageAt);
         this.read = read;
     }
 

--- a/db/src/main/resources/schema.sql
+++ b/db/src/main/resources/schema.sql
@@ -47,6 +47,7 @@ CREATE TABLE IF NOT EXISTS threads (
     latest_subject             VARCHAR(500) NULL,
     latest_snippet             VARCHAR(500) NULL,
     latest_participant_address VARCHAR(255) NULL,
+    latest_participant_name    VARCHAR(255) NULL,
     last_message_at            TIMESTAMP    NULL,
     is_read                    BOOLEAN      NOT NULL DEFAULT FALSE,
     message_count              INT          NOT NULL DEFAULT 0,

--- a/worker/src/main/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryService.java
@@ -261,8 +261,9 @@ public class GoogleMailMessageQueryService {
             List<String> names = new ArrayList<>();
             for (InternetAddress address : addresses) {
                 if (address != null && !isBlank(address.getAddress())) {
-                    normalizedAddresses.add(address.getAddress().trim().toLowerCase());
-                    names.add(normalizePersonalName(address.getPersonal()));
+                    String normalizedAddress = address.getAddress().trim().toLowerCase();
+                    normalizedAddresses.add(normalizedAddress);
+                    names.add(normalizePersonalName(address.getPersonal(), normalizedAddress));
                 }
             }
             return ParsedMailAddresses.of(normalizedAddresses, names);
@@ -385,9 +386,9 @@ public class GoogleMailMessageQueryService {
         return !isBlank(primary) ? primary : secondary;
     }
 
-    private String normalizePersonalName(String personalName) {
+    private String normalizePersonalName(String personalName, String address) {
         if (isBlank(personalName)) {
-            return null;
+            return address;
         }
         return personalName.trim();
     }

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
@@ -253,12 +253,14 @@ public class InitialMailSyncCommandService {
                 latestParticipantAddress = resolveLatestParticipantAddress(
                         messageCommand.direction(),
                         messageCommand.fromAddress(),
-                        messageCommand.toAddresses()
+                        messageCommand.toAddresses(),
+                        messageCommand.ccAddresses()
                 );
                 latestParticipantName = resolveLatestParticipantName(
                         messageCommand.direction(),
                         messageCommand.fromName(),
                         messageCommand.toNames(),
+                        messageCommand.ccNames(),
                         latestParticipantAddress
                 );
                 lastMessageAt = candidateSentAt;
@@ -315,9 +317,17 @@ public class InitialMailSyncCommandService {
             return null;
         }
 
-        private String resolveLatestParticipantAddress(Direction direction, String fromAddress, List<String> toAddresses) {
+        private String resolveLatestParticipantAddress(
+                Direction direction,
+                String fromAddress,
+                List<String> toAddresses,
+                List<String> ccAddresses
+        ) {
             if (direction == Direction.OUTBOUND) {
-                return toAddresses == null || toAddresses.isEmpty() ? null : toAddresses.getFirst();
+                if (toAddresses != null && !toAddresses.isEmpty()) {
+                    return toAddresses.getFirst();
+                }
+                return ccAddresses == null || ccAddresses.isEmpty() ? null : ccAddresses.getFirst();
             }
             return fromAddress;
         }
@@ -326,11 +336,15 @@ public class InitialMailSyncCommandService {
                 Direction direction,
                 String fromName,
                 List<String> toNames,
+                List<String> ccNames,
                 String participantAddress
         ) {
             if (direction == Direction.OUTBOUND) {
                 if (toNames == null || toNames.isEmpty()) {
-                    return participantAddress;
+                    if (ccNames == null || ccNames.isEmpty()) {
+                        return participantAddress;
+                    }
+                    return normalizeName(ccNames.getFirst(), participantAddress);
                 }
                 return normalizeName(toNames.getFirst(), participantAddress);
             }

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
@@ -89,6 +89,7 @@ public class InitialMailSyncCommandService {
                 aggregate.latestSubject(),
                 aggregate.latestSnippet(),
                 aggregate.latestParticipantAddress(),
+                aggregate.latestParticipantName(),
                 aggregate.lastMessageAt(),
                 aggregate.read()
         );
@@ -217,6 +218,7 @@ public class InitialMailSyncCommandService {
         private String latestSubject;
         private String latestSnippet;
         private String latestParticipantAddress;
+        private String latestParticipantName;
         private LocalDateTime lastMessageAt;
         private boolean read;
         private int messageCount;
@@ -227,6 +229,7 @@ public class InitialMailSyncCommandService {
             aggregate.latestSubject = thread.getLatestSubject();
             aggregate.latestSnippet = thread.getLatestSnippet();
             aggregate.latestParticipantAddress = thread.getLatestParticipantAddress();
+            aggregate.latestParticipantName = thread.getLatestParticipantName();
             aggregate.lastMessageAt = thread.getLastMessageAt();
             aggregate.read = thread.isRead();
             aggregate.messageCount = thread.getMessageCount();
@@ -251,6 +254,12 @@ public class InitialMailSyncCommandService {
                         messageCommand.direction(),
                         messageCommand.fromAddress(),
                         messageCommand.toAddresses()
+                );
+                latestParticipantName = resolveLatestParticipantName(
+                        messageCommand.direction(),
+                        messageCommand.fromName(),
+                        messageCommand.toNames(),
+                        latestParticipantAddress
                 );
                 lastMessageAt = candidateSentAt;
                 read = messageCommand.read();
@@ -281,6 +290,10 @@ public class InitialMailSyncCommandService {
             return latestParticipantAddress;
         }
 
+        private String latestParticipantName() {
+            return latestParticipantName;
+        }
+
         private LocalDateTime lastMessageAt() {
             return lastMessageAt;
         }
@@ -307,6 +320,22 @@ public class InitialMailSyncCommandService {
                 return toAddresses == null || toAddresses.isEmpty() ? null : toAddresses.getFirst();
             }
             return fromAddress;
+        }
+
+        private String resolveLatestParticipantName(
+                Direction direction,
+                String fromName,
+                List<String> toNames,
+                String participantAddress
+        ) {
+            if (direction == Direction.OUTBOUND) {
+                if (toNames == null || toNames.isEmpty()) {
+                    return participantAddress;
+                }
+                String firstName = toNames.getFirst();
+                return isBlank(firstName) ? participantAddress : firstName;
+            }
+            return isBlank(fromName) ? participantAddress : fromName;
         }
 
         private boolean isBlank(String value) {

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
@@ -332,10 +332,22 @@ public class InitialMailSyncCommandService {
                 if (toNames == null || toNames.isEmpty()) {
                     return participantAddress;
                 }
-                String firstName = toNames.getFirst();
-                return isBlank(firstName) ? participantAddress : firstName;
+                return normalizeName(toNames.getFirst(), participantAddress);
             }
-            return isBlank(fromName) ? participantAddress : fromName;
+            return normalizeName(fromName, participantAddress);
+        }
+
+        private String normalizeName(String name, String fallbackAddress) {
+            if (name == null) {
+                return fallbackAddress;
+            }
+
+            String trimmedName = name.trim();
+            if (trimmedName.isBlank()) {
+                return fallbackAddress;
+            }
+
+            return trimmedName;
         }
 
         private boolean isBlank(String value) {

--- a/worker/src/test/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryServiceTest.java
@@ -72,7 +72,7 @@ class GoogleMailMessageQueryServiceTest {
         assertEquals("alice@example.com", results.getFirst().messages().getFirst().fromAddress());
         assertEquals("Alice Kim", results.getFirst().messages().getFirst().fromName());
         assertEquals(List.of("bob@example.com", "carol@example.com"), results.getFirst().messages().getFirst().toAddresses());
-        assertEquals(Arrays.asList("Bob", null), results.getFirst().messages().getFirst().toNames());
+        assertEquals(Arrays.asList("Bob", "carol@example.com"), results.getFirst().messages().getFirst().toNames());
         assertEquals(List.of("dave@example.com"), results.getFirst().messages().getFirst().ccAddresses());
         assertEquals(List.of("Dave, Jr."), results.getFirst().messages().getFirst().ccNames());
         assertEquals(Direction.INBOUND, results.getFirst().messages().getFirst().direction());

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.SliceImpl;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -147,6 +148,49 @@ class InitialMailSyncCommandServiceTest {
         assertEquals("snippet-1", savedThread.getLatestSnippet());
         assertEquals(LocalDateTime.of(2026, 4, 11, 10, 0), savedThread.getLastMessageAt());
         assertEquals(2, savedThread.getMessageCount());
+    }
+
+    @Test
+    void saveThreadBatch_fillsMessageNamesAndLatestParticipantNameWithAddressFallback() {
+        InMemoryThreadRepository threadRepository = new InMemoryThreadRepository();
+        InMemoryMessageRepository messageRepository = new InMemoryMessageRepository();
+        InitialMailSyncCommandService service = new InitialMailSyncCommandService(threadRepository, messageRepository);
+
+        MailAccount mailAccount = MailAccount.builder()
+                .id(UUID.randomUUID())
+                .build();
+
+        service.saveThreadBatch(mailAccount, List.of(new InitialMailSyncThreadSaveCommand(
+                "thread-1",
+                "history-1",
+                List.of(new InitialMailSyncMessageSaveCommand(
+                        "message-1",
+                        "history-1",
+                        Direction.OUTBOUND,
+                        "subject",
+                        "sender@example.com",
+                        null,
+                        List.of("first@example.com", "second@example.com"),
+                        Arrays.asList((String) null),
+                        List.of("cc@example.com"),
+                        List.of(""),
+                        "snippet",
+                        true,
+                        LocalDateTime.of(2026, 4, 11, 10, 0),
+                        "body",
+                        null,
+                        List.of()
+                ))
+        )));
+
+        Message savedMessage = messageRepository.savedMessages.getFirst();
+        Thread savedThread = threadRepository.savedThreads.getFirst();
+
+        assertEquals("sender@example.com", savedMessage.getFromName());
+        assertEquals(List.of("first@example.com", "second@example.com"), savedMessage.getToNames());
+        assertEquals(List.of("cc@example.com"), savedMessage.getCcNames());
+        assertEquals("first@example.com", savedThread.getLatestParticipantAddress());
+        assertEquals("first@example.com", savedThread.getLatestParticipantName());
     }
 
     private static final class InMemoryThreadRepository implements ThreadRepositoryPort {

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
@@ -193,6 +193,48 @@ class InitialMailSyncCommandServiceTest {
         assertEquals("first@example.com", savedThread.getLatestParticipantName());
     }
 
+    @Test
+    void saveThreadBatch_trimsNamesBeforeSaving() {
+        InMemoryThreadRepository threadRepository = new InMemoryThreadRepository();
+        InMemoryMessageRepository messageRepository = new InMemoryMessageRepository();
+        InitialMailSyncCommandService service = new InitialMailSyncCommandService(threadRepository, messageRepository);
+
+        MailAccount mailAccount = MailAccount.builder()
+                .id(UUID.randomUUID())
+                .build();
+
+        service.saveThreadBatch(mailAccount, List.of(new InitialMailSyncThreadSaveCommand(
+                "thread-1",
+                "history-1",
+                List.of(new InitialMailSyncMessageSaveCommand(
+                        "message-1",
+                        "history-1",
+                        Direction.OUTBOUND,
+                        "subject",
+                        "sender@example.com",
+                        "  Sender Name  ",
+                        List.of("first@example.com"),
+                        List.of("  First Receiver  "),
+                        List.of("cc@example.com"),
+                        List.of("  "),
+                        "snippet",
+                        true,
+                        LocalDateTime.of(2026, 4, 11, 10, 0),
+                        "body",
+                        null,
+                        List.of()
+                ))
+        )));
+
+        Message savedMessage = messageRepository.savedMessages.getFirst();
+        Thread savedThread = threadRepository.savedThreads.getFirst();
+
+        assertEquals("Sender Name", savedMessage.getFromName());
+        assertEquals(List.of("First Receiver"), savedMessage.getToNames());
+        assertEquals(List.of("cc@example.com"), savedMessage.getCcNames());
+        assertEquals("First Receiver", savedThread.getLatestParticipantName());
+    }
+
     private static final class InMemoryThreadRepository implements ThreadRepositoryPort {
         private final List<Thread> savedThreads = new ArrayList<>();
 

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
@@ -235,6 +235,45 @@ class InitialMailSyncCommandServiceTest {
         assertEquals("First Receiver", savedThread.getLatestParticipantName());
     }
 
+    @Test
+    void saveThreadBatch_usesCcAsLatestParticipantWhenToIsEmpty() {
+        InMemoryThreadRepository threadRepository = new InMemoryThreadRepository();
+        InMemoryMessageRepository messageRepository = new InMemoryMessageRepository();
+        InitialMailSyncCommandService service = new InitialMailSyncCommandService(threadRepository, messageRepository);
+
+        MailAccount mailAccount = MailAccount.builder()
+                .id(UUID.randomUUID())
+                .build();
+
+        service.saveThreadBatch(mailAccount, List.of(new InitialMailSyncThreadSaveCommand(
+                "thread-1",
+                "history-1",
+                List.of(new InitialMailSyncMessageSaveCommand(
+                        "message-1",
+                        "history-1",
+                        Direction.OUTBOUND,
+                        "subject",
+                        "sender@example.com",
+                        "Sender",
+                        List.of(),
+                        List.of(),
+                        List.of("cc@example.com"),
+                        List.of("CC Receiver"),
+                        "snippet",
+                        true,
+                        LocalDateTime.of(2026, 4, 11, 10, 0),
+                        "body",
+                        null,
+                        List.of()
+                ))
+        )));
+
+        Thread savedThread = threadRepository.savedThreads.getFirst();
+
+        assertEquals("cc@example.com", savedThread.getLatestParticipantAddress());
+        assertEquals("CC Receiver", savedThread.getLatestParticipantName());
+    }
+
     private static final class InMemoryThreadRepository implements ThreadRepositoryPort {
         private final List<Thread> savedThreads = new ArrayList<>();
 


### PR DESCRIPTION
  ## 🔗 관련 작업

  ### 👤 User Story
  - mailsangja/docs4capstone#6

  ### 📌 Task
  - Closes #19 


  ## 💡 작업 내용

  - `Message` 엔티티 저장/갱신 시 `fromName`, `toNames`, `ccNames`가 비어 있으면 이메일 주소를 fallback으로 저장하도록 보정했습니다.
  - `Thread` 엔티티에 `latestParticipantName` 필드를 추가하고, 최신 메시지 기준 참여자 이름까지 함께 저장하도록 반영했습니다.
  - 메일 전송(core)과 초기 동기화/신규 메일 반영(worker) 경로 모두 동일한 name fallback 규칙으로 맞췄습니다.
  - 스레드 목록 응답에서 저장된 최신 참여자 이름을 우선 사용하도록 조정했습니다.


  ## 📝 추가 설명

  ### 1. Message name fallback 저장
  - `Message.CreateValues` 단계에서 이름 정규화를 수행하도록 변경했습니다.
  - `fromName`이 null/blank이면 `fromAddress`를 저장합니다.
  - `toNames`, `ccNames`는 각 인덱스 기준으로 이름이 없으면 대응하는 이메일 주소를 저장합니다.
  - 신규 insert뿐 아니라 기존 `Message.updateFrom(...)` 갱신 경로에도 동일 규칙을 적용했습니다.

  ### 2. Thread 최신 참여자 이름 저장
  - `Thread`에 `latestParticipantName` 컬럼을 추가했습니다.
  - OUTBOUND Thread는 첫 번째 `to` 수신자의 이름, INBOUND Thread는 `fromName` 기준으로 최신 참여자 이름을 계산합니다.
  - 이름이 없으면 동일하게 이메일 주소를 fallback으로 사용합니다.
  - `ThreadSummaryResponse`는 이제 저장된 `latestParticipantName`을 우선 사용해 참여자 정보를 내려줍니다.

  ### 3. core / worker 저장 경로 동기화
  - `MailSendPersistCommand`에 최신 참여자 이름 계산 로직을 추가해 메일 전송 후 저장되는 Thread에도 이름이 반영되도록 했습니다.
  - core `GoogleMailMessageQueryService`, worker `GoogleMailMessageQueryService` 모두 헤더 파싱 시 personal name이 비어 있으면 address fallback을 사용하도록 맞췄습니
  다.
  - `InitialMailSyncCommandService` 집계 로직에도 최신 참여자 이름 계산을 추가해 초기 동기화와 신규 메시지 반영 시 동일한 결과가 저장되도록 했습니다.


  ## ⚡️ Test 결과

  | 받은 편지함 조회 |
  | -- |
  | GET |
  | /api/v1/threads/inbox |
  | <img width="689" height="585" alt="image" src="https://github.com/user-attachments/assets/78ff8244-b5e8-4f09-a2ff-c532a4777241" /> |