### PR TITLE
[STORY-102] 구글 OAuth 콜백 실패 시 에러 코드를 쿼리에 담아 리다이렉트하도록 수정

### DIFF
--- a/core/src/main/java/com/mailsangja/core/controller/MailAccountController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/MailAccountController.java
@@ -1,6 +1,8 @@
 package com.mailsangja.core.controller;
 
 import com.mailsangja.core.common.auth.AuthUser;
+import com.mailsangja.core.common.exception.ErrorCode;
+import com.mailsangja.core.common.exception.common.CommonErrorCode;
 import com.mailsangja.core.common.exception.mail.MailAccountErrorCode;
 import com.mailsangja.core.common.exception.mail.MailAccountException;
 import com.mailsangja.core.config.properties.GoogleOAuthProperties;
@@ -17,8 +19,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 
@@ -72,6 +76,26 @@ public class MailAccountController implements MailAccountControllerDocs {
         String savedIcon = (String) session.getAttribute(GOOGLE_OAUTH_ICON);
         String savedColor = (String) session.getAttribute(GOOGLE_OAUTH_COLOR);
 
+        try {
+            validateGoogleOAuthSession(user, state, savedState, savedUserId);
+            mailAccountFacade.handleGoogleCallback(user, code, savedAlias, savedIcon, savedColor);
+            return ResponseEntity.status(302)
+                    .location(buildCallbackRedirectUri())
+                    .build();
+        } catch (MailAccountException e) {
+            return ResponseEntity.status(302)
+                    .location(buildCallbackRedirectUri(e.getErrorCode()))
+                    .build();
+        } catch (Exception e) {
+            return ResponseEntity.status(302)
+                    .location(buildCallbackRedirectUri(CommonErrorCode.INTERNAL_FAILURE))
+                    .build();
+        } finally {
+            clearGoogleOAuthSession(session);
+        }
+    }
+
+    private void validateGoogleOAuthSession(User user, String state, String savedState, String savedUserId) {
         if (savedState == null) {
             throw new MailAccountException(MailAccountErrorCode.OAUTH_SESSION_NOT_FOUND);
         }
@@ -83,17 +107,27 @@ public class MailAccountController implements MailAccountControllerDocs {
         if (!savedState.equals(state)) {
             throw new MailAccountException(MailAccountErrorCode.INVALID_OAUTH_STATE);
         }
+    }
 
+    private void clearGoogleOAuthSession(HttpSession session) {
         session.removeAttribute(GOOGLE_OAUTH_STATE);
         session.removeAttribute(GOOGLE_OAUTH_USER_ID);
         session.removeAttribute(GOOGLE_OAUTH_ALIAS);
         session.removeAttribute(GOOGLE_OAUTH_ICON);
         session.removeAttribute(GOOGLE_OAUTH_COLOR);
+    }
 
-        mailAccountFacade.handleGoogleCallback(user, code, savedAlias, savedIcon, savedColor);
+    private URI buildCallbackRedirectUri() {
+        return URI.create(googleOAuthProperties.getCallbackRedirectUri());
+    }
 
-        return ResponseEntity.status(302)
-                .location(URI.create(googleOAuthProperties.getCallbackRedirectUri()))
-                .build();
+    private URI buildCallbackRedirectUri(ErrorCode errorCode) {
+        return UriComponentsBuilder.fromUriString(googleOAuthProperties.getCallbackRedirectUri())
+                .queryParam("status", errorCode.getStatus())
+                .queryParam("errorCode", errorCode.getCode())
+                .queryParam("errorMessage", errorCode.getMessage())
+                .build()
+                .encode(StandardCharsets.UTF_8)
+                .toUri();
     }
 }


### PR DESCRIPTION
  ## 🔗 관련 작업

  ### 👤 User Story
  - mailsangja/docs4capstone#2

  ### 📌 Task
  - Closes #9


  ## 💡 작업 내용

  - Google OAuth callback 처리 중 예외가 발생해도 `callbackRedirectUri`로 리다이렉트되도록 수정했습니다.
  - 실패 시 프론트엔드가 후속 처리를 할 수 있도록 `status`, `errorCode`, `errorMessage`를 query parameter로 전달하도록 변경했습니다.
  - OAuth callback에서 사용하는 session 기반 검증(`state`, `initiating userId`)은 컨트롤러에서 처리하고, 성공/실패 여부와 관계없이 세션 값을 정리하도록 보완했습니다.
  - 한글 에러 메시지가 포함되어도 redirect URI 생성이 실패하지 않도록 UTF-8 인코딩 방식으로 수정했습니다.


  ## 📝 추가 설명

  ### 1. 변경 배경
  - 기존에는 `googleCallback` 처리 중 예외가 발생하면 글로벌 예외 처리로 빠져 프론트엔드 callback 페이지에서 실패 원인을 식별하기 어려웠습니다.
  - 특히 Gmail 계정이 이미 연결된 경우 같은 비즈니스 예외도 callback redirect 흐름으로 전달되지 않아 사용자 경험이 끊기는 문제가 있었습니다.

  ### 2. 주요 변경 사항
  - `MailAccountController.googleCallback`에서 `MailAccountException` 발생 시 `callbackRedirectUri`로 302 redirect 하도록 변경했습니다.
  - redirect query parameter에 아래 값을 포함하도록 구성했습니다.
  - `status`: HTTP status code
  - `errorCode`: 서버 ErrorCode
  - `errorMessage`: 사용자 노출 가능한 에러 메시지
  - 예상하지 못한 예외는 `MS-COMMON-INTERNAL-FAILURE`로 매핑하여 동일한 redirect 흐름을 유지합니다.

  ### 3. 구현 상세
  - OAuth callback의 session 검증은 프로젝트 규칙에 맞게 Controller 계층에서 유지했습니다.
  - session attribute 정리는 `finally` 블록에서 수행하도록 변경해 성공/실패 경로 모두에서 일관되게 정리되도록 했습니다.
  - `errorMessage`에 한글이 포함될 수 있으므로 `UriComponentsBuilder`에서 UTF-8 인코딩 후 URI를 생성하도록 수정했습니다.


  ## ⚡️ Test 결과

  | 기능 1 | 
  | -- | 
  | GET | 
  | /api/v1/mail-accounts/google/callback | 
  | <img width="1046" height="52" alt="image" src="https://github.com/user-attachments/assets/b2b095f8-34c9-4905-b5f7-d61f662c1d90" /> | 