### PR TITLE
[STORY-203] 스레드·메시지 읽음/안읽음 처리 API 및 로컬 Gmail push ack 처리 추가

### DIFF
--- a/core/src/main/java/com/mailsangja/core/common/exception/inbox/InboxErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/inbox/InboxErrorCode.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 public enum InboxErrorCode implements ErrorCode {
 
     THREAD_NOT_FOUND(404, "MS-INBOX-THREAD-NOT-FOUND", "메일 스레드를 찾을 수 없습니다."),
+    MESSAGE_NOT_FOUND(404, "MS-INBOX-MESSAGE-NOT-FOUND", "메일 메시지를 찾을 수 없습니다."),
     THREAD_ACCESS_DENIED(403, "MS-INBOX-THREAD-ACCESS-DENIED", "해당 메일 스레드에 접근할 권한이 없습니다."),
     ATTACHMENT_NOT_FOUND(404, "MS-INBOX-ATTACHMENT-NOT-FOUND", "첨부파일을 찾을 수 없습니다."),
     ATTACHMENT_ACCESS_DENIED(403, "MS-INBOX-ATTACHMENT-ACCESS-DENIED", "해당 첨부파일에 접근할 권한이 없습니다."),

--- a/core/src/main/java/com/mailsangja/core/common/exception/mail/MailAccountErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/mail/MailAccountErrorCode.java
@@ -24,6 +24,7 @@ public enum MailAccountErrorCode implements ErrorCode {
     GOOGLE_MAIL_READ_MODIFY_FAILED(502, "MS-MAIL-GOOGLE-MAIL-READ-MODIFY-FAILED", "Google Gmail 읽음 처리 동기화에 실패했습니다."),
     GOOGLE_MESSAGE_READ_MODIFY_FAILED(502, "MS-MAIL-GOOGLE-MESSAGE-READ-MODIFY-FAILED", "Google Gmail 메시지 읽음 처리 동기화에 실패했습니다."),
     GOOGLE_MAIL_UNREAD_MODIFY_FAILED(502, "MS-MAIL-GOOGLE-MAIL-UNREAD-MODIFY-FAILED", "Google Gmail 안읽음 처리 동기화에 실패했습니다."),
+    GOOGLE_MESSAGE_UNREAD_MODIFY_FAILED(502, "MS-MAIL-GOOGLE-MESSAGE-UNREAD-MODIFY-FAILED", "Google Gmail 메시지 안읽음 처리 동기화에 실패했습니다."),
     GOOGLE_MAIL_WATCH_RESULT_INVALID(502, "MS-MAIL-GOOGLE-MAIL-WATCH-RESULT-INVALID", "Google Gmail watch 응답값이 올바르지 않습니다."),
     GOOGLE_EMAIL_NOT_VERIFIED(400, "MS-MAIL-GOOGLE-EMAIL-NOT-VERIFIED", "Google 계정의 이메일 인증이 확인되지 않았습니다. 인증된 계정으로 다시 시도해주세요."),
     GOOGLE_REFRESH_TOKEN_MISSING(400, "MS-MAIL-GOOGLE-REFRESH-TOKEN-MISSING", "Google 계정 재연동이 필요합니다. 다시 동의하고 계정을 연결해주세요."),

--- a/core/src/main/java/com/mailsangja/core/common/exception/mail/MailAccountErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/mail/MailAccountErrorCode.java
@@ -22,6 +22,7 @@ public enum MailAccountErrorCode implements ErrorCode {
     GOOGLE_USER_INFO_FETCH_FAILED(502, "MS-MAIL-GOOGLE-USER-INFO-FETCH-FAILED", "Google 사용자 정보 조회에 실패했습니다."),
     GOOGLE_MAIL_WATCH_FAILED(502, "MS-MAIL-GOOGLE-MAIL-WATCH-FAILED", "Google Gmail watch 등록에 실패했습니다."),
     GOOGLE_MAIL_READ_MODIFY_FAILED(502, "MS-MAIL-GOOGLE-MAIL-READ-MODIFY-FAILED", "Google Gmail 읽음 처리 동기화에 실패했습니다."),
+    GOOGLE_MAIL_UNREAD_MODIFY_FAILED(502, "MS-MAIL-GOOGLE-MAIL-UNREAD-MODIFY-FAILED", "Google Gmail 안읽음 처리 동기화에 실패했습니다."),
     GOOGLE_MAIL_WATCH_RESULT_INVALID(502, "MS-MAIL-GOOGLE-MAIL-WATCH-RESULT-INVALID", "Google Gmail watch 응답값이 올바르지 않습니다."),
     GOOGLE_EMAIL_NOT_VERIFIED(400, "MS-MAIL-GOOGLE-EMAIL-NOT-VERIFIED", "Google 계정의 이메일 인증이 확인되지 않았습니다. 인증된 계정으로 다시 시도해주세요."),
     GOOGLE_REFRESH_TOKEN_MISSING(400, "MS-MAIL-GOOGLE-REFRESH-TOKEN-MISSING", "Google 계정 재연동이 필요합니다. 다시 동의하고 계정을 연결해주세요."),

--- a/core/src/main/java/com/mailsangja/core/common/exception/mail/MailAccountErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/mail/MailAccountErrorCode.java
@@ -22,6 +22,7 @@ public enum MailAccountErrorCode implements ErrorCode {
     GOOGLE_USER_INFO_FETCH_FAILED(502, "MS-MAIL-GOOGLE-USER-INFO-FETCH-FAILED", "Google 사용자 정보 조회에 실패했습니다."),
     GOOGLE_MAIL_WATCH_FAILED(502, "MS-MAIL-GOOGLE-MAIL-WATCH-FAILED", "Google Gmail watch 등록에 실패했습니다."),
     GOOGLE_MAIL_READ_MODIFY_FAILED(502, "MS-MAIL-GOOGLE-MAIL-READ-MODIFY-FAILED", "Google Gmail 읽음 처리 동기화에 실패했습니다."),
+    GOOGLE_MESSAGE_READ_MODIFY_FAILED(502, "MS-MAIL-GOOGLE-MESSAGE-READ-MODIFY-FAILED", "Google Gmail 메시지 읽음 처리 동기화에 실패했습니다."),
     GOOGLE_MAIL_UNREAD_MODIFY_FAILED(502, "MS-MAIL-GOOGLE-MAIL-UNREAD-MODIFY-FAILED", "Google Gmail 안읽음 처리 동기화에 실패했습니다."),
     GOOGLE_MAIL_WATCH_RESULT_INVALID(502, "MS-MAIL-GOOGLE-MAIL-WATCH-RESULT-INVALID", "Google Gmail watch 응답값이 올바르지 않습니다."),
     GOOGLE_EMAIL_NOT_VERIFIED(400, "MS-MAIL-GOOGLE-EMAIL-NOT-VERIFIED", "Google 계정의 이메일 인증이 확인되지 않았습니다. 인증된 계정으로 다시 시도해주세요."),

--- a/core/src/main/java/com/mailsangja/core/config/properties/GoogleMailProperties.java
+++ b/core/src/main/java/com/mailsangja/core/config/properties/GoogleMailProperties.java
@@ -20,6 +20,7 @@ public class GoogleMailProperties {
     private String topicName;
     private String watchUri;
     private String threadModifyUri;
+    private String messageModifyUri;
     private String sendUri;
     private String messagesUri;
     private String attachmentsUri;

--- a/core/src/main/java/com/mailsangja/core/controller/InboxController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/InboxController.java
@@ -60,6 +60,16 @@ public class InboxController implements InboxControllerDocs {
     }
 
     @Override
+    @PostMapping("/api/v1/threads/{threadId}/unread")
+    public ResponseEntity<Void> markThreadAsUnread(
+            @AuthUser User user,
+            @PathVariable UUID threadId
+    ) {
+        inboxFacade.markThreadAsUnread(user, threadId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
     @GetMapping("/api/v1/threads/inbox/unread-count")
     public ResponseEntity<UnreadCountResponse> getUnreadCount(@AuthUser User user) {
         return ResponseEntity.ok(UnreadCountResponse.of(inboxFacade.getUnreadCount(user)));

--- a/core/src/main/java/com/mailsangja/core/controller/InboxController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/InboxController.java
@@ -70,6 +70,16 @@ public class InboxController implements InboxControllerDocs {
     }
 
     @Override
+    @PostMapping("/api/v1/messages/{messageId}/unread")
+    public ResponseEntity<Void> markMessageAsUnread(
+            @AuthUser User user,
+            @PathVariable UUID messageId
+    ) {
+        inboxFacade.markMessageAsUnread(user, messageId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
     @PostMapping("/api/v1/threads/{threadId}/unread")
     public ResponseEntity<Void> markThreadAsUnread(
             @AuthUser User user,

--- a/core/src/main/java/com/mailsangja/core/controller/InboxController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/InboxController.java
@@ -60,6 +60,16 @@ public class InboxController implements InboxControllerDocs {
     }
 
     @Override
+    @PostMapping("/api/v1/messages/{messageId}/read")
+    public ResponseEntity<Void> markMessageAsRead(
+            @AuthUser User user,
+            @PathVariable UUID messageId
+    ) {
+        inboxFacade.markMessageAsRead(user, messageId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
     @PostMapping("/api/v1/threads/{threadId}/unread")
     public ResponseEntity<Void> markThreadAsUnread(
             @AuthUser User user,

--- a/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
@@ -101,6 +101,8 @@ public interface InboxControllerDocs {
             @ApiResponse(responseCode = "403", description = "스레드 접근 권한 없음",
                     content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", description = "스레드를 찾을 수 없음",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "502", description = "Gmail 읽음 처리 동기화 실패",
                     content = @Content(schema = @Schema(hidden = true)))
     })
     ResponseEntity<Void> markThreadAsRead(
@@ -121,6 +123,8 @@ public interface InboxControllerDocs {
             @ApiResponse(responseCode = "403", description = "메시지 접근 권한 없음",
                     content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", description = "메시지를 찾을 수 없음",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "502", description = "Gmail 메시지 읽음 처리 동기화 실패",
                     content = @Content(schema = @Schema(hidden = true)))
     })
     ResponseEntity<Void> markMessageAsRead(
@@ -141,6 +145,8 @@ public interface InboxControllerDocs {
             @ApiResponse(responseCode = "403", description = "메시지 접근 권한 없음",
                     content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", description = "메시지를 찾을 수 없음",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "502", description = "Gmail 메시지 안읽음 처리 동기화 실패",
                     content = @Content(schema = @Schema(hidden = true)))
     })
     ResponseEntity<Void> markMessageAsUnread(
@@ -161,6 +167,8 @@ public interface InboxControllerDocs {
             @ApiResponse(responseCode = "403", description = "스레드 접근 권한 없음",
                     content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", description = "스레드를 찾을 수 없음",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "502", description = "Gmail 안읽음 처리 동기화 실패",
                     content = @Content(schema = @Schema(hidden = true)))
     })
     ResponseEntity<Void> markThreadAsUnread(

--- a/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
@@ -110,6 +110,26 @@ public interface InboxControllerDocs {
     );
 
     @Operation(
+            summary = "메일 스레드 안읽음 처리",
+            description = "특정 스레드를 안읽음 처리합니다. 대상 스레드는 INBOUND, OUTBOUND 모두 가능합니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "스레드 안읽음 처리 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "스레드 접근 권한 없음",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "스레드를 찾을 수 없음",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<Void> markThreadAsUnread(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "스레드 내부 ID", required = true)
+            @PathVariable UUID threadId
+    );
+
+    @Operation(
             summary = "읽지 않은 스레드 수 조회",
             description = "로그인한 사용자의 모든 메일 계정에서 읽지 않은 수신 스레드 수를 반환합니다.",
             security = @SecurityRequirement(name = "cookieAuth")

--- a/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
@@ -130,6 +130,26 @@ public interface InboxControllerDocs {
     );
 
     @Operation(
+            summary = "메일 메시지 안읽음 처리",
+            description = "특정 메시지를 안읽음 처리합니다. 대상 메시지가 속한 스레드도 안읽음 처리합니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "메시지 안읽음 처리 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "메시지 접근 권한 없음",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "메시지를 찾을 수 없음",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<Void> markMessageAsUnread(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "메시지 내부 ID", required = true)
+            @PathVariable UUID messageId
+    );
+
+    @Operation(
             summary = "메일 스레드 안읽음 처리",
             description = "특정 스레드를 안읽음 처리합니다. 대상 스레드는 INBOUND, OUTBOUND 모두 가능합니다.",
             security = @SecurityRequirement(name = "cookieAuth")

--- a/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/InboxControllerDocs.java
@@ -110,6 +110,26 @@ public interface InboxControllerDocs {
     );
 
     @Operation(
+            summary = "메일 메시지 읽음 처리",
+            description = "특정 메시지를 읽음 처리합니다. 해당 스레드의 모든 메시지가 읽음이면 스레드도 읽음 처리합니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "메시지 읽음 처리 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "메시지 접근 권한 없음",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "메시지를 찾을 수 없음",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<Void> markMessageAsRead(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "메시지 내부 ID", required = true)
+            @PathVariable UUID messageId
+    );
+
+    @Operation(
             summary = "메일 스레드 안읽음 처리",
             description = "특정 스레드를 안읽음 처리합니다. 대상 스레드는 INBOUND, OUTBOUND 모두 가능합니다.",
             security = @SecurityRequirement(name = "cookieAuth")

--- a/core/src/main/java/com/mailsangja/core/dto/mail/GoogleMailUnreadModifyRequest.java
+++ b/core/src/main/java/com/mailsangja/core/dto/mail/GoogleMailUnreadModifyRequest.java
@@ -1,0 +1,8 @@
+package com.mailsangja.core.dto.mail;
+
+import java.util.List;
+
+public record GoogleMailUnreadModifyRequest(
+        List<String> addLabelIds
+) {
+}

--- a/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
@@ -12,6 +12,7 @@ import com.mailsangja.core.dto.inbox.ThreadDetailResult;
 import com.mailsangja.core.dto.inbox.ThreadListResult;
 import com.mailsangja.core.service.mail.MailAccountQueryService;
 import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.MailProvider;
 import com.mailsangja.db.entity.mail.Thread;
 import com.mailsangja.db.entity.user.User;
@@ -57,6 +58,15 @@ public class InboxFacade {
             googleMailReadCommandService.markThreadAsRead(thread.getMailAccount(), thread);
         }
         inboxCommandService.markThreadAsRead(thread);
+    }
+
+    public void markMessageAsRead(User user, UUID messageId) {
+        Message message = inboxQueryService.findActiveMessageById(messageId);
+        validateThreadAccess(mailAccountQueryService.findAllActiveByUserId(user.getId()), message.getThread());
+        if (message.getThread().getMailAccount().getProvider() == MailProvider.GMAIL) {
+            googleMailReadCommandService.markMessageAsRead(message.getThread().getMailAccount(), message);
+        }
+        inboxCommandService.markMessageAsRead(message);
     }
 
     public void markThreadAsUnread(User user, UUID threadId) {

--- a/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
@@ -69,6 +69,15 @@ public class InboxFacade {
         inboxCommandService.markMessageAsRead(message);
     }
 
+    public void markMessageAsUnread(User user, UUID messageId) {
+        Message message = inboxQueryService.findActiveMessageById(messageId);
+        validateThreadAccess(mailAccountQueryService.findAllActiveByUserId(user.getId()), message.getThread());
+        if (message.getThread().getMailAccount().getProvider() == MailProvider.GMAIL) {
+            googleMailReadCommandService.markMessageAsUnread(message.getThread().getMailAccount(), message);
+        }
+        inboxCommandService.markMessageAsUnread(message);
+    }
+
     public void markThreadAsUnread(User user, UUID threadId) {
         Thread thread = inboxQueryService.findThreadById(threadId);
         validateThreadAccess(mailAccountQueryService.findAllActiveByUserId(user.getId()), thread);

--- a/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
@@ -59,6 +59,15 @@ public class InboxFacade {
         inboxCommandService.markThreadAsRead(thread);
     }
 
+    public void markThreadAsUnread(User user, UUID threadId) {
+        Thread thread = inboxQueryService.findThreadById(threadId);
+        validateThreadAccess(mailAccountQueryService.findAllActiveByUserId(user.getId()), thread);
+        if (thread.getMailAccount().getProvider() == MailProvider.GMAIL) {
+            googleMailReadCommandService.markThreadAsUnread(thread.getMailAccount(), thread);
+        }
+        inboxCommandService.markThreadAsUnread(thread);
+    }
+
     public long getUnreadCount(User user) {
         return inboxQueryService.countUnreadInbox(user.getId());
     }

--- a/core/src/main/java/com/mailsangja/core/service/google/GoogleMailReadCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/google/GoogleMailReadCommandService.java
@@ -37,94 +37,80 @@ public class GoogleMailReadCommandService {
     }
 
     public void markThreadAsRead(MailAccount mailAccount, Thread thread) {
-        validateInput(mailAccount, thread, MailAccountErrorCode.GOOGLE_MAIL_READ_MODIFY_FAILED);
+        MailAccountErrorCode errorCode = MailAccountErrorCode.GOOGLE_MAIL_READ_MODIFY_FAILED;
+        validateInput(mailAccount, thread, errorCode);
 
         GoogleMailReadModifyRequest request = new GoogleMailReadModifyRequest(REMOVE_UNREAD_LABEL_IDS);
-
-        try {
-            googleMailRestClient
-                    .post()
-                    .uri(
-                            googleMailProperties.getThreadModifyUri(),
-                            Map.of("gmailThreadId", thread.getGmailThreadId())
-                    )
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + mailAccount.getAccessToken())
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .body(request)
-                    .retrieve()
-                    .toBodilessEntity();
-        } catch (RestClientException e) {
-            throw new MailAccountException(MailAccountErrorCode.GOOGLE_MAIL_READ_MODIFY_FAILED);
-        }
+        executeModifyRequest(
+                googleMailProperties.getThreadModifyUri(),
+                Map.of("gmailThreadId", thread.getGmailThreadId()),
+                mailAccount.getAccessToken(),
+                request,
+                errorCode
+        );
     }
 
     public void markMessageAsRead(MailAccount mailAccount, Message message) {
-        validateInput(mailAccount, message, MailAccountErrorCode.GOOGLE_MESSAGE_READ_MODIFY_FAILED);
+        MailAccountErrorCode errorCode = MailAccountErrorCode.GOOGLE_MESSAGE_READ_MODIFY_FAILED;
+        validateInput(mailAccount, message, errorCode);
 
         GoogleMailReadModifyRequest request = new GoogleMailReadModifyRequest(REMOVE_UNREAD_LABEL_IDS);
-
-        try {
-            googleMailRestClient
-                    .post()
-                    .uri(
-                            googleMailProperties.getMessageModifyUri(),
-                            Map.of("gmailMessageId", message.getGmailMessageId())
-                    )
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + mailAccount.getAccessToken())
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .body(request)
-                    .retrieve()
-                    .toBodilessEntity();
-        } catch (RestClientException e) {
-            throw new MailAccountException(MailAccountErrorCode.GOOGLE_MESSAGE_READ_MODIFY_FAILED);
-        }
+        executeModifyRequest(
+                googleMailProperties.getMessageModifyUri(),
+                Map.of("gmailMessageId", message.getGmailMessageId()),
+                mailAccount.getAccessToken(),
+                request,
+                errorCode
+        );
     }
 
     public void markMessageAsUnread(MailAccount mailAccount, Message message) {
-        validateInput(mailAccount, message, MailAccountErrorCode.GOOGLE_MESSAGE_UNREAD_MODIFY_FAILED);
+        MailAccountErrorCode errorCode = MailAccountErrorCode.GOOGLE_MESSAGE_UNREAD_MODIFY_FAILED;
+        validateInput(mailAccount, message, errorCode);
 
         GoogleMailUnreadModifyRequest request = new GoogleMailUnreadModifyRequest(ADD_UNREAD_LABEL_IDS);
-
-        try {
-            googleMailRestClient
-                    .post()
-                    .uri(
-                            googleMailProperties.getMessageModifyUri(),
-                            Map.of("gmailMessageId", message.getGmailMessageId())
-                    )
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + mailAccount.getAccessToken())
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .body(request)
-                    .retrieve()
-                    .toBodilessEntity();
-        } catch (RestClientException e) {
-            throw new MailAccountException(MailAccountErrorCode.GOOGLE_MESSAGE_UNREAD_MODIFY_FAILED);
-        }
+        executeModifyRequest(
+                googleMailProperties.getMessageModifyUri(),
+                Map.of("gmailMessageId", message.getGmailMessageId()),
+                mailAccount.getAccessToken(),
+                request,
+                errorCode
+        );
     }
 
     public void markThreadAsUnread(MailAccount mailAccount, Thread thread) {
-        validateInput(mailAccount, thread, MailAccountErrorCode.GOOGLE_MAIL_UNREAD_MODIFY_FAILED);
+        MailAccountErrorCode errorCode = MailAccountErrorCode.GOOGLE_MAIL_UNREAD_MODIFY_FAILED;
+        validateInput(mailAccount, thread, errorCode);
 
         GoogleMailUnreadModifyRequest request = new GoogleMailUnreadModifyRequest(ADD_UNREAD_LABEL_IDS);
+        executeModifyRequest(
+                googleMailProperties.getThreadModifyUri(),
+                Map.of("gmailThreadId", thread.getGmailThreadId()),
+                mailAccount.getAccessToken(),
+                request,
+                errorCode
+        );
+    }
 
+    private void executeModifyRequest(
+            String uri,
+            Map<String, String> uriVariables,
+            String accessToken,
+            Object request,
+            MailAccountErrorCode errorCode
+    ) {
         try {
             googleMailRestClient
                     .post()
-                    .uri(
-                            googleMailProperties.getThreadModifyUri(),
-                            Map.of("gmailThreadId", thread.getGmailThreadId())
-                    )
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + mailAccount.getAccessToken())
+                    .uri(uri, uriVariables)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
                     .body(request)
                     .retrieve()
                     .toBodilessEntity();
         } catch (RestClientException e) {
-            throw new MailAccountException(MailAccountErrorCode.GOOGLE_MAIL_UNREAD_MODIFY_FAILED);
+            throw new MailAccountException(errorCode);
         }
     }
 

--- a/core/src/main/java/com/mailsangja/core/service/google/GoogleMailReadCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/google/GoogleMailReadCommandService.java
@@ -6,6 +6,7 @@ import com.mailsangja.core.config.properties.GoogleMailProperties;
 import com.mailsangja.core.dto.mail.GoogleMailReadModifyRequest;
 import com.mailsangja.core.dto.mail.GoogleMailUnreadModifyRequest;
 import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.MailProvider;
 import com.mailsangja.db.entity.mail.Thread;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -58,6 +59,29 @@ public class GoogleMailReadCommandService {
         }
     }
 
+    public void markMessageAsRead(MailAccount mailAccount, Message message) {
+        validateInput(mailAccount, message, MailAccountErrorCode.GOOGLE_MESSAGE_READ_MODIFY_FAILED);
+
+        GoogleMailReadModifyRequest request = new GoogleMailReadModifyRequest(REMOVE_UNREAD_LABEL_IDS);
+
+        try {
+            googleMailRestClient
+                    .post()
+                    .uri(
+                            googleMailProperties.getMessageModifyUri(),
+                            Map.of("gmailMessageId", message.getGmailMessageId())
+                    )
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + mailAccount.getAccessToken())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (RestClientException e) {
+            throw new MailAccountException(MailAccountErrorCode.GOOGLE_MESSAGE_READ_MODIFY_FAILED);
+        }
+    }
+
     public void markThreadAsUnread(MailAccount mailAccount, Thread thread) {
         validateInput(mailAccount, thread, MailAccountErrorCode.GOOGLE_MAIL_UNREAD_MODIFY_FAILED);
 
@@ -88,6 +112,17 @@ public class GoogleMailReadCommandService {
                 || isBlank(mailAccount.getAccessToken())
                 || isBlank(thread.getGmailThreadId())
                 || isBlank(googleMailProperties.getThreadModifyUri())) {
+            throw new MailAccountException(errorCode);
+        }
+    }
+
+    private void validateInput(MailAccount mailAccount, Message message, MailAccountErrorCode errorCode) {
+        if (mailAccount == null
+                || message == null
+                || mailAccount.getProvider() != MailProvider.GMAIL
+                || isBlank(mailAccount.getAccessToken())
+                || isBlank(message.getGmailMessageId())
+                || isBlank(googleMailProperties.getMessageModifyUri())) {
             throw new MailAccountException(errorCode);
         }
     }

--- a/core/src/main/java/com/mailsangja/core/service/google/GoogleMailReadCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/google/GoogleMailReadCommandService.java
@@ -82,6 +82,29 @@ public class GoogleMailReadCommandService {
         }
     }
 
+    public void markMessageAsUnread(MailAccount mailAccount, Message message) {
+        validateInput(mailAccount, message, MailAccountErrorCode.GOOGLE_MESSAGE_UNREAD_MODIFY_FAILED);
+
+        GoogleMailUnreadModifyRequest request = new GoogleMailUnreadModifyRequest(ADD_UNREAD_LABEL_IDS);
+
+        try {
+            googleMailRestClient
+                    .post()
+                    .uri(
+                            googleMailProperties.getMessageModifyUri(),
+                            Map.of("gmailMessageId", message.getGmailMessageId())
+                    )
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + mailAccount.getAccessToken())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (RestClientException e) {
+            throw new MailAccountException(MailAccountErrorCode.GOOGLE_MESSAGE_UNREAD_MODIFY_FAILED);
+        }
+    }
+
     public void markThreadAsUnread(MailAccount mailAccount, Thread thread) {
         validateInput(mailAccount, thread, MailAccountErrorCode.GOOGLE_MAIL_UNREAD_MODIFY_FAILED);
 

--- a/core/src/main/java/com/mailsangja/core/service/google/GoogleMailReadCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/google/GoogleMailReadCommandService.java
@@ -4,6 +4,7 @@ import com.mailsangja.core.common.exception.mail.MailAccountErrorCode;
 import com.mailsangja.core.common.exception.mail.MailAccountException;
 import com.mailsangja.core.config.properties.GoogleMailProperties;
 import com.mailsangja.core.dto.mail.GoogleMailReadModifyRequest;
+import com.mailsangja.core.dto.mail.GoogleMailUnreadModifyRequest;
 import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.MailProvider;
 import com.mailsangja.db.entity.mail.Thread;
@@ -21,6 +22,7 @@ import java.util.Map;
 public class GoogleMailReadCommandService {
 
     private static final List<String> REMOVE_UNREAD_LABEL_IDS = List.of("UNREAD");
+    private static final List<String> ADD_UNREAD_LABEL_IDS = List.of("UNREAD");
 
     private final GoogleMailProperties googleMailProperties;
     private final RestClient googleMailRestClient;
@@ -34,7 +36,7 @@ public class GoogleMailReadCommandService {
     }
 
     public void markThreadAsRead(MailAccount mailAccount, Thread thread) {
-        validateInput(mailAccount, thread);
+        validateInput(mailAccount, thread, MailAccountErrorCode.GOOGLE_MAIL_READ_MODIFY_FAILED);
 
         GoogleMailReadModifyRequest request = new GoogleMailReadModifyRequest(REMOVE_UNREAD_LABEL_IDS);
 
@@ -56,14 +58,37 @@ public class GoogleMailReadCommandService {
         }
     }
 
-    private void validateInput(MailAccount mailAccount, Thread thread) {
+    public void markThreadAsUnread(MailAccount mailAccount, Thread thread) {
+        validateInput(mailAccount, thread, MailAccountErrorCode.GOOGLE_MAIL_UNREAD_MODIFY_FAILED);
+
+        GoogleMailUnreadModifyRequest request = new GoogleMailUnreadModifyRequest(ADD_UNREAD_LABEL_IDS);
+
+        try {
+            googleMailRestClient
+                    .post()
+                    .uri(
+                            googleMailProperties.getThreadModifyUri(),
+                            Map.of("gmailThreadId", thread.getGmailThreadId())
+                    )
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + mailAccount.getAccessToken())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (RestClientException e) {
+            throw new MailAccountException(MailAccountErrorCode.GOOGLE_MAIL_UNREAD_MODIFY_FAILED);
+        }
+    }
+
+    private void validateInput(MailAccount mailAccount, Thread thread, MailAccountErrorCode errorCode) {
         if (mailAccount == null
                 || thread == null
                 || mailAccount.getProvider() != MailProvider.GMAIL
                 || isBlank(mailAccount.getAccessToken())
                 || isBlank(thread.getGmailThreadId())
                 || isBlank(googleMailProperties.getThreadModifyUri())) {
-            throw new MailAccountException(MailAccountErrorCode.GOOGLE_MAIL_READ_MODIFY_FAILED);
+            throw new MailAccountException(errorCode);
         }
     }
 

--- a/core/src/main/java/com/mailsangja/core/service/inbox/InboxCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/inbox/InboxCommandService.java
@@ -56,6 +56,19 @@ public class InboxCommandService {
     }
 
     @Transactional
+    public void markMessageAsUnread(Message message) {
+        gmailThreadLockRepositoryPort.acquireThreadLock(message.getThread().getMailAccount(), message.getThread().getGmailThreadId());
+
+        message.markAsUnread();
+
+        List<Thread> threads = threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
+                message.getThread().getMailAccount().getId(),
+                message.getThread().getGmailThreadId()
+        );
+        threads.forEach(thread -> thread.updateReadStatus(false));
+    }
+
+    @Transactional
     public void markThreadAsUnread(Thread thread) {
         gmailThreadLockRepositoryPort.acquireThreadLock(thread.getMailAccount(), thread.getGmailThreadId());
 

--- a/core/src/main/java/com/mailsangja/core/service/inbox/InboxCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/inbox/InboxCommandService.java
@@ -31,4 +31,19 @@ public class InboxCommandService {
         );
         messages.forEach(Message::markAsRead);
     }
+
+    @Transactional
+    public void markThreadAsUnread(Thread thread) {
+        List<Thread> threads = threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
+                thread.getMailAccount().getId(),
+                thread.getGmailThreadId()
+        );
+        threads.forEach(targetThread -> targetThread.updateReadStatus(false));
+
+        List<Message> messages = messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
+                thread.getMailAccount().getId(),
+                thread.getGmailThreadId()
+        );
+        messages.forEach(Message::markAsUnread);
+    }
 }

--- a/core/src/main/java/com/mailsangja/core/service/inbox/InboxCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/inbox/InboxCommandService.java
@@ -2,6 +2,7 @@ package com.mailsangja.core.service.inbox;
 
 import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.Thread;
+import com.mailsangja.db.port.GmailThreadLockRepositoryPort;
 import com.mailsangja.db.port.MessageRepositoryPort;
 import com.mailsangja.db.port.ThreadRepositoryPort;
 import lombok.RequiredArgsConstructor;
@@ -14,11 +15,14 @@ import java.util.List;
 @RequiredArgsConstructor
 public class InboxCommandService {
 
+    private final GmailThreadLockRepositoryPort gmailThreadLockRepositoryPort;
     private final MessageRepositoryPort messageRepositoryPort;
     private final ThreadRepositoryPort threadRepositoryPort;
 
     @Transactional
     public void markThreadAsRead(Thread thread) {
+        gmailThreadLockRepositoryPort.acquireThreadLock(thread.getMailAccount(), thread.getGmailThreadId());
+
         List<Thread> threads = threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
                 thread.getMailAccount().getId(),
                 thread.getGmailThreadId()
@@ -33,7 +37,28 @@ public class InboxCommandService {
     }
 
     @Transactional
+    public void markMessageAsRead(Message message) {
+        gmailThreadLockRepositoryPort.acquireThreadLock(message.getThread().getMailAccount(), message.getThread().getGmailThreadId());
+
+        message.markAsRead();
+
+        List<Message> messages = messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
+                message.getThread().getMailAccount().getId(),
+                message.getThread().getGmailThreadId()
+        );
+        boolean allMessagesRead = messages.stream().allMatch(Message::isRead);
+
+        List<Thread> threads = threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
+                message.getThread().getMailAccount().getId(),
+                message.getThread().getGmailThreadId()
+        );
+        threads.forEach(thread -> thread.updateReadStatus(allMessagesRead));
+    }
+
+    @Transactional
     public void markThreadAsUnread(Thread thread) {
+        gmailThreadLockRepositoryPort.acquireThreadLock(thread.getMailAccount(), thread.getGmailThreadId());
+
         List<Thread> threads = threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
                 thread.getMailAccount().getId(),
                 thread.getGmailThreadId()

--- a/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
@@ -36,6 +36,15 @@ public class InboxQueryService {
                 .orElseThrow(() -> new InboxException(InboxErrorCode.THREAD_NOT_FOUND));
     }
 
+    public Message findActiveMessageById(UUID messageId) {
+        Message message = messageRepositoryPort.findByIdIncludingDeleted(messageId)
+                .orElseThrow(() -> new InboxException(InboxErrorCode.MESSAGE_NOT_FOUND));
+        if (message.isDeleted()) {
+            throw new InboxException(InboxErrorCode.MESSAGE_NOT_FOUND);
+        }
+        return message;
+    }
+
     public ThreadListResult findInboxThreadsResult(UUID userId, UUID markerId, Pageable pageable) {
         Slice<Thread> threads = threadRepositoryPort.findInboxByUserIdAndDeletedAtIsNull(userId, markerId, pageable);
         return buildThreadListResult(threads);

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -83,6 +83,7 @@ mailsangja:
       topic-name: ${GOOGLE_GMAIL_WATCH_TOPIC_NAME:projects/local/topics/mailbox-gmail-watch}
       watch-uri: ${GOOGLE_GMAIL_WATCH_URI:https://gmail.googleapis.com/gmail/v1/users/me/watch}
       thread-modify-uri: ${GOOGLE_GMAIL_THREAD_MODIFY_URI:https://gmail.googleapis.com/gmail/v1/users/me/threads/{gmailThreadId}/modify}
+      message-modify-uri: ${GOOGLE_GMAIL_MESSAGE_MODIFY_URI:https://gmail.googleapis.com/gmail/v1/users/me/messages/{gmailMessageId}/modify}
       send-uri: ${GOOGLE_GMAIL_SEND_URI:https://gmail.googleapis.com/gmail/v1/users/me/messages/send}
       messages-uri: ${GOOGLE_GMAIL_MESSAGES_URI:https://gmail.googleapis.com/gmail/v1/users/me/messages}
       attachments-uri: ${GOOGLE_GMAIL_ATTACHMENTS_URI:https://gmail.googleapis.com/gmail/v1/users/me/messages}

--- a/core/src/test/java/com/mailsangja/core/service/google/GoogleMailReadCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/google/GoogleMailReadCommandServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.mock.http.client.MockClientHttpRequest;
 import org.springframework.mock.http.client.MockClientHttpResponse;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.ResourceAccessException;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -140,6 +141,24 @@ class GoogleMailReadCommandServiceTest {
         assertEquals(MailAccountErrorCode.GOOGLE_MESSAGE_UNREAD_MODIFY_FAILED, exception.getErrorCode());
     }
 
+    @Test
+    void markMessageAsUnread_호출실패시동일한에러코드로예외를반환한다() {
+        GoogleMailProperties properties = new GoogleMailProperties();
+        properties.setMessageModifyUri("https://gmail.googleapis.com/gmail/v1/users/me/messages/{gmailMessageId}/modify");
+
+        GoogleMailReadCommandService service = new GoogleMailReadCommandService(
+                properties,
+                RestClient.builder().requestFactory(new FailingClientHttpRequestFactory()).build()
+        );
+
+        MailAccountException exception = assertThrows(
+                MailAccountException.class,
+                () -> service.markMessageAsUnread(createMailAccount(), createMessage())
+        );
+
+        assertEquals(MailAccountErrorCode.GOOGLE_MESSAGE_UNREAD_MODIFY_FAILED, exception.getErrorCode());
+    }
+
     private MailAccount createMailAccount() {
         return MailAccount.builder()
                 .id(UUID.randomUUID())
@@ -193,6 +212,18 @@ class GoogleMailReadCommandServiceTest {
 
         private String requestBody() {
             return requestBody;
+        }
+    }
+
+    private static final class FailingClientHttpRequestFactory extends SimpleClientHttpRequestFactory {
+        @Override
+        public ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod) {
+            return new MockClientHttpRequest(httpMethod, uri) {
+                @Override
+                protected ClientHttpResponse executeInternal() {
+                    throw new ResourceAccessException("failed");
+                }
+            };
         }
     }
 }

--- a/core/src/test/java/com/mailsangja/core/service/google/GoogleMailReadCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/google/GoogleMailReadCommandServiceTest.java
@@ -77,6 +77,22 @@ class GoogleMailReadCommandServiceTest {
     }
 
     @Test
+    void markMessageAsUnread_UNREAD라벨을추가한다() {
+        GoogleMailProperties properties = new GoogleMailProperties();
+        properties.setMessageModifyUri("https://gmail.googleapis.com/gmail/v1/users/me/messages/{gmailMessageId}/modify");
+        CapturingClientHttpRequestFactory requestFactory = new CapturingClientHttpRequestFactory();
+
+        GoogleMailReadCommandService service = new GoogleMailReadCommandService(
+                properties,
+                RestClient.builder().requestFactory(requestFactory).build()
+        );
+
+        service.markMessageAsUnread(createMailAccount(), createMessage());
+
+        assertTrue(requestFactory.requestBody().contains("\"addLabelIds\":[\"UNREAD\"]"));
+    }
+
+    @Test
     void markThreadAsUnread_유효하지않은입력이면예외가발생한다() {
         GoogleMailProperties properties = new GoogleMailProperties();
         GoogleMailReadCommandService service = new GoogleMailReadCommandService(
@@ -106,6 +122,22 @@ class GoogleMailReadCommandServiceTest {
         );
 
         assertEquals(MailAccountErrorCode.GOOGLE_MESSAGE_READ_MODIFY_FAILED, exception.getErrorCode());
+    }
+
+    @Test
+    void markMessageAsUnread_유효하지않은입력이면예외가발생한다() {
+        GoogleMailProperties properties = new GoogleMailProperties();
+        GoogleMailReadCommandService service = new GoogleMailReadCommandService(
+                properties,
+                RestClient.builder().build()
+        );
+
+        MailAccountException exception = assertThrows(
+                MailAccountException.class,
+                () -> service.markMessageAsUnread(createMailAccount(), createMessage())
+        );
+
+        assertEquals(MailAccountErrorCode.GOOGLE_MESSAGE_UNREAD_MODIFY_FAILED, exception.getErrorCode());
     }
 
     private MailAccount createMailAccount() {

--- a/core/src/test/java/com/mailsangja/core/service/google/GoogleMailReadCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/google/GoogleMailReadCommandServiceTest.java
@@ -1,0 +1,121 @@
+package com.mailsangja.core.service.google;
+
+import com.mailsangja.core.common.exception.mail.MailAccountException;
+import com.mailsangja.core.common.exception.mail.MailAccountErrorCode;
+import com.mailsangja.core.config.properties.GoogleMailProperties;
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.MailProvider;
+import com.mailsangja.db.entity.mail.Thread;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+import org.springframework.web.client.RestClient;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GoogleMailReadCommandServiceTest {
+
+    @Test
+    void markThreadAsRead_UNREAD라벨을제거한다() {
+        GoogleMailProperties properties = new GoogleMailProperties();
+        properties.setThreadModifyUri("https://gmail.googleapis.com/gmail/v1/users/me/threads/{gmailThreadId}/modify");
+        CapturingClientHttpRequestFactory requestFactory = new CapturingClientHttpRequestFactory();
+
+        GoogleMailReadCommandService service = new GoogleMailReadCommandService(
+                properties,
+                RestClient.builder().requestFactory(requestFactory).build()
+        );
+
+        service.markThreadAsRead(createMailAccount(), createThread());
+
+        assertTrue(requestFactory.requestBody().contains("\"removeLabelIds\":[\"UNREAD\"]"));
+    }
+
+    @Test
+    void markThreadAsUnread_UNREAD라벨을추가한다() {
+        GoogleMailProperties properties = new GoogleMailProperties();
+        properties.setThreadModifyUri("https://gmail.googleapis.com/gmail/v1/users/me/threads/{gmailThreadId}/modify");
+        CapturingClientHttpRequestFactory requestFactory = new CapturingClientHttpRequestFactory();
+
+        GoogleMailReadCommandService service = new GoogleMailReadCommandService(
+                properties,
+                RestClient.builder().requestFactory(requestFactory).build()
+        );
+
+        service.markThreadAsUnread(createMailAccount(), createThread());
+
+        assertTrue(requestFactory.requestBody().contains("\"addLabelIds\":[\"UNREAD\"]"));
+    }
+
+    @Test
+    void markThreadAsUnread_유효하지않은입력이면예외가발생한다() {
+        GoogleMailProperties properties = new GoogleMailProperties();
+        GoogleMailReadCommandService service = new GoogleMailReadCommandService(
+                properties,
+                RestClient.builder().build()
+        );
+
+        MailAccountException exception = assertThrows(
+                MailAccountException.class,
+                () -> service.markThreadAsUnread(createMailAccount(), createThread())
+        );
+
+        assertEquals(MailAccountErrorCode.GOOGLE_MAIL_UNREAD_MODIFY_FAILED, exception.getErrorCode());
+    }
+
+    private MailAccount createMailAccount() {
+        return MailAccount.builder()
+                .id(UUID.randomUUID())
+                .provider(MailProvider.GMAIL)
+                .emailAddress("user@example.com")
+                .alias("gmail")
+                .icon("gmail")
+                .color("#4285F4")
+                .accessToken("access-token")
+                .build();
+    }
+
+    private Thread createThread() {
+        return Thread.builder()
+                .id(UUID.randomUUID())
+                .mailAccount(createMailAccount())
+                .gmailThreadId("gmail-thread-id")
+                .build();
+    }
+
+    private static final class CapturingClientHttpRequestFactory extends SimpleClientHttpRequestFactory {
+        private String requestBody;
+
+        @Override
+        public ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod) {
+            return new MockClientHttpRequest(httpMethod, uri) {
+                @Override
+                protected ClientHttpResponse executeInternal() {
+                    requestBody = getBodyAsString();
+                    MockClientHttpResponse response = new MockClientHttpResponse(
+                            "{}".getBytes(StandardCharsets.UTF_8),
+                            HttpStatus.OK
+                    );
+                    response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+                    return response;
+                }
+            };
+        }
+
+        private String requestBody() {
+            return requestBody;
+        }
+    }
+}

--- a/core/src/test/java/com/mailsangja/core/service/google/GoogleMailReadCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/google/GoogleMailReadCommandServiceTest.java
@@ -4,6 +4,7 @@ import com.mailsangja.core.common.exception.mail.MailAccountException;
 import com.mailsangja.core.common.exception.mail.MailAccountErrorCode;
 import com.mailsangja.core.config.properties.GoogleMailProperties;
 import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.MailProvider;
 import com.mailsangja.db.entity.mail.Thread;
 import org.junit.jupiter.api.Test;
@@ -60,6 +61,22 @@ class GoogleMailReadCommandServiceTest {
     }
 
     @Test
+    void markMessageAsRead_UNREAD라벨을제거한다() {
+        GoogleMailProperties properties = new GoogleMailProperties();
+        properties.setMessageModifyUri("https://gmail.googleapis.com/gmail/v1/users/me/messages/{gmailMessageId}/modify");
+        CapturingClientHttpRequestFactory requestFactory = new CapturingClientHttpRequestFactory();
+
+        GoogleMailReadCommandService service = new GoogleMailReadCommandService(
+                properties,
+                RestClient.builder().requestFactory(requestFactory).build()
+        );
+
+        service.markMessageAsRead(createMailAccount(), createMessage());
+
+        assertTrue(requestFactory.requestBody().contains("\"removeLabelIds\":[\"UNREAD\"]"));
+    }
+
+    @Test
     void markThreadAsUnread_유효하지않은입력이면예외가발생한다() {
         GoogleMailProperties properties = new GoogleMailProperties();
         GoogleMailReadCommandService service = new GoogleMailReadCommandService(
@@ -73,6 +90,22 @@ class GoogleMailReadCommandServiceTest {
         );
 
         assertEquals(MailAccountErrorCode.GOOGLE_MAIL_UNREAD_MODIFY_FAILED, exception.getErrorCode());
+    }
+
+    @Test
+    void markMessageAsRead_유효하지않은입력이면예외가발생한다() {
+        GoogleMailProperties properties = new GoogleMailProperties();
+        GoogleMailReadCommandService service = new GoogleMailReadCommandService(
+                properties,
+                RestClient.builder().build()
+        );
+
+        MailAccountException exception = assertThrows(
+                MailAccountException.class,
+                () -> service.markMessageAsRead(createMailAccount(), createMessage())
+        );
+
+        assertEquals(MailAccountErrorCode.GOOGLE_MESSAGE_READ_MODIFY_FAILED, exception.getErrorCode());
     }
 
     private MailAccount createMailAccount() {
@@ -92,6 +125,18 @@ class GoogleMailReadCommandServiceTest {
                 .id(UUID.randomUUID())
                 .mailAccount(createMailAccount())
                 .gmailThreadId("gmail-thread-id")
+                .build();
+    }
+
+    private Message createMessage() {
+        Thread thread = createThread();
+        return Message.builder()
+                .id(UUID.randomUUID())
+                .thread(thread)
+                .gmailMessageId("gmail-message-id")
+                .direction(com.mailsangja.db.entity.mail.Direction.INBOUND)
+                .fromAddress("sender@example.com")
+                .read(false)
                 .build();
     }
 

--- a/core/src/test/java/com/mailsangja/core/service/inbox/InboxCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/inbox/InboxCommandServiceTest.java
@@ -5,6 +5,7 @@ import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.MailProvider;
 import com.mailsangja.db.entity.mail.Thread;
+import com.mailsangja.db.port.GmailThreadLockRepositoryPort;
 import com.mailsangja.db.port.MessageRepositoryPort;
 import com.mailsangja.db.port.ThreadRepositoryPort;
 import org.junit.jupiter.api.Test;
@@ -16,11 +17,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class InboxCommandServiceTest {
+
+    @Mock
+    private GmailThreadLockRepositoryPort gmailThreadLockRepositoryPort;
 
     @Mock
     private MessageRepositoryPort messageRepositoryPort;
@@ -81,6 +87,7 @@ class InboxCommandServiceTest {
 
         inboxCommandService.markThreadAsRead(inboundThread);
 
+        verify(gmailThreadLockRepositoryPort).acquireThreadLock(mailAccount, gmailThreadId);
         assertTrue(inboundThread.isRead());
         assertTrue(outboundThread.isRead());
         assertTrue(inboundMessage.isRead());
@@ -123,6 +130,7 @@ class InboxCommandServiceTest {
 
         inboxCommandService.markThreadAsRead(thread);
 
+        verify(gmailThreadLockRepositoryPort).acquireThreadLock(mailAccount, gmailThreadId);
         assertTrue(thread.isRead());
         assertTrue(readMessage.isRead());
     }
@@ -177,6 +185,7 @@ class InboxCommandServiceTest {
 
         inboxCommandService.markThreadAsUnread(inboundThread);
 
+        verify(gmailThreadLockRepositoryPort).acquireThreadLock(mailAccount, gmailThreadId);
         org.junit.jupiter.api.Assertions.assertFalse(inboundThread.isRead());
         org.junit.jupiter.api.Assertions.assertFalse(outboundThread.isRead());
         org.junit.jupiter.api.Assertions.assertFalse(inboundMessage.isRead());
@@ -219,7 +228,112 @@ class InboxCommandServiceTest {
 
         inboxCommandService.markThreadAsUnread(thread);
 
+        verify(gmailThreadLockRepositoryPort).acquireThreadLock(mailAccount, gmailThreadId);
         org.junit.jupiter.api.Assertions.assertFalse(thread.isRead());
         org.junit.jupiter.api.Assertions.assertFalse(unreadMessage.isRead());
+    }
+
+    @Test
+    void markMessageAsRead_모든메시지가읽음이면스레드도읽음처리한다() {
+        UUID mailAccountId = UUID.randomUUID();
+        String gmailThreadId = "gmail-thread-5";
+        MailAccount mailAccount = MailAccount.builder()
+                .id(mailAccountId)
+                .provider(MailProvider.GMAIL)
+                .emailAddress("user@example.com")
+                .alias("gmail")
+                .icon("gmail")
+                .color("#4285F4")
+                .accessToken("token")
+                .build();
+
+        Thread inboundThread = Thread.builder()
+                .id(UUID.randomUUID())
+                .mailAccount(mailAccount)
+                .gmailThreadId(gmailThreadId)
+                .direction(Direction.INBOUND)
+                .read(false)
+                .build();
+        Thread outboundThread = Thread.builder()
+                .id(UUID.randomUUID())
+                .mailAccount(mailAccount)
+                .gmailThreadId(gmailThreadId)
+                .direction(Direction.OUTBOUND)
+                .read(false)
+                .build();
+        Message targetMessage = Message.builder()
+                .thread(inboundThread)
+                .gmailMessageId("gmail-message-7")
+                .direction(Direction.INBOUND)
+                .fromAddress("sender@example.com")
+                .read(false)
+                .build();
+        Message alreadyReadMessage = Message.builder()
+                .thread(outboundThread)
+                .gmailMessageId("gmail-message-8")
+                .direction(Direction.OUTBOUND)
+                .fromAddress("sender@example.com")
+                .read(true)
+                .build();
+
+        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, gmailThreadId))
+                .thenReturn(List.of(targetMessage, alreadyReadMessage));
+        when(threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, gmailThreadId))
+                .thenReturn(List.of(inboundThread, outboundThread));
+
+        inboxCommandService.markMessageAsRead(targetMessage);
+
+        verify(gmailThreadLockRepositoryPort).acquireThreadLock(mailAccount, gmailThreadId);
+        assertTrue(targetMessage.isRead());
+        assertTrue(inboundThread.isRead());
+        assertTrue(outboundThread.isRead());
+    }
+
+    @Test
+    void markMessageAsRead_안읽은메시지가남아있으면스레드는안읽음으로유지한다() {
+        UUID mailAccountId = UUID.randomUUID();
+        String gmailThreadId = "gmail-thread-6";
+        MailAccount mailAccount = MailAccount.builder()
+                .id(mailAccountId)
+                .provider(MailProvider.GMAIL)
+                .emailAddress("user@example.com")
+                .alias("gmail")
+                .icon("gmail")
+                .color("#4285F4")
+                .accessToken("token")
+                .build();
+
+        Thread thread = Thread.builder()
+                .id(UUID.randomUUID())
+                .mailAccount(mailAccount)
+                .gmailThreadId(gmailThreadId)
+                .direction(Direction.INBOUND)
+                .read(false)
+                .build();
+        Message targetMessage = Message.builder()
+                .thread(thread)
+                .gmailMessageId("gmail-message-9")
+                .direction(Direction.INBOUND)
+                .fromAddress("sender@example.com")
+                .read(false)
+                .build();
+        Message unreadSiblingMessage = Message.builder()
+                .thread(thread)
+                .gmailMessageId("gmail-message-10")
+                .direction(Direction.INBOUND)
+                .fromAddress("sender@example.com")
+                .read(false)
+                .build();
+
+        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, gmailThreadId))
+                .thenReturn(List.of(targetMessage, unreadSiblingMessage));
+        when(threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, gmailThreadId))
+                .thenReturn(List.of(thread));
+
+        inboxCommandService.markMessageAsRead(targetMessage);
+
+        verify(gmailThreadLockRepositoryPort).acquireThreadLock(mailAccount, gmailThreadId);
+        assertTrue(targetMessage.isRead());
+        assertFalse(thread.isRead());
     }
 }

--- a/core/src/test/java/com/mailsangja/core/service/inbox/InboxCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/inbox/InboxCommandServiceTest.java
@@ -336,4 +336,98 @@ class InboxCommandServiceTest {
         assertTrue(targetMessage.isRead());
         assertFalse(thread.isRead());
     }
+
+    @Test
+    void markMessageAsUnread_대상메시지를안읽음처리하고스레드도안읽음처리한다() {
+        UUID mailAccountId = UUID.randomUUID();
+        String gmailThreadId = "gmail-thread-7";
+        MailAccount mailAccount = MailAccount.builder()
+                .id(mailAccountId)
+                .provider(MailProvider.GMAIL)
+                .emailAddress("user@example.com")
+                .alias("gmail")
+                .icon("gmail")
+                .color("#4285F4")
+                .accessToken("token")
+                .build();
+
+        Thread inboundThread = Thread.builder()
+                .id(UUID.randomUUID())
+                .mailAccount(mailAccount)
+                .gmailThreadId(gmailThreadId)
+                .direction(Direction.INBOUND)
+                .read(true)
+                .build();
+        Thread outboundThread = Thread.builder()
+                .id(UUID.randomUUID())
+                .mailAccount(mailAccount)
+                .gmailThreadId(gmailThreadId)
+                .direction(Direction.OUTBOUND)
+                .read(true)
+                .build();
+        Message targetMessage = Message.builder()
+                .thread(inboundThread)
+                .gmailMessageId("gmail-message-11")
+                .direction(Direction.INBOUND)
+                .fromAddress("sender@example.com")
+                .read(true)
+                .build();
+        Message alreadyReadMessage = Message.builder()
+                .thread(outboundThread)
+                .gmailMessageId("gmail-message-12")
+                .direction(Direction.OUTBOUND)
+                .fromAddress("sender@example.com")
+                .read(true)
+                .build();
+
+        when(threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, gmailThreadId))
+                .thenReturn(List.of(inboundThread, outboundThread));
+
+        inboxCommandService.markMessageAsUnread(targetMessage);
+
+        verify(gmailThreadLockRepositoryPort).acquireThreadLock(mailAccount, gmailThreadId);
+        assertFalse(targetMessage.isRead());
+        assertTrue(alreadyReadMessage.isRead());
+        assertFalse(inboundThread.isRead());
+        assertFalse(outboundThread.isRead());
+    }
+
+    @Test
+    void markMessageAsUnread_이미안읽은메시지에도안전하게동작한다() {
+        UUID mailAccountId = UUID.randomUUID();
+        String gmailThreadId = "gmail-thread-8";
+        MailAccount mailAccount = MailAccount.builder()
+                .id(mailAccountId)
+                .provider(MailProvider.GMAIL)
+                .emailAddress("user@example.com")
+                .alias("gmail")
+                .icon("gmail")
+                .color("#4285F4")
+                .accessToken("token")
+                .build();
+
+        Thread thread = Thread.builder()
+                .id(UUID.randomUUID())
+                .mailAccount(mailAccount)
+                .gmailThreadId(gmailThreadId)
+                .direction(Direction.INBOUND)
+                .read(false)
+                .build();
+        Message unreadMessage = Message.builder()
+                .thread(thread)
+                .gmailMessageId("gmail-message-13")
+                .direction(Direction.INBOUND)
+                .fromAddress("sender@example.com")
+                .read(false)
+                .build();
+
+        when(threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, gmailThreadId))
+                .thenReturn(List.of(thread));
+
+        inboxCommandService.markMessageAsUnread(unreadMessage);
+
+        verify(gmailThreadLockRepositoryPort).acquireThreadLock(mailAccount, gmailThreadId);
+        assertFalse(unreadMessage.isRead());
+        assertFalse(thread.isRead());
+    }
 }

--- a/core/src/test/java/com/mailsangja/core/service/inbox/InboxCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/inbox/InboxCommandServiceTest.java
@@ -126,4 +126,100 @@ class InboxCommandServiceTest {
         assertTrue(thread.isRead());
         assertTrue(readMessage.isRead());
     }
+
+    @Test
+    void markThreadAsUnread_같은지메일스레드의양방향스레드와메시지를모두안읽음처리한다() {
+        UUID mailAccountId = UUID.randomUUID();
+        String gmailThreadId = "gmail-thread-3";
+        MailAccount mailAccount = MailAccount.builder()
+                .id(mailAccountId)
+                .provider(MailProvider.GMAIL)
+                .emailAddress("user@example.com")
+                .alias("gmail")
+                .icon("gmail")
+                .color("#4285F4")
+                .accessToken("token")
+                .build();
+
+        Thread inboundThread = Thread.builder()
+                .id(UUID.randomUUID())
+                .mailAccount(mailAccount)
+                .gmailThreadId(gmailThreadId)
+                .direction(Direction.INBOUND)
+                .read(true)
+                .build();
+        Thread outboundThread = Thread.builder()
+                .id(UUID.randomUUID())
+                .mailAccount(mailAccount)
+                .gmailThreadId(gmailThreadId)
+                .direction(Direction.OUTBOUND)
+                .read(true)
+                .build();
+        Message inboundMessage = Message.builder()
+                .thread(inboundThread)
+                .gmailMessageId("gmail-message-4")
+                .direction(Direction.INBOUND)
+                .fromAddress("sender@example.com")
+                .read(true)
+                .build();
+        Message outboundMessage = Message.builder()
+                .thread(outboundThread)
+                .gmailMessageId("gmail-message-5")
+                .direction(Direction.OUTBOUND)
+                .fromAddress("sender@example.com")
+                .read(true)
+                .build();
+
+        when(threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, gmailThreadId))
+                .thenReturn(List.of(inboundThread, outboundThread));
+        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, gmailThreadId))
+                .thenReturn(List.of(inboundMessage, outboundMessage));
+
+        inboxCommandService.markThreadAsUnread(inboundThread);
+
+        org.junit.jupiter.api.Assertions.assertFalse(inboundThread.isRead());
+        org.junit.jupiter.api.Assertions.assertFalse(outboundThread.isRead());
+        org.junit.jupiter.api.Assertions.assertFalse(inboundMessage.isRead());
+        org.junit.jupiter.api.Assertions.assertFalse(outboundMessage.isRead());
+    }
+
+    @Test
+    void markThreadAsUnread_이미안읽은메시지에도안전하게동작한다() {
+        UUID mailAccountId = UUID.randomUUID();
+        String gmailThreadId = "gmail-thread-4";
+        MailAccount mailAccount = MailAccount.builder()
+                .id(mailAccountId)
+                .provider(MailProvider.GMAIL)
+                .emailAddress("user@example.com")
+                .alias("gmail")
+                .icon("gmail")
+                .color("#4285F4")
+                .accessToken("token")
+                .build();
+
+        Thread thread = Thread.builder()
+                .id(UUID.randomUUID())
+                .mailAccount(mailAccount)
+                .gmailThreadId(gmailThreadId)
+                .direction(Direction.OUTBOUND)
+                .read(false)
+                .build();
+        Message unreadMessage = Message.builder()
+                .thread(thread)
+                .gmailMessageId("gmail-message-6")
+                .direction(Direction.OUTBOUND)
+                .fromAddress("sender@example.com")
+                .read(false)
+                .build();
+
+        when(threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, gmailThreadId))
+                .thenReturn(List.of(thread));
+        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, gmailThreadId))
+                .thenReturn(List.of(unreadMessage));
+
+        inboxCommandService.markThreadAsUnread(thread);
+
+        org.junit.jupiter.api.Assertions.assertFalse(thread.isRead());
+        org.junit.jupiter.api.Assertions.assertFalse(unreadMessage.isRead());
+    }
 }

--- a/worker/src/main/java/com/mailsangja/worker/common/exception/GlobalExceptionHandler.java
+++ b/worker/src/main/java/com/mailsangja/worker/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,11 @@
 package com.mailsangja.worker.common.exception;
 
 import com.mailsangja.worker.common.exception.common.CommonErrorCode;
+import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
+import com.mailsangja.worker.common.exception.mail.MailPushException;
+import com.mailsangja.worker.config.properties.GmailPushLocalAckProperties;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,7 +15,30 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
+
+    private static final String GMAIL_PUSH_PATH = "/api/v1/gmail/push";
+
+    private final GmailPushLocalAckProperties gmailPushLocalAckProperties;
+
+    @ExceptionHandler(MailPushException.class)
+    public ResponseEntity<?> handleMailPushException(MailPushException e, HttpServletRequest request) {
+        MailPushErrorCode errorCode = (MailPushErrorCode) e.getErrorCode();
+        if (shouldAckLocalGmailPush(errorCode, request)) {
+            log.warn(
+                    "Local Gmail push ack applied: path='{}', errorCode={}, message={}",
+                    request.getRequestURI(),
+                    errorCode.name(),
+                    e.getMessage()
+            );
+            return ResponseEntity.noContent().build();
+        }
+
+        log.warn("BaseException: {}", e.getMessage());
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ErrorResponse.from(errorCode));
+    }
 
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
@@ -34,5 +62,11 @@ public class GlobalExceptionHandler {
         log.error("[Exception] Unhandled Server Error - {}", e.getMessage(), e);
         return ResponseEntity.status(CommonErrorCode.INTERNAL_FAILURE.getStatus())
                 .body(ErrorResponse.from(CommonErrorCode.INTERNAL_FAILURE));
+    }
+
+    private boolean shouldAckLocalGmailPush(MailPushErrorCode errorCode, HttpServletRequest request) {
+        return request != null
+                && GMAIL_PUSH_PATH.equals(request.getRequestURI())
+                && gmailPushLocalAckProperties.isWhitelisted(errorCode);
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/config/properties/GmailPushLocalAckProperties.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/properties/GmailPushLocalAckProperties.java
@@ -1,0 +1,63 @@
+package com.mailsangja.worker.config.properties;
+
+import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "mailsangja.gmail.push.local-ack")
+public class GmailPushLocalAckProperties {
+
+    private boolean enabled = false;
+    private List<String> whitelistedErrorCodes = List.of();
+
+    @PostConstruct
+    public void validate() {
+        resolveWhitelistedErrorCodes();
+    }
+
+    public boolean isWhitelisted(MailPushErrorCode errorCode) {
+        if (!enabled || errorCode == null) {
+            return false;
+        }
+
+        return resolveWhitelistedErrorCodes().contains(errorCode);
+    }
+
+    private Set<MailPushErrorCode> resolveWhitelistedErrorCodes() {
+        EnumSet<MailPushErrorCode> resolved = EnumSet.noneOf(MailPushErrorCode.class);
+
+        for (String rawCode : whitelistedErrorCodes) {
+            if (isBlank(rawCode)) {
+                continue;
+            }
+
+            String normalizedCode = rawCode.trim();
+            try {
+                resolved.add(MailPushErrorCode.valueOf(normalizedCode));
+            } catch (IllegalArgumentException e) {
+                throw new IllegalStateException(
+                        "Invalid mailsangja.gmail.push.local-ack.whitelisted-error-codes value: " + normalizedCode
+                                + ". Supported values: " + Arrays.toString(MailPushErrorCode.values()),
+                        e
+                );
+            }
+        }
+
+        return resolved;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/config/properties/GmailPushLocalAckProperties.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/properties/GmailPushLocalAckProperties.java
@@ -20,10 +20,16 @@ public class GmailPushLocalAckProperties {
 
     private boolean enabled = false;
     private List<String> whitelistedErrorCodes = List.of();
+    private Set<MailPushErrorCode> resolvedWhitelistedErrorCodes = Set.of();
 
     @PostConstruct
     public void validate() {
-        resolveWhitelistedErrorCodes();
+        if (!enabled) {
+            resolvedWhitelistedErrorCodes = Set.of();
+            return;
+        }
+
+        resolvedWhitelistedErrorCodes = resolveWhitelistedErrorCodes();
     }
 
     public boolean isWhitelisted(MailPushErrorCode errorCode) {
@@ -31,7 +37,7 @@ public class GmailPushLocalAckProperties {
             return false;
         }
 
-        return resolveWhitelistedErrorCodes().contains(errorCode);
+        return resolvedWhitelistedErrorCodes.contains(errorCode);
     }
 
     private Set<MailPushErrorCode> resolveWhitelistedErrorCodes() {

--- a/worker/src/main/resources/application.yaml
+++ b/worker/src/main/resources/application.yaml
@@ -69,6 +69,9 @@ mailsangja:
       read-timeout: ${GOOGLE_GMAIL_WATCH_READ_TIMEOUT:5s}
       label-filter-behavior: ${GOOGLE_GMAIL_WATCH_LABEL_FILTER_BEHAVIOR:}
     push:
+      local-ack:
+        enabled: ${GOOGLE_GMAIL_PUSH_LOCAL_ACK_ENABLED:false}
+        whitelisted-error-codes: ${GOOGLE_GMAIL_PUSH_LOCAL_ACK_WHITELIST:}
       oidc:
         jwk-set-uri: ${GOOGLE_PUBSUB_PUSH_OIDC_JWK_SET_URI:https://www.googleapis.com/oauth2/v3/certs}
         allowed-issuers:

--- a/worker/src/test/java/com/mailsangja/worker/common/exception/GlobalExceptionHandlerTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/common/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,73 @@
+package com.mailsangja.worker.common.exception;
+
+import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
+import com.mailsangja.worker.common.exception.mail.MailPushException;
+import com.mailsangja.worker.config.properties.GmailPushLocalAckProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class GlobalExceptionHandlerTest {
+
+    @Test
+    void handleMailPushException_화이트리스트에포함된지메일푸시예외면204를반환한다() {
+        GmailPushLocalAckProperties properties = new GmailPushLocalAckProperties();
+        properties.setEnabled(true);
+        properties.setWhitelistedErrorCodes(List.of("MAIL_ACCOUNT_NOT_FOUND"));
+        properties.validate();
+
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(properties);
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/gmail/push");
+
+        ResponseEntity<?> response = handler.handleMailPushException(
+                new MailPushException(MailPushErrorCode.MAIL_ACCOUNT_NOT_FOUND),
+                request
+        );
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+    }
+
+    @Test
+    void handleMailPushException_화이트리스트에없으면원래에러응답을반환한다() {
+        GmailPushLocalAckProperties properties = new GmailPushLocalAckProperties();
+        properties.setEnabled(true);
+        properties.setWhitelistedErrorCodes(List.of("MAIL_ACCOUNT_NOT_FOUND"));
+        properties.validate();
+
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(properties);
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/gmail/push");
+
+        ResponseEntity<?> response = handler.handleMailPushException(
+                new MailPushException(MailPushErrorCode.INVALID_PUBSUB_OIDC_TOKEN),
+                request
+        );
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        assertInstanceOf(ErrorResponse.class, response.getBody());
+    }
+
+    @Test
+    void handleMailPushException_다른경로면화이트리스트여도원래에러응답을반환한다() {
+        GmailPushLocalAckProperties properties = new GmailPushLocalAckProperties();
+        properties.setEnabled(true);
+        properties.setWhitelistedErrorCodes(List.of("MAIL_ACCOUNT_NOT_FOUND"));
+        properties.validate();
+
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(properties);
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/other");
+
+        ResponseEntity<?> response = handler.handleMailPushException(
+                new MailPushException(MailPushErrorCode.MAIL_ACCOUNT_NOT_FOUND),
+                request
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertInstanceOf(ErrorResponse.class, response.getBody());
+    }
+}

--- a/worker/src/test/java/com/mailsangja/worker/config/properties/GmailPushLocalAckPropertiesTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/config/properties/GmailPushLocalAckPropertiesTest.java
@@ -1,0 +1,34 @@
+package com.mailsangja.worker.config.properties;
+
+import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GmailPushLocalAckPropertiesTest {
+
+    @Test
+    void isWhitelisted_설정된에러코드면true를반환한다() {
+        GmailPushLocalAckProperties properties = new GmailPushLocalAckProperties();
+        properties.setEnabled(true);
+        properties.setWhitelistedErrorCodes(List.of("MAIL_ACCOUNT_NOT_FOUND", "INVALID_PUBSUB_OIDC_TOKEN"));
+        properties.validate();
+
+        assertTrue(properties.isWhitelisted(MailPushErrorCode.MAIL_ACCOUNT_NOT_FOUND));
+        assertTrue(properties.isWhitelisted(MailPushErrorCode.INVALID_PUBSUB_OIDC_TOKEN));
+        assertFalse(properties.isWhitelisted(MailPushErrorCode.INVALID_GMAIL_PUSH_NOTIFICATION));
+    }
+
+    @Test
+    void validate_잘못된에러코드가있으면예외가발생한다() {
+        GmailPushLocalAckProperties properties = new GmailPushLocalAckProperties();
+        properties.setEnabled(true);
+        properties.setWhitelistedErrorCodes(List.of("NOT_EXISTS"));
+
+        assertThrows(IllegalStateException.class, properties::validate);
+    }
+}

--- a/worker/src/test/java/com/mailsangja/worker/config/properties/GmailPushLocalAckPropertiesTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/config/properties/GmailPushLocalAckPropertiesTest.java
@@ -31,4 +31,15 @@ class GmailPushLocalAckPropertiesTest {
 
         assertThrows(IllegalStateException.class, properties::validate);
     }
+
+    @Test
+    void validate_enabled가false면잘못된에러코드가있어도예외가발생하지않는다() {
+        GmailPushLocalAckProperties properties = new GmailPushLocalAckProperties();
+        properties.setEnabled(false);
+        properties.setWhitelistedErrorCodes(List.of("NOT_EXISTS"));
+
+        properties.validate();
+
+        assertFalse(properties.isWhitelisted(MailPushErrorCode.MAIL_ACCOUNT_NOT_FOUND));
+    }
 }


### PR DESCRIPTION
  ## 🔗 관련 작업

  ### 👤 User Story
  - mailsangja/docs4capstone#6

  ### 📌 Task
  - Closes #34
  - Closes #22


  ## 💡 작업 내용

  - 스레드 안읽음 처리 API를 추가하고 Gmail thread unread 동기화를 구현했습니다.
  - 메시지 읽음/안읽음 처리 API를 추가하고 스레드 읽음 상태 연동 및 thread lock 적용을 반영했습니다.
  - worker 로컬 환경에서 Gmail push 예외를 화이트리스트 기반으로 ack 처리할 수 있도록 설정을 추가했습니다.


  ## 📝 추가 설명

  ### 1. 스레드/메시지 읽음 상태 API 확장
  - `POST /api/v1/threads/{threadId}/unread` API를 추가해 스레드 단위 안읽음 처리를 지원했습니다.
  - `POST /api/v1/messages/{messageId}/read`, `POST /api/v1/messages/{messageId}/unread` API를 추가해 메시지 단위 읽음/안읽음 처리를 지원했습니다.
  - 메시지 읽음 처리 시 같은 conversation의 모든 메시지가 읽음이면 스레드도 읽음 처리되도록 반영했습니다.
  - 메시지 안읽음 처리 시 대상 메시지가 속한 스레드는 즉시 안읽음 처리되도록 반영했습니다.

  ### 2. Gmail 연동 및 동시성 보강
  - Gmail thread/message modify API를 사용해 read/unread 상태를 원격 Gmail과 동기화하도록 확장했습니다.
  - message read/unread, thread read/unread 경로 모두 `mailAccount + gmailThreadId` 단위 thread lock을 적용했습니다.
  - read/unread는 최대한 대칭 구조로 구현하고, 차이는 message unread 시 thread를 즉시 unread로 내리는 규칙만 명시적으로 유지했습니다.

  ### 3. worker 로컬 push 처리 개선
  - 로컬 환경에서만 Gmail push 예외를 화이트리스트 기반으로 `204 No Content` ack 처리할 수 있도록 설정을 추가했습니다.
  - `/api/v1/gmail/push` 경로에서 지정한 `MailPushErrorCode` enum 이름만 ack 처리하도록 제한했습니다.
  - 잘못된 화이트리스트 값은 애플리케이션 시작 시점에 검증되도록 구성했습니다.

  ## ⚡️ Test 결과

  | 기능 1 | 기능 2 |
  | -- | -- |
  | POST | POST |
  | /api/v1/messages/{messageId}/unread | /api/v1/messages/{messageId}/read |
  | <img width="1368" height="629" alt="image" src="https://github.com/user-attachments/assets/0d3922c6-5dfa-43d8-ae9e-d134f79388d7" /> <img width="1383" height="766" alt="image" src="https://github.com/user-attachments/assets/2f0fbf02-a61d-42be-8919-30d065d452ff" /> | <img width="1371" height="530" alt="image" src="https://github.com/user-attachments/assets/256580a8-9591-4c05-94db-681c2e5d03aa" /> <img width="1375" height="737" alt="image" src="https://github.com/user-attachments/assets/e389b5eb-a768-457c-a8f7-b8dc85261d47" /> |