### PR TITLE
[STORY-205] Thread 응답시 messageCount 필드를 추가

### DIFF
--- a/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponse.java
@@ -28,7 +28,9 @@ public record ThreadSummaryResponse(
         @Schema(description = "최신 메시지 시각")
         LocalDateTime lastMessageAt,
         @Schema(description = "스레드 내 첨부파일 목록")
-        List<AttachmentResponse> attachments
+        List<AttachmentResponse> attachments,
+        @Schema(description = "스레드 내 메시지 수", example = "3")
+        int messageCount
 ) {
     public static ThreadSummaryResponse from(Thread thread, List<Attachment> attachments, Map<String, String> contactNameByEmail) {
         List<AttachmentResponse> attachmentResponses = attachments.stream()
@@ -44,7 +46,8 @@ public record ThreadSummaryResponse(
                 thread.getLatestSnippet(),
                 thread.isRead(),
                 thread.getLastMessageAt(),
-                attachmentResponses
+                attachmentResponses,
+                thread.getMessageCount()
         );
     }
 }


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#8

### 📌 Task
- Closes #56 
- Closes #57 
- Closes #58 


## 💡 작업 내용

- 스레드 목록 조회시 스레드 내 메시지 수를 응답 DTO에 추가합니다.