### PR TITLE
[STORY-102] Google OAuth 액세스 토큰 사용 직전 갱신 로직 추가

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/core/src/main/java/com/mailsangja/core/common/exception/mail/MailAccountErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/mail/MailAccountErrorCode.java
@@ -19,6 +19,7 @@ public enum MailAccountErrorCode implements ErrorCode {
     INVALID_OAUTH_RESULT(400, "MS-MAIL-INVALID-OAUTH-RESULT", "OAuth 응답값이 올바르지 않습니다."),
     INVALID_INITIAL_MAIL_SYNC_MESSAGE(400, "MS-MAIL-INVALID-INITIAL-MAIL-SYNC-MESSAGE", "초기 메일 동기화 메시지 값이 올바르지 않습니다."),
     GOOGLE_TOKEN_EXCHANGE_FAILED(502, "MS-MAIL-GOOGLE-TOKEN-EXCHANGE-FAILED", "Google OAuth 토큰 교환에 실패했습니다."),
+    GOOGLE_TOKEN_REFRESH_FAILED(502, "MS-MAIL-GOOGLE-TOKEN-REFRESH-FAILED", "Google access token 재발급에 실패했습니다."),
     GOOGLE_USER_INFO_FETCH_FAILED(502, "MS-MAIL-GOOGLE-USER-INFO-FETCH-FAILED", "Google 사용자 정보 조회에 실패했습니다."),
     GOOGLE_MAIL_WATCH_FAILED(502, "MS-MAIL-GOOGLE-MAIL-WATCH-FAILED", "Google Gmail watch 등록에 실패했습니다."),
     GOOGLE_MAIL_READ_MODIFY_FAILED(502, "MS-MAIL-GOOGLE-MAIL-READ-MODIFY-FAILED", "Google Gmail 읽음 처리 동기화에 실패했습니다."),

--- a/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
@@ -10,6 +10,7 @@ import com.mailsangja.core.service.inbox.InboxCommandService;
 import com.mailsangja.core.service.inbox.InboxQueryService;
 import com.mailsangja.core.dto.inbox.ThreadDetailResult;
 import com.mailsangja.core.dto.inbox.ThreadListResult;
+import com.mailsangja.core.service.mail.GoogleAccessTokenEnsureService;
 import com.mailsangja.core.service.mail.MailAccountQueryService;
 import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.Message;
@@ -33,6 +34,7 @@ public class InboxFacade {
     private final InboxCommandService inboxCommandService;
     private final InboxQueryService inboxQueryService;
     private final MailAccountQueryService mailAccountQueryService;
+    private final GoogleAccessTokenEnsureService googleAccessTokenEnsureService;
 
     public MarkerSliceResponse<ThreadSummaryResponse> getInbox(User user, UUID marker, int size) {
         ThreadListResult result = inboxQueryService.findInboxThreadsResult(user.getId(), marker, PageRequest.of(0, size));
@@ -55,7 +57,10 @@ public class InboxFacade {
         Thread thread = inboxQueryService.findThreadById(threadId);
         validateThreadAccess(mailAccountQueryService.findAllActiveByUserId(user.getId()), thread);
         if (thread.getMailAccount().getProvider() == MailProvider.GMAIL) {
-            googleMailReadCommandService.markThreadAsRead(thread.getMailAccount(), thread);
+            googleMailReadCommandService.markThreadAsRead(
+                    googleAccessTokenEnsureService.ensureValidGoogleAccessToken(thread.getMailAccount()),
+                    thread
+            );
         }
         inboxCommandService.markThreadAsRead(thread);
     }
@@ -64,7 +69,10 @@ public class InboxFacade {
         Message message = inboxQueryService.findActiveMessageById(messageId);
         validateThreadAccess(mailAccountQueryService.findAllActiveByUserId(user.getId()), message.getThread());
         if (message.getThread().getMailAccount().getProvider() == MailProvider.GMAIL) {
-            googleMailReadCommandService.markMessageAsRead(message.getThread().getMailAccount(), message);
+            googleMailReadCommandService.markMessageAsRead(
+                    googleAccessTokenEnsureService.ensureValidGoogleAccessToken(message.getThread().getMailAccount()),
+                    message
+            );
         }
         inboxCommandService.markMessageAsRead(message);
     }
@@ -73,7 +81,10 @@ public class InboxFacade {
         Message message = inboxQueryService.findActiveMessageById(messageId);
         validateThreadAccess(mailAccountQueryService.findAllActiveByUserId(user.getId()), message.getThread());
         if (message.getThread().getMailAccount().getProvider() == MailProvider.GMAIL) {
-            googleMailReadCommandService.markMessageAsUnread(message.getThread().getMailAccount(), message);
+            googleMailReadCommandService.markMessageAsUnread(
+                    googleAccessTokenEnsureService.ensureValidGoogleAccessToken(message.getThread().getMailAccount()),
+                    message
+            );
         }
         inboxCommandService.markMessageAsUnread(message);
     }
@@ -82,7 +93,10 @@ public class InboxFacade {
         Thread thread = inboxQueryService.findThreadById(threadId);
         validateThreadAccess(mailAccountQueryService.findAllActiveByUserId(user.getId()), thread);
         if (thread.getMailAccount().getProvider() == MailProvider.GMAIL) {
-            googleMailReadCommandService.markThreadAsUnread(thread.getMailAccount(), thread);
+            googleMailReadCommandService.markThreadAsUnread(
+                    googleAccessTokenEnsureService.ensureValidGoogleAccessToken(thread.getMailAccount()),
+                    thread
+            );
         }
         inboxCommandService.markThreadAsUnread(thread);
     }

--- a/core/src/main/java/com/mailsangja/core/facade/MailFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/MailFacade.java
@@ -9,6 +9,7 @@ import com.mailsangja.core.dto.mail.MailAddressCommand;
 import com.mailsangja.core.dto.mail.MailSendCommand;
 import com.mailsangja.core.dto.mail.MailSendRequest;
 import com.mailsangja.core.service.google.GoogleMailAttachmentQueryService;
+import com.mailsangja.core.service.mail.GoogleAccessTokenEnsureService;
 import com.mailsangja.core.service.mail.MailAttachmentQueryService;
 import com.mailsangja.core.service.mail.MailAccountQueryService;
 import com.mailsangja.core.service.mail.MailCommandService;
@@ -37,6 +38,7 @@ public class MailFacade {
     private static final long MAX_TOTAL_ATTACHMENT_SIZE = 20L * 1024 * 1024;
 
     private final MailAccountQueryService mailAccountQueryService;
+    private final GoogleAccessTokenEnsureService googleAccessTokenEnsureService;
     private final MailCommandService mailCommandService;
     private final MailAttachmentQueryService mailAttachmentQueryService;
     private final GoogleMailAttachmentQueryService googleMailAttachmentQueryService;
@@ -61,8 +63,11 @@ public class MailFacade {
         validateAttachmentAccess(mailAccountQueryService.findAllActiveByUserId(user.getId()), attachment);
         validateAttachmentProvider(attachment);
 
+        MailAccount ensuredMailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(
+                attachment.getMessage().getThread().getMailAccount()
+        );
         byte[] attachmentBytes = googleMailAttachmentQueryService.download(
-                attachment.getMessage().getThread().getMailAccount(),
+                ensuredMailAccount,
                 attachment.getMessage(),
                 attachment
         );

--- a/core/src/main/java/com/mailsangja/core/facade/TrashFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/TrashFacade.java
@@ -3,10 +3,10 @@ package com.mailsangja.core.facade;
 import com.mailsangja.core.common.exception.trash.TrashErrorCode;
 import com.mailsangja.core.common.exception.trash.TrashException;
 import com.mailsangja.core.dto.common.MarkerSliceResponse;
-import com.mailsangja.core.dto.trash.TrashMessageItemResponse;
 import com.mailsangja.core.dto.trash.TrashThreadDetailResponse;
 import com.mailsangja.core.dto.trash.TrashThreadSummaryResponse;
 import com.mailsangja.core.service.google.GoogleGmailApiService;
+import com.mailsangja.core.service.mail.GoogleAccessTokenEnsureService;
 import com.mailsangja.core.service.mail.MailAccountQueryService;
 import com.mailsangja.core.service.trash.TrashCommandService;
 import com.mailsangja.core.service.trash.TrashQueryService;
@@ -34,19 +34,22 @@ public class TrashFacade {
     private final TrashQueryService trashQueryService;
     private final GoogleGmailApiService googleGmailApiService;
     private final MailAccountQueryService mailAccountQueryService;
+    private final GoogleAccessTokenEnsureService googleAccessTokenEnsureService;
 
     public void deleteThread(User user, UUID threadId) {
         Thread thread = trashQueryService.findActiveThreadById(threadId);
         validateThreadAccess(user, thread);
         trashCommandService.softDeleteThread(thread);
-        googleGmailApiService.trashThread(thread.getMailAccount().getAccessToken(), thread.getGmailThreadId());
+        MailAccount ensuredMailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(thread.getMailAccount());
+        googleGmailApiService.trashThread(ensuredMailAccount.getAccessToken(), thread.getGmailThreadId());
     }
 
     public void deleteMessage(User user, UUID messageId) {
         Message message = trashQueryService.findActiveMessageById(messageId);
         validateThreadAccess(user, message.getThread());
         trashCommandService.softDeleteMessage(message);
-        googleGmailApiService.trashMessage(message.getThread().getMailAccount().getAccessToken(), message.getGmailMessageId());
+        MailAccount ensuredMailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(message.getThread().getMailAccount());
+        googleGmailApiService.trashMessage(ensuredMailAccount.getAccessToken(), message.getGmailMessageId());
     }
 
     public MarkerSliceResponse<TrashThreadSummaryResponse> getTrashThreads(User user, UUID marker, int size) {
@@ -88,14 +91,16 @@ public class TrashFacade {
         Thread thread = trashQueryService.findDeletedThreadById(threadId);
         validateThreadAccess(user, thread);
         trashCommandService.restoreThread(thread);
-        googleGmailApiService.untrashThread(thread.getMailAccount().getAccessToken(), thread.getGmailThreadId());
+        MailAccount ensuredMailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(thread.getMailAccount());
+        googleGmailApiService.untrashThread(ensuredMailAccount.getAccessToken(), thread.getGmailThreadId());
     }
 
     public void restoreMessage(User user, UUID messageId) {
         Message message = trashQueryService.findDeletedMessageById(messageId);
         validateThreadAccess(user, message.getThread());
         trashCommandService.restoreMessage(message);
-        googleGmailApiService.untrashMessage(message.getThread().getMailAccount().getAccessToken(), message.getGmailMessageId());
+        MailAccount ensuredMailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(message.getThread().getMailAccount());
+        googleGmailApiService.untrashMessage(ensuredMailAccount.getAccessToken(), message.getGmailMessageId());
     }
 
     private void validateThreadAccess(User user, Thread thread) {

--- a/core/src/main/java/com/mailsangja/core/service/google/GoogleOAuthQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/google/GoogleOAuthQueryService.java
@@ -17,10 +17,13 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.StringJoiner;
 
 @Service
 public class GoogleOAuthQueryService {
+
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
 
     private final GoogleOAuthProperties googleOAuthProperties;
     private final RestClient googleOAuthRestClient;
@@ -126,9 +129,13 @@ public class GoogleOAuthQueryService {
         return new GoogleMailAccountResult(
                 userInfoResult.email(),
                 tokenResult.accessToken(),
-                LocalDateTime.now().plusSeconds(tokenResult.expiresIn()),
+                getKstNow().plusSeconds(tokenResult.expiresIn()),
                 tokenResult.refreshToken()
         );
+    }
+
+    private LocalDateTime getKstNow() {
+        return LocalDateTime.now(KST_ZONE_ID);
     }
 
     private void validateTokenExchangeInput(String code) {

--- a/core/src/main/java/com/mailsangja/core/service/google/GoogleOAuthQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/google/GoogleOAuthQueryService.java
@@ -67,10 +67,36 @@ public class GoogleOAuthQueryService {
                     .retrieve()
                     .body(GoogleOAuthTokenResult.class);
 
-            validateTokenResult(tokenResult);
+            validateTokenResult(tokenResult, MailAccountErrorCode.GOOGLE_TOKEN_EXCHANGE_FAILED);
             return tokenResult;
         } catch (RestClientException e) {
             throw new MailAccountException(MailAccountErrorCode.GOOGLE_TOKEN_EXCHANGE_FAILED);
+        }
+    }
+
+    public GoogleOAuthTokenResult refreshAccessToken(String refreshToken) {
+        validateRefreshInput(refreshToken);
+
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("client_id", googleOAuthProperties.getClientId());
+        formData.add("client_secret", googleOAuthProperties.getClientSecret());
+        formData.add("refresh_token", refreshToken);
+        formData.add("grant_type", "refresh_token");
+
+        try {
+            GoogleOAuthTokenResult tokenResult = googleOAuthRestClient
+                    .post()
+                    .uri(googleOAuthProperties.getTokenUri())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .body(formData)
+                    .retrieve()
+                    .body(GoogleOAuthTokenResult.class);
+
+            validateTokenResult(tokenResult, MailAccountErrorCode.GOOGLE_TOKEN_REFRESH_FAILED);
+            return tokenResult;
+        } catch (RestClientException e) {
+            throw new MailAccountException(MailAccountErrorCode.GOOGLE_TOKEN_REFRESH_FAILED);
         }
     }
 
@@ -115,12 +141,21 @@ public class GoogleOAuthQueryService {
         }
     }
 
-    private void validateTokenResult(GoogleOAuthTokenResult tokenResult) {
+    private void validateRefreshInput(String refreshToken) {
+        if (isBlank(refreshToken)
+                || isBlank(googleOAuthProperties.getClientId())
+                || isBlank(googleOAuthProperties.getClientSecret())
+                || isBlank(googleOAuthProperties.getTokenUri())) {
+            throw new MailAccountException(MailAccountErrorCode.GOOGLE_TOKEN_REFRESH_FAILED);
+        }
+    }
+
+    private void validateTokenResult(GoogleOAuthTokenResult tokenResult, MailAccountErrorCode errorCode) {
         if (tokenResult == null
                 || isBlank(tokenResult.accessToken())
                 || tokenResult.expiresIn() == null
                 || tokenResult.expiresIn() <= 0) {
-            throw new MailAccountException(MailAccountErrorCode.GOOGLE_TOKEN_EXCHANGE_FAILED);
+            throw new MailAccountException(errorCode);
         }
     }
 

--- a/core/src/main/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureService.java
+++ b/core/src/main/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureService.java
@@ -1,0 +1,79 @@
+package com.mailsangja.core.service.mail;
+
+import com.mailsangja.core.common.exception.mail.MailAccountErrorCode;
+import com.mailsangja.core.common.exception.mail.MailAccountException;
+import com.mailsangja.core.service.google.GoogleOAuthQueryService;
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.MailProvider;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class GoogleAccessTokenEnsureService {
+
+    private static final long REFRESH_WINDOW_MINUTES = 10L;
+
+    private final MailAccountQueryService mailAccountQueryService;
+    private final MailAccountCommandService mailAccountCommandService;
+    private final GoogleOAuthQueryService googleOAuthQueryService;
+
+    public GoogleAccessTokenEnsureService(
+            MailAccountQueryService mailAccountQueryService,
+            MailAccountCommandService mailAccountCommandService,
+            GoogleOAuthQueryService googleOAuthQueryService
+    ) {
+        this.mailAccountQueryService = mailAccountQueryService;
+        this.mailAccountCommandService = mailAccountCommandService;
+        this.googleOAuthQueryService = googleOAuthQueryService;
+    }
+
+    public MailAccount ensureValidGoogleAccessToken(MailAccount mailAccount) {
+        validateMailAccountInput(mailAccount);
+
+        MailAccount latestMailAccount = mailAccountQueryService.findActiveById(mailAccount.getId());
+        validateGoogleMailAccount(latestMailAccount);
+
+        if (!needsRefresh(latestMailAccount)) {
+            return latestMailAccount;
+        }
+
+        if (isBlank(latestMailAccount.getRefreshToken())) {
+            throw new MailAccountException(MailAccountErrorCode.GOOGLE_REFRESH_TOKEN_MISSING);
+        }
+
+        return mailAccountCommandService.refreshGoogleAccessToken(
+                latestMailAccount.getId(),
+                googleOAuthQueryService.refreshAccessToken(latestMailAccount.getRefreshToken())
+        );
+    }
+
+    private boolean needsRefresh(MailAccount mailAccount) {
+        LocalDateTime refreshThreshold = LocalDateTime.now().plusMinutes(REFRESH_WINDOW_MINUTES);
+        return !mailAccount.getAccessTokenExpiresAt().isAfter(refreshThreshold);
+    }
+
+    private void validateMailAccountInput(MailAccount mailAccount) {
+        if (mailAccount == null || mailAccount.getId() == null) {
+            throw new MailAccountException(MailAccountErrorCode.MAIL_ACCOUNT_NOT_FOUND);
+        }
+    }
+
+    private void validateGoogleMailAccount(MailAccount mailAccount) {
+        if (mailAccount.getProvider() != MailProvider.GMAIL) {
+            throw new MailAccountException(MailAccountErrorCode.UNSUPPORTED_MAIL_PROVIDER);
+        }
+
+        if (mailAccount.getAccessTokenExpiresAt() == null) {
+            throw new MailAccountException(MailAccountErrorCode.INVALID_OAUTH_RESULT);
+        }
+
+        if (isBlank(mailAccount.getAccessToken())) {
+            throw new MailAccountException(MailAccountErrorCode.GOOGLE_TOKEN_REFRESH_FAILED);
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureService.java
+++ b/core/src/main/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureService.java
@@ -30,26 +30,24 @@ public class GoogleAccessTokenEnsureService {
 
     public MailAccount ensureValidGoogleAccessToken(MailAccount mailAccount) {
         validateMailAccountInput(mailAccount);
+        validateGoogleMailAccount(mailAccount);
 
-        MailAccount latestMailAccount = mailAccountQueryService.findActiveById(mailAccount.getId());
-        validateGoogleMailAccount(latestMailAccount);
-
-        if (!needsRefresh(latestMailAccount)) {
-            return latestMailAccount;
+        if (!needsRefresh(mailAccount)) {
+            return mailAccount;
         }
 
-        if (isBlank(latestMailAccount.getRefreshToken())) {
+        if (isBlank(mailAccount.getRefreshToken())) {
             throw new MailAccountException(MailAccountErrorCode.GOOGLE_REFRESH_TOKEN_MISSING);
         }
 
         return mailAccountCommandService.refreshGoogleAccessToken(
-                latestMailAccount.getId(),
-                googleOAuthQueryService.refreshAccessToken(latestMailAccount.getRefreshToken())
+                mailAccount.getId(),
+                googleOAuthQueryService.refreshAccessToken(mailAccount.getRefreshToken())
         );
     }
 
     private boolean needsRefresh(MailAccount mailAccount) {
-        LocalDateTime refreshThreshold = LocalDateTime.now().plusMinutes(REFRESH_WINDOW_MINUTES);
+        LocalDateTime refreshThreshold = mailAccountQueryService.getKstNow().plusMinutes(REFRESH_WINDOW_MINUTES);
         return !mailAccount.getAccessTokenExpiresAt().isAfter(refreshThreshold);
     }
 

--- a/core/src/main/java/com/mailsangja/core/service/mail/MailAccountCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/mail/MailAccountCommandService.java
@@ -86,14 +86,19 @@ public class MailAccountCommandService {
 
         MailAccount mailAccount = mailAccountQueryService.findActiveById(mailAccountId);
         validateRefreshableGoogleMailAccount(mailAccount);
+        String updatedRefreshToken = isBlank(tokenResult.refreshToken())
+                ? mailAccount.getRefreshToken()
+                : tokenResult.refreshToken();
 
-        mailAccount.updateAccessToken(tokenResult.accessToken());
-        mailAccount.updateAccessTokenExpiresAt(mailAccountQueryService.getKstNow().plusSeconds(tokenResult.expiresIn()));
-        if (!isBlank(tokenResult.refreshToken())) {
-            mailAccount.updateRefreshToken(tokenResult.refreshToken());
-        }
+        mailAccountRepositoryPort.updateGoogleTokenIfAccessTokenMatches(
+                mailAccountId,
+                mailAccount.getAccessToken(),
+                tokenResult.accessToken(),
+                mailAccountQueryService.getKstNow().plusSeconds(tokenResult.expiresIn()),
+                updatedRefreshToken
+        );
 
-        return mailAccount;
+        return mailAccountQueryService.findActiveById(mailAccountId);
     }
 
     private void validateGoogleMailAccountResult(GoogleMailAccountResult result) {

--- a/core/src/main/java/com/mailsangja/core/service/mail/MailAccountCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/mail/MailAccountCommandService.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -89,7 +88,7 @@ public class MailAccountCommandService {
         validateRefreshableGoogleMailAccount(mailAccount);
 
         mailAccount.updateAccessToken(tokenResult.accessToken());
-        mailAccount.updateAccessTokenExpiresAt(LocalDateTime.now().plusSeconds(tokenResult.expiresIn()));
+        mailAccount.updateAccessTokenExpiresAt(mailAccountQueryService.getKstNow().plusSeconds(tokenResult.expiresIn()));
         if (!isBlank(tokenResult.refreshToken())) {
             mailAccount.updateRefreshToken(tokenResult.refreshToken());
         }

--- a/core/src/main/java/com/mailsangja/core/service/mail/MailAccountCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/mail/MailAccountCommandService.java
@@ -3,6 +3,7 @@ package com.mailsangja.core.service.mail;
 import com.mailsangja.core.common.exception.mail.MailAccountErrorCode;
 import com.mailsangja.core.common.exception.mail.MailAccountException;
 import com.mailsangja.core.dto.mail.GoogleMailAccountResult;
+import com.mailsangja.core.dto.mail.GoogleOAuthTokenResult;
 import com.mailsangja.core.dto.mail.GoogleMailWatchResult;
 import com.mailsangja.core.dto.mail.MailAccountCreateCommand;
 import com.mailsangja.db.entity.mail.MailAccount;
@@ -13,7 +14,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -78,6 +81,22 @@ public class MailAccountCommandService {
         return savedMailAccount;
     }
 
+    @Transactional
+    public MailAccount refreshGoogleAccessToken(UUID mailAccountId, GoogleOAuthTokenResult tokenResult) {
+        validateRefreshGoogleAccessTokenInput(mailAccountId, tokenResult);
+
+        MailAccount mailAccount = mailAccountQueryService.findActiveById(mailAccountId);
+        validateRefreshableGoogleMailAccount(mailAccount);
+
+        mailAccount.updateAccessToken(tokenResult.accessToken());
+        mailAccount.updateAccessTokenExpiresAt(LocalDateTime.now().plusSeconds(tokenResult.expiresIn()));
+        if (!isBlank(tokenResult.refreshToken())) {
+            mailAccount.updateRefreshToken(tokenResult.refreshToken());
+        }
+
+        return mailAccount;
+    }
+
     private void validateGoogleMailAccountResult(GoogleMailAccountResult result) {
         if (result == null
                 || isBlank(result.emailAddress())
@@ -108,6 +127,26 @@ public class MailAccountCommandService {
         }
 
         if (isBlank(command.refreshToken())) {
+            throw new MailAccountException(MailAccountErrorCode.GOOGLE_REFRESH_TOKEN_MISSING);
+        }
+    }
+
+    private void validateRefreshGoogleAccessTokenInput(UUID mailAccountId, GoogleOAuthTokenResult tokenResult) {
+        if (mailAccountId == null
+                || tokenResult == null
+                || isBlank(tokenResult.accessToken())
+                || tokenResult.expiresIn() == null
+                || tokenResult.expiresIn() <= 0) {
+            throw new MailAccountException(MailAccountErrorCode.GOOGLE_TOKEN_REFRESH_FAILED);
+        }
+    }
+
+    private void validateRefreshableGoogleMailAccount(MailAccount mailAccount) {
+        if (mailAccount.getProvider() != MailProvider.GMAIL) {
+            throw new MailAccountException(MailAccountErrorCode.UNSUPPORTED_MAIL_PROVIDER);
+        }
+
+        if (isBlank(mailAccount.getRefreshToken())) {
             throw new MailAccountException(MailAccountErrorCode.GOOGLE_REFRESH_TOKEN_MISSING);
         }
     }

--- a/core/src/main/java/com/mailsangja/core/service/mail/MailAccountQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/mail/MailAccountQueryService.java
@@ -8,6 +8,8 @@ import com.mailsangja.db.port.MailAccountRepositoryPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -15,6 +17,8 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class MailAccountQueryService {
+
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
 
     private final MailAccountRepositoryPort mailAccountRepositoryPort;
 
@@ -42,5 +46,9 @@ public class MailAccountQueryService {
 
     public List<MailAccount> findAllActiveByUserId(UUID userId) {
         return mailAccountRepositoryPort.findAllByUserIdAndActiveAndDeletedAtIsNull(userId, true);
+    }
+
+    public LocalDateTime getKstNow() {
+        return LocalDateTime.now(KST_ZONE_ID);
     }
 }

--- a/core/src/main/java/com/mailsangja/core/service/mail/MailCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/mail/MailCommandService.java
@@ -28,6 +28,7 @@ import java.util.List;
 public class MailCommandService {
 
     private final MailQueryService mailQueryService;
+    private final GoogleAccessTokenEnsureService googleAccessTokenEnsureService;
     private final GoogleMailSendCommandService googleMailSendCommandService;
     private final GoogleMailMessageQueryService googleMailMessageQueryService;
     private final ThreadRepositoryPort threadRepositoryPort;
@@ -39,16 +40,17 @@ public class MailCommandService {
                 command.userId(),
                 command.from().address()
         );
+        MailAccount ensuredMailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(senderMailAccount);
 
-        var sendResult = googleMailSendCommandService.send(senderMailAccount, command);
+        var sendResult = googleMailSendCommandService.send(ensuredMailAccount, command);
         validateSendResult(sendResult);
         GoogleMailMessageResult messageResult = googleMailMessageQueryService.getMessage(
-                senderMailAccount.getAccessToken(),
+                ensuredMailAccount.getAccessToken(),
                 sendResult.gmailMessageId()
         );
         validateMessageResult(sendResult.gmailMessageId(), sendResult.gmailThreadId(), messageResult);
 
-        return new MailSendPersistCommand(senderMailAccount, messageResult, command);
+        return new MailSendPersistCommand(ensuredMailAccount, messageResult, command);
     }
 
     private void validateSendResult(GoogleMailSendResult sendResult) {

--- a/core/src/test/java/com/mailsangja/core/CoreApplicationTests.java
+++ b/core/src/test/java/com/mailsangja/core/CoreApplicationTests.java
@@ -1,13 +1,57 @@
 package com.mailsangja.core;
 
+import com.mailsangja.core.config.SecurityConfig;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
 
-@SpringBootTest
+@SpringBootTest(classes = CoreApplicationTests.TestApplication.class)
 class CoreApplicationTests {
 
     @Test
     void contextLoads() {
+    }
+
+    @SpringBootConfiguration
+    @EnableJpaAuditing
+    @EntityScan(basePackages = "com.mailsangja.db")
+    @EnableJpaRepositories(basePackages = "com.mailsangja.db")
+    @EnableAutoConfiguration
+    @ComponentScan(
+            basePackages = {"com.mailsangja.core", "com.mailsangja.db"},
+            excludeFilters = {
+                    @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class),
+                    @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = CoreApplication.class)
+            }
+    )
+    static class TestApplication {
+
+        @Bean
+        PasswordEncoder passwordEncoder() {
+            return Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8();
+        }
+
+        @Bean
+        AuthenticationManager authenticationManager() {
+            return authentication -> authentication;
+        }
+
+        @Bean
+        SecurityContextRepository securityContextRepository() {
+            return new HttpSessionSecurityContextRepository();
+        }
     }
 
 }

--- a/core/src/test/java/com/mailsangja/core/facade/MailFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/MailFacadeTest.java
@@ -5,13 +5,20 @@ import com.mailsangja.core.common.exception.mail.MailSendException;
 import com.mailsangja.core.dto.mail.GoogleMailAttachmentResult;
 import com.mailsangja.core.dto.mail.GoogleMailMessageResult;
 import com.mailsangja.core.dto.mail.GoogleMailSendResult;
+import com.mailsangja.core.dto.mail.GoogleOAuthTokenResult;
 import com.mailsangja.core.dto.mail.MailAttachmentDownloadResult;
+import com.mailsangja.core.dto.mail.MailSendCommand;
 import com.mailsangja.core.dto.mail.MailSendRequest;
+import com.mailsangja.core.config.properties.GoogleMailProperties;
+import com.mailsangja.core.config.properties.GoogleOAuthProperties;
 import com.mailsangja.core.service.google.GoogleMailAttachmentQueryService;
 import com.mailsangja.core.service.google.GoogleMailMessageQueryService;
+import com.mailsangja.core.service.google.GoogleOAuthQueryService;
 import com.mailsangja.core.service.google.GoogleMailSendCommandService;
+import com.mailsangja.core.service.mail.GoogleAccessTokenEnsureService;
 import com.mailsangja.core.service.mail.MailAttachmentQueryService;
 import com.mailsangja.core.service.mail.MailAccountQueryService;
+import com.mailsangja.core.service.mail.MailAccountCommandService;
 import com.mailsangja.core.service.mail.MailCommandService;
 import com.mailsangja.core.service.mail.MailQueryService;
 import com.mailsangja.db.entity.mail.Attachment;
@@ -220,10 +227,17 @@ class MailFacadeTest {
     }
 
     private MailFacade createMailFacade(List<MailAccount> mailAccounts, List<Attachment> attachments) {
-        MailQueryService mailQueryService = new MailQueryService(new FakeMailAccountRepositoryPort(mailAccounts));
-        MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(new FakeMailAccountRepositoryPort(mailAccounts));
+        FakeMailAccountRepositoryPort mailAccountRepositoryPort = new FakeMailAccountRepositoryPort(mailAccounts);
+        MailQueryService mailQueryService = new MailQueryService(mailAccountRepositoryPort);
+        MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(mailAccountRepositoryPort);
+        GoogleAccessTokenEnsureService googleAccessTokenEnsureService = new GoogleAccessTokenEnsureService(
+                mailAccountQueryService,
+                new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService),
+                new FakeGoogleOAuthQueryService()
+        );
         MailCommandService mailCommandService = new MailCommandService(
                 mailQueryService,
+                googleAccessTokenEnsureService,
                 new FakeGoogleMailSendCommandService(),
                 new FakeGoogleMailMessageQueryService(),
                 new FakeThreadRepositoryPort(),
@@ -235,6 +249,7 @@ class MailFacadeTest {
         );
         return new MailFacade(
                 mailAccountQueryService,
+                googleAccessTokenEnsureService,
                 mailCommandService,
                 mailAttachmentQueryService,
                 new FakeGoogleMailAttachmentQueryService()
@@ -315,12 +330,17 @@ class MailFacadeTest {
 
         @Override
         public Optional<MailAccount> findByIdAndDeletedAtIsNull(UUID id) {
-            return Optional.empty();
+            return mailAccounts.stream()
+                    .filter(mailAccount -> id.equals(mailAccount.getId()))
+                    .findFirst();
         }
 
         @Override
         public Optional<MailAccount> findByIdAndActiveAndDeletedAtIsNull(UUID id, boolean active) {
-            return Optional.empty();
+            return mailAccounts.stream()
+                    .filter(mailAccount -> id.equals(mailAccount.getId()))
+                    .filter(mailAccount -> mailAccount.isActive() == active)
+                    .findFirst();
         }
 
         @Override
@@ -410,11 +430,11 @@ class MailFacadeTest {
     private static class FakeGoogleMailSendCommandService extends GoogleMailSendCommandService {
 
         private FakeGoogleMailSendCommandService() {
-            super(new com.mailsangja.core.config.properties.GoogleMailProperties(), RestClient.builder().build());
+            super(new GoogleMailProperties(), RestClient.builder().build());
         }
 
         @Override
-        public GoogleMailSendResult send(MailAccount mailAccount, com.mailsangja.core.dto.mail.MailSendCommand command) {
+        public GoogleMailSendResult send(MailAccount mailAccount, MailSendCommand command) {
             return new GoogleMailSendResult(
                     "gmail-message-id",
                     "gmail-thread-id"
@@ -422,10 +442,28 @@ class MailFacadeTest {
         }
     }
 
+    private static class FakeGoogleOAuthQueryService extends GoogleOAuthQueryService {
+
+        private FakeGoogleOAuthQueryService() {
+            super(new GoogleOAuthProperties(), RestClient.builder().build());
+        }
+
+        @Override
+        public GoogleOAuthTokenResult refreshAccessToken(String refreshToken) {
+            return new GoogleOAuthTokenResult(
+                    "refreshed-token",
+                    refreshToken,
+                    3600L,
+                    null,
+                    "Bearer"
+            );
+        }
+    }
+
     private static class FakeGoogleMailMessageQueryService extends GoogleMailMessageQueryService {
 
         private FakeGoogleMailMessageQueryService() {
-            super(new com.mailsangja.core.config.properties.GoogleMailProperties(), RestClient.builder().build());
+            super(new GoogleMailProperties(), RestClient.builder().build());
         }
 
         @Override
@@ -458,7 +496,7 @@ class MailFacadeTest {
     private static class FakeGoogleMailAttachmentQueryService extends GoogleMailAttachmentQueryService {
 
         private FakeGoogleMailAttachmentQueryService() {
-            super(new com.mailsangja.core.config.properties.GoogleMailProperties(), RestClient.builder().build());
+            super(new GoogleMailProperties(), RestClient.builder().build());
         }
 
         @Override

--- a/core/src/test/java/com/mailsangja/core/facade/MailFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/MailFacadeTest.java
@@ -2,6 +2,8 @@ package com.mailsangja.core.facade;
 
 import com.mailsangja.core.common.exception.inbox.InboxException;
 import com.mailsangja.core.common.exception.mail.MailSendException;
+import com.mailsangja.core.config.properties.GoogleMailProperties;
+import com.mailsangja.core.config.properties.GoogleOAuthProperties;
 import com.mailsangja.core.dto.mail.GoogleMailAttachmentResult;
 import com.mailsangja.core.dto.mail.GoogleMailMessageResult;
 import com.mailsangja.core.dto.mail.GoogleMailSendResult;
@@ -9,24 +11,21 @@ import com.mailsangja.core.dto.mail.GoogleOAuthTokenResult;
 import com.mailsangja.core.dto.mail.MailAttachmentDownloadResult;
 import com.mailsangja.core.dto.mail.MailSendCommand;
 import com.mailsangja.core.dto.mail.MailSendRequest;
-import com.mailsangja.core.config.properties.GoogleMailProperties;
-import com.mailsangja.core.config.properties.GoogleOAuthProperties;
 import com.mailsangja.core.service.google.GoogleMailAttachmentQueryService;
 import com.mailsangja.core.service.google.GoogleMailMessageQueryService;
-import com.mailsangja.core.service.google.GoogleOAuthQueryService;
 import com.mailsangja.core.service.google.GoogleMailSendCommandService;
+import com.mailsangja.core.service.google.GoogleOAuthQueryService;
 import com.mailsangja.core.service.mail.GoogleAccessTokenEnsureService;
-import com.mailsangja.core.service.mail.MailAttachmentQueryService;
-import com.mailsangja.core.service.mail.MailAccountQueryService;
 import com.mailsangja.core.service.mail.MailAccountCommandService;
+import com.mailsangja.core.service.mail.MailAccountQueryService;
+import com.mailsangja.core.service.mail.MailAttachmentQueryService;
 import com.mailsangja.core.service.mail.MailCommandService;
 import com.mailsangja.core.service.mail.MailQueryService;
 import com.mailsangja.db.entity.mail.Attachment;
 import com.mailsangja.db.entity.mail.Direction;
-import com.mailsangja.db.entity.mail.GmailThreadLock;
 import com.mailsangja.db.entity.mail.MailAccount;
-import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.MailProvider;
+import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.Thread;
 import com.mailsangja.db.entity.user.Plan;
 import com.mailsangja.db.entity.user.Role;
@@ -37,19 +36,22 @@ import com.mailsangja.db.port.MailAccountRepositoryPort;
 import com.mailsangja.db.port.MessageRepositoryPort;
 import com.mailsangja.db.port.ThreadRepositoryPort;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.client.RestClient;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class MailFacadeTest {
 
@@ -227,7 +229,60 @@ class MailFacadeTest {
     }
 
     private MailFacade createMailFacade(List<MailAccount> mailAccounts, List<Attachment> attachments) {
-        FakeMailAccountRepositoryPort mailAccountRepositoryPort = new FakeMailAccountRepositoryPort(mailAccounts);
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        AttachmentRepositoryPort attachmentRepositoryPort = mock(AttachmentRepositoryPort.class);
+        ThreadRepositoryPort threadRepositoryPort = mock(ThreadRepositoryPort.class);
+        MessageRepositoryPort messageRepositoryPort = mock(MessageRepositoryPort.class);
+        GmailThreadLockRepositoryPort gmailThreadLockRepositoryPort = mock(GmailThreadLockRepositoryPort.class);
+
+        when(mailAccountRepositoryPort.findByUserIdAndEmailAddressAndActiveAndDeletedAtIsNull(any(), anyString(), eq(true)))
+                .thenAnswer(invocation -> mailAccounts.stream()
+                        .filter(mailAccount -> mailAccount.getUser() != null)
+                        .filter(mailAccount -> invocation.getArgument(0).equals(mailAccount.getUser().getId()))
+                        .filter(mailAccount -> invocation.getArgument(1).equals(mailAccount.getEmailAddress()))
+                        .filter(MailAccount::isActive)
+                        .findFirst());
+        when(mailAccountRepositoryPort.findAllByUserIdAndActiveAndDeletedAtIsNull(any(), eq(true)))
+                .thenAnswer(invocation -> mailAccounts.stream()
+                        .filter(mailAccount -> mailAccount.getUser() != null)
+                        .filter(mailAccount -> invocation.getArgument(0).equals(mailAccount.getUser().getId()))
+                        .filter(MailAccount::isActive)
+                        .toList());
+        when(mailAccountRepositoryPort.findByIdAndActiveAndDeletedAtIsNull(any(), eq(true)))
+                .thenAnswer(invocation -> mailAccounts.stream()
+                        .filter(mailAccount -> invocation.getArgument(0).equals(mailAccount.getId()))
+                        .filter(mailAccount -> mailAccount.isActive() == (boolean) invocation.getArgument(1))
+                        .findFirst());
+        when(attachmentRepositoryPort.findByIdAndDeletedAtIsNull(any()))
+                .thenAnswer(invocation -> attachments.stream()
+                        .filter(attachment -> invocation.getArgument(0).equals(attachment.getId()))
+                        .findFirst());
+        when(threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(any(), anyString(), any()))
+                .thenReturn(Optional.empty());
+        when(threadRepositoryPort.save(any(Thread.class))).thenAnswer(invocation -> {
+            Thread thread = invocation.getArgument(0);
+            if (thread.getId() != null) {
+                return thread;
+            }
+            return Thread.builder()
+                    .id(UUID.randomUUID())
+                    .mailAccount(thread.getMailAccount())
+                    .gmailThreadId(thread.getGmailThreadId())
+                    .direction(thread.getDirection())
+                    .historyId(thread.getHistoryId())
+                    .latestSubject(thread.getLatestSubject())
+                    .latestSnippet(thread.getLatestSnippet())
+                    .latestParticipantAddress(thread.getLatestParticipantAddress())
+                    .latestParticipantName(thread.getLatestParticipantName())
+                    .lastMessageAt(thread.getLastMessageAt())
+                    .read(thread.isRead())
+                    .messageCount(thread.getMessageCount())
+                    .build();
+        });
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(any(), anyString()))
+                .thenReturn(Optional.empty());
+        when(messageRepositoryPort.save(any(Message.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
         MailQueryService mailQueryService = new MailQueryService(mailAccountRepositoryPort);
         MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(mailAccountRepositoryPort);
         GoogleAccessTokenEnsureService googleAccessTokenEnsureService = new GoogleAccessTokenEnsureService(
@@ -240,13 +295,11 @@ class MailFacadeTest {
                 googleAccessTokenEnsureService,
                 new FakeGoogleMailSendCommandService(),
                 new FakeGoogleMailMessageQueryService(),
-                new FakeThreadRepositoryPort(),
-                new FakeMessageRepositoryPort(),
-                new FakeGmailThreadLockRepositoryPort()
+                threadRepositoryPort,
+                messageRepositoryPort,
+                gmailThreadLockRepositoryPort
         );
-        MailAttachmentQueryService mailAttachmentQueryService = new MailAttachmentQueryService(
-                new FakeAttachmentRepositoryPort(attachments)
-        );
+        MailAttachmentQueryService mailAttachmentQueryService = new MailAttachmentQueryService(attachmentRepositoryPort);
         return new MailFacade(
                 mailAccountQueryService,
                 googleAccessTokenEnsureService,
@@ -315,153 +368,7 @@ class MailFacadeTest {
                 .build();
     }
 
-    private static class FakeMailAccountRepositoryPort implements MailAccountRepositoryPort {
-
-        private final List<MailAccount> mailAccounts;
-
-        private FakeMailAccountRepositoryPort(List<MailAccount> mailAccounts) {
-            this.mailAccounts = mailAccounts;
-        }
-
-        @Override
-        public MailAccount save(MailAccount mailAccount) {
-            return mailAccount;
-        }
-
-        @Override
-        public Optional<MailAccount> findByIdAndDeletedAtIsNull(UUID id) {
-            return mailAccounts.stream()
-                    .filter(mailAccount -> id.equals(mailAccount.getId()))
-                    .findFirst();
-        }
-
-        @Override
-        public Optional<MailAccount> findByIdAndActiveAndDeletedAtIsNull(UUID id, boolean active) {
-            return mailAccounts.stream()
-                    .filter(mailAccount -> id.equals(mailAccount.getId()))
-                    .filter(mailAccount -> mailAccount.isActive() == active)
-                    .findFirst();
-        }
-
-        @Override
-        public Optional<MailAccount> findByEmailAddressAndDeletedAtIsNull(String emailAddress) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<MailAccount> findByUserIdAndProviderAndDeletedAtIsNull(UUID userId, MailProvider provider) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<MailAccount> findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(
-                UUID userId,
-                MailProvider provider,
-                String emailAddress
-        ) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<MailAccount> findByUserIdAndEmailAddressAndActiveAndDeletedAtIsNull(
-                UUID userId,
-                String emailAddress,
-                boolean active
-        ) {
-            return mailAccounts.stream()
-                    .filter(mailAccount -> mailAccount.getUser() != null)
-                    .filter(mailAccount -> userId.equals(mailAccount.getUser().getId()))
-                    .filter(mailAccount -> emailAddress.equalsIgnoreCase(mailAccount.getEmailAddress()))
-                    .filter(mailAccount -> mailAccount.isActive() == active)
-                    .findFirst();
-        }
-
-        @Override
-        public Optional<MailAccount> findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress) {
-            return Optional.empty();
-        }
-
-        @Override
-        public List<MailAccount> findAllByUserIdAndDeletedAtIsNull(UUID userId) {
-            return List.of();
-        }
-
-        @Override
-        public int updateGoogleTokenIfAccessTokenMatches(
-                UUID id,
-                String expectedAccessToken,
-                String newAccessToken,
-                LocalDateTime newAccessTokenExpiresAt,
-                String newRefreshToken
-        ) {
-            return mailAccounts.stream()
-                    .filter(mailAccount -> id.equals(mailAccount.getId()))
-                    .filter(mailAccount -> expectedAccessToken.equals(mailAccount.getAccessToken()))
-                    .findFirst()
-                    .map(mailAccount -> {
-                        mailAccount.updateAccessToken(newAccessToken);
-                        mailAccount.updateAccessTokenExpiresAt(newAccessTokenExpiresAt);
-                        mailAccount.updateRefreshToken(newRefreshToken);
-                        return 1;
-                    })
-                    .orElse(0);
-        }
-
-        @Override
-        public int renewGoogleWatchIfAccessTokenMatches(
-                UUID id,
-                String expectedAccessToken,
-                String newAccessToken,
-                LocalDateTime newAccessTokenExpiresAt,
-                String newRefreshToken,
-                String newSyncHistoryId,
-                LocalDateTime newWatchExpiresAt
-        ) {
-            return 0;
-        }
-
-        @Override
-        public List<MailAccount> findRenewalTargetGmailAccounts(MailProvider provider, LocalDateTime watchExpiresAtThreshold, int limit) {
-            return List.of();
-        }
-
-        @Override
-        public List<MailAccount> findAllByUserIdAndActiveAndDeletedAtIsNull(UUID userId, boolean active) {
-            return mailAccounts.stream()
-                    .filter(mailAccount -> mailAccount.getUser() != null)
-                    .filter(mailAccount -> userId.equals(mailAccount.getUser().getId()))
-                    .filter(mailAccount -> mailAccount.isActive() == active)
-                    .toList();
-        }
-    }
-
-    private static class FakeAttachmentRepositoryPort implements AttachmentRepositoryPort {
-
-        private final List<Attachment> attachments;
-
-        private FakeAttachmentRepositoryPort(List<Attachment> attachments) {
-            this.attachments = attachments;
-        }
-
-        @Override
-        public Attachment save(Attachment attachment) {
-            return attachment;
-        }
-
-        @Override
-        public Optional<Attachment> findByIdAndDeletedAtIsNull(UUID id) {
-            return attachments.stream()
-                    .filter(attachment -> id.equals(attachment.getId()))
-                    .findFirst();
-        }
-
-        @Override
-        public List<Attachment> findAllByMessageIdAndDeletedAtIsNull(UUID messageId) {
-            return List.of();
-        }
-    }
-
-    private static class FakeGoogleMailSendCommandService extends GoogleMailSendCommandService {
+    private static final class FakeGoogleMailSendCommandService extends GoogleMailSendCommandService {
 
         private FakeGoogleMailSendCommandService() {
             super(new GoogleMailProperties(), RestClient.builder().build());
@@ -469,14 +376,11 @@ class MailFacadeTest {
 
         @Override
         public GoogleMailSendResult send(MailAccount mailAccount, MailSendCommand command) {
-            return new GoogleMailSendResult(
-                    "gmail-message-id",
-                    "gmail-thread-id"
-            );
+            return new GoogleMailSendResult("gmail-message-id", "gmail-thread-id");
         }
     }
 
-    private static class FakeGoogleOAuthQueryService extends GoogleOAuthQueryService {
+    private static final class FakeGoogleOAuthQueryService extends GoogleOAuthQueryService {
 
         private FakeGoogleOAuthQueryService() {
             super(new GoogleOAuthProperties(), RestClient.builder().build());
@@ -484,17 +388,11 @@ class MailFacadeTest {
 
         @Override
         public GoogleOAuthTokenResult refreshAccessToken(String refreshToken) {
-            return new GoogleOAuthTokenResult(
-                    "refreshed-token",
-                    refreshToken,
-                    3600L,
-                    null,
-                    "Bearer"
-            );
+            return new GoogleOAuthTokenResult("refreshed-token", refreshToken, 3600L, null, "Bearer");
         }
     }
 
-    private static class FakeGoogleMailMessageQueryService extends GoogleMailMessageQueryService {
+    private static final class FakeGoogleMailMessageQueryService extends GoogleMailMessageQueryService {
 
         private FakeGoogleMailMessageQueryService() {
             super(new GoogleMailProperties(), RestClient.builder().build());
@@ -517,17 +415,12 @@ class MailFacadeTest {
                     LocalDateTime.now(),
                     "본문",
                     null,
-                    List.of(new GoogleMailAttachmentResult(
-                            "gmail-attachment-id",
-                            "file.txt",
-                            "text/plain",
-                            5
-                    ))
+                    List.of(new GoogleMailAttachmentResult("gmail-attachment-id", "file.txt", "text/plain", 5))
             );
         }
     }
 
-    private static class FakeGoogleMailAttachmentQueryService extends GoogleMailAttachmentQueryService {
+    private static final class FakeGoogleMailAttachmentQueryService extends GoogleMailAttachmentQueryService {
 
         private FakeGoogleMailAttachmentQueryService() {
             super(new GoogleMailProperties(), RestClient.builder().build());
@@ -536,266 +429,6 @@ class MailFacadeTest {
         @Override
         public byte[] download(MailAccount mailAccount, Message message, Attachment attachment) {
             return "file-content".getBytes();
-        }
-    }
-
-    private static class FakeThreadRepositoryPort implements ThreadRepositoryPort {
-
-        private final List<Thread> threads = new ArrayList<>();
-
-        @Override
-        public Thread save(Thread thread) {
-            Thread savedThread = thread.getId() == null
-                    ? Thread.builder()
-                    .id(UUID.randomUUID())
-                    .mailAccount(thread.getMailAccount())
-                    .gmailThreadId(thread.getGmailThreadId())
-                    .direction(thread.getDirection())
-                    .historyId(thread.getHistoryId())
-                    .latestSubject(thread.getLatestSubject())
-                    .latestSnippet(thread.getLatestSnippet())
-                    .latestParticipantAddress(thread.getLatestParticipantAddress())
-                    .latestParticipantName(thread.getLatestParticipantName())
-                    .lastMessageAt(thread.getLastMessageAt())
-                    .read(thread.isRead())
-                    .messageCount(thread.getMessageCount())
-                    .build()
-                    : thread;
-            threads.removeIf(existing -> existing.getId() != null && existing.getId().equals(savedThread.getId()));
-            threads.add(savedThread);
-            return savedThread;
-        }
-
-        @Override
-        public Optional<Thread> findByIdAndDeletedAtIsNull(UUID id) {
-            return threads.stream().filter(thread -> id.equals(thread.getId())).findFirst();
-        }
-
-        public Optional<Thread> findByIdIncludingDeleted(UUID id) {
-            return threads.stream().filter(thread -> id.equals(thread.getId())).findFirst();
-        }
-
-        @Override
-        public Optional<Thread> findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
-                UUID mailAccountId,
-                String gmailThreadId,
-                Direction direction
-        ) {
-            return threads.stream()
-                    .filter(thread -> thread.getMailAccount() != null)
-                    .filter(thread -> mailAccountId.equals(thread.getMailAccount().getId()))
-                    .filter(thread -> gmailThreadId.equals(thread.getGmailThreadId()))
-                    .filter(thread -> direction == thread.getDirection())
-                    .findFirst();
-        }
-
-        @Override
-        public List<Thread> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId) {
-            return List.of();
-        }
-
-        public List<Thread> findAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return List.of();
-        }
-
-        public void hardDeleteAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-        }
-
-        public int bulkRestoreAndResetMessageCountByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return 0;
-        }
-
-        public int bulkRestoreByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return 0;
-        }
-
-        public int bulkSoftDeleteByMailAccountIdAndGmailThreadId(
-                UUID mailAccountId,
-                String gmailThreadId,
-                LocalDateTime deletedAt
-        ) {
-            return 0;
-        }
-
-        @Override
-        public org.springframework.data.domain.Slice<Thread> findInboxByUserIdAndDeletedAtIsNull(
-                UUID userId,
-                UUID markerId,
-                org.springframework.data.domain.Pageable pageable
-        ) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public org.springframework.data.domain.Slice<Thread> findSentByUserIdAndDeletedAtIsNull(
-                UUID userId,
-                UUID markerId,
-                org.springframework.data.domain.Pageable pageable
-        ) {
-            throw new UnsupportedOperationException();
-        }
-
-        public Slice<Thread> findTrashByUserId(UUID userId, UUID markerId, Pageable pageable) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long countUnreadInboxByUserId(UUID userId) {
-            throw new UnsupportedOperationException();
-        }
-    }
-
-    private static class FakeGmailThreadLockRepositoryPort implements GmailThreadLockRepositoryPort {
-
-        @Override
-        public GmailThreadLock save(GmailThreadLock gmailThreadLock) {
-            return gmailThreadLock;
-        }
-
-        @Override
-        public void acquireThreadLock(MailAccount mailAccount, String gmailThreadId) {
-        }
-
-        @Override
-        public Optional<GmailThreadLock> findByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
-                UUID mailAccountId,
-                String gmailThreadId
-        ) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<GmailThreadLock> findByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullForUpdate(
-                UUID mailAccountId,
-                String gmailThreadId
-        ) {
-            return Optional.empty();
-        }
-    }
-
-    private static class FakeMessageRepositoryPort implements MessageRepositoryPort {
-
-        private final List<Message> messages = new ArrayList<>();
-
-        public Optional<Message> findByIdIncludingDeleted(UUID id) {
-            return messages.stream()
-                    .filter(message -> id.equals(message.getId()))
-                    .findFirst();
-        }
-
-        @Override
-        public Message save(Message message) {
-            messages.removeIf(existing -> existing.getId() != null && existing.getId().equals(message.getId()));
-            messages.add(message);
-            return message;
-        }
-
-        @Override
-        public Optional<Message> findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(UUID threadId, String gmailMessageId) {
-            if (threadId == null) {
-                return Optional.empty();
-            }
-            return messages.stream()
-                    .filter(message -> message.getThread() != null)
-                    .filter(message -> threadId.equals(message.getThread().getId()))
-                    .filter(message -> gmailMessageId.equals(message.getGmailMessageId()))
-                    .findFirst();
-        }
-
-        public Optional<Message> findByThreadIdAndGmailMessageId(UUID threadId, String gmailMessageId) {
-            if (threadId == null) {
-                return Optional.empty();
-            }
-            return messages.stream()
-                    .filter(message -> message.getThread() != null)
-                    .filter(message -> threadId.equals(message.getThread().getId()))
-                    .filter(message -> gmailMessageId.equals(message.getGmailMessageId()))
-                    .findFirst();
-        }
-
-        @Override
-        public Optional<Message> findByMailAccountIdAndGmailThreadIdAndGmailMessageIdAndDeletedAtIsNull(
-                UUID mailAccountId,
-                String gmailThreadId,
-                String gmailMessageId
-        ) {
-            return Optional.empty();
-        }
-
-        public Optional<Message> findByMailAccountIdAndGmailThreadIdAndGmailMessageId(
-                UUID mailAccountId,
-                String gmailThreadId,
-                String gmailMessageId
-        ) {
-            return Optional.empty();
-        }
-
-        @Override
-        public List<Message> findAllByThreadIdAndDeletedAtIsNull(UUID threadId) {
-            return List.of();
-        }
-
-        public List<Message> findAllByThreadIdIncludingDeleted(UUID threadId) {
-            return List.of();
-        }
-
-        @Override
-        public List<Message> findAllByThreadIdInAndDeletedAtIsNull(List<UUID> threadIds) {
-            return List.of();
-        }
-
-        @Override
-        public List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId) {
-            return List.of();
-        }
-
-        public List<Message> findAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return List.of();
-        }
-
-        public boolean existsByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return messages.stream()
-                    .filter(message -> message.getThread() != null)
-                    .filter(message -> message.getThread().getMailAccount() != null)
-                    .anyMatch(message -> mailAccountId.equals(message.getThread().getMailAccount().getId())
-                            && gmailThreadId.equals(message.getThread().getGmailThreadId()));
-        }
-
-        public boolean existsByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullAndGmailMessageIdNot(
-                UUID mailAccountId,
-                String gmailThreadId,
-                String gmailMessageId
-        ) {
-            return messages.stream()
-                    .filter(message -> message.getThread() != null)
-                    .filter(message -> message.getThread().getMailAccount() != null)
-                    .anyMatch(message -> mailAccountId.equals(message.getThread().getMailAccount().getId())
-                            && gmailThreadId.equals(message.getThread().getGmailThreadId())
-                            && !gmailMessageId.equals(message.getGmailMessageId()));
-        }
-
-        public int bulkRestoreByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return 0;
-        }
-
-        public int bulkSoftDeleteByMailAccountIdAndGmailThreadId(
-                UUID mailAccountId,
-                String gmailThreadId,
-                LocalDateTime deletedAt
-        ) {
-            return 0;
-        }
-
-        public List<Message> findAllDeletedByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return List.of();
-        }
-
-        public Slice<Message> findDeletedByUserId(UUID userId, UUID markerId, Pageable pageable) {
-            throw new UnsupportedOperationException();
-        }
-
-        public void hardDelete(Message message) {
-            messages.remove(message);
         }
     }
 }

--- a/core/src/test/java/com/mailsangja/core/facade/MailFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/MailFacadeTest.java
@@ -387,6 +387,40 @@ class MailFacadeTest {
         }
 
         @Override
+        public int updateGoogleTokenIfAccessTokenMatches(
+                UUID id,
+                String expectedAccessToken,
+                String newAccessToken,
+                LocalDateTime newAccessTokenExpiresAt,
+                String newRefreshToken
+        ) {
+            return mailAccounts.stream()
+                    .filter(mailAccount -> id.equals(mailAccount.getId()))
+                    .filter(mailAccount -> expectedAccessToken.equals(mailAccount.getAccessToken()))
+                    .findFirst()
+                    .map(mailAccount -> {
+                        mailAccount.updateAccessToken(newAccessToken);
+                        mailAccount.updateAccessTokenExpiresAt(newAccessTokenExpiresAt);
+                        mailAccount.updateRefreshToken(newRefreshToken);
+                        return 1;
+                    })
+                    .orElse(0);
+        }
+
+        @Override
+        public int renewGoogleWatchIfAccessTokenMatches(
+                UUID id,
+                String expectedAccessToken,
+                String newAccessToken,
+                LocalDateTime newAccessTokenExpiresAt,
+                String newRefreshToken,
+                String newSyncHistoryId,
+                LocalDateTime newWatchExpiresAt
+        ) {
+            return 0;
+        }
+
+        @Override
         public List<MailAccount> findRenewalTargetGmailAccounts(MailProvider provider, LocalDateTime watchExpiresAtThreshold, int limit) {
             return List.of();
         }

--- a/core/src/test/java/com/mailsangja/core/service/google/GoogleOAuthQueryServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/google/GoogleOAuthQueryServiceTest.java
@@ -1,0 +1,52 @@
+package com.mailsangja.core.service.google;
+
+import com.mailsangja.core.config.properties.GoogleOAuthProperties;
+import com.mailsangja.core.dto.mail.GoogleMailAccountResult;
+import com.mailsangja.core.dto.mail.GoogleOAuthTokenResult;
+import com.mailsangja.core.dto.mail.GoogleUserInfoResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GoogleOAuthQueryServiceTest {
+
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    @Test
+    void getGoogleMailAccountResult_토큰만료시각을KST기준으로계산한다() {
+        GoogleOAuthQueryService service = new FakeGoogleOAuthQueryService();
+        LocalDateTime lowerBound = LocalDateTime.now(KST_ZONE_ID).plusSeconds(3600);
+
+        GoogleMailAccountResult result = service.getGoogleMailAccountResult("auth-code");
+
+        LocalDateTime upperBound = LocalDateTime.now(KST_ZONE_ID).plusSeconds(3600);
+
+        assertEquals("user@example.com", result.emailAddress());
+        assertEquals("access-token", result.accessToken());
+        assertEquals("refresh-token", result.refreshToken());
+        assertTrue(!result.accessTokenExpiresAt().isBefore(lowerBound));
+        assertTrue(!result.accessTokenExpiresAt().isAfter(upperBound));
+    }
+
+    private static final class FakeGoogleOAuthQueryService extends GoogleOAuthQueryService {
+
+        private FakeGoogleOAuthQueryService() {
+            super(new GoogleOAuthProperties(), RestClient.builder().build());
+        }
+
+        @Override
+        public GoogleOAuthTokenResult exchangeCodeForToken(String code) {
+            return new GoogleOAuthTokenResult("access-token", "refresh-token", 3600L, "scope", "Bearer");
+        }
+
+        @Override
+        public GoogleUserInfoResult fetchUserInfo(String accessToken) {
+            return new GoogleUserInfoResult("user@example.com", true);
+        }
+    }
+}

--- a/core/src/test/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestClient;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -18,9 +19,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class GoogleAccessTokenEnsureServiceTest {
 
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
+
     @Test
     void ensureValidGoogleAccessToken_만료가충분히남아있으면기존토큰을사용한다() {
-        MailAccount mailAccount = createMailAccount(LocalDateTime.now().plusMinutes(30), "access-token", "refresh-token");
+        MailAccount mailAccount = createMailAccount(LocalDateTime.now(KST_ZONE_ID).plusMinutes(30), "access-token", "refresh-token");
         InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
         FakeGoogleOAuthQueryService googleOAuthQueryService = new FakeGoogleOAuthQueryService();
         GoogleAccessTokenEnsureService service = createService(repository, googleOAuthQueryService);
@@ -33,7 +36,7 @@ class GoogleAccessTokenEnsureServiceTest {
 
     @Test
     void ensureValidGoogleAccessToken_만료가임박하면토큰을재발급한다() {
-        MailAccount mailAccount = createMailAccount(LocalDateTime.now().plusMinutes(5), "old-token", "refresh-token");
+        MailAccount mailAccount = createMailAccount(LocalDateTime.now(KST_ZONE_ID).plusMinutes(5), "old-token", "refresh-token");
         InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
         FakeGoogleOAuthQueryService googleOAuthQueryService = new FakeGoogleOAuthQueryService();
         GoogleAccessTokenEnsureService service = createService(repository, googleOAuthQueryService);

--- a/core/src/test/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureServiceTest.java
@@ -1,0 +1,154 @@
+package com.mailsangja.core.service.mail;
+
+import com.mailsangja.core.dto.mail.GoogleOAuthTokenResult;
+import com.mailsangja.core.config.properties.GoogleOAuthProperties;
+import com.mailsangja.core.service.google.GoogleOAuthQueryService;
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.MailProvider;
+import com.mailsangja.db.port.MailAccountRepositoryPort;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GoogleAccessTokenEnsureServiceTest {
+
+    @Test
+    void ensureValidGoogleAccessToken_만료가충분히남아있으면기존토큰을사용한다() {
+        MailAccount mailAccount = createMailAccount(LocalDateTime.now().plusMinutes(30), "access-token", "refresh-token");
+        InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
+        FakeGoogleOAuthQueryService googleOAuthQueryService = new FakeGoogleOAuthQueryService();
+        GoogleAccessTokenEnsureService service = createService(repository, googleOAuthQueryService);
+
+        MailAccount ensuredMailAccount = service.ensureValidGoogleAccessToken(mailAccount);
+
+        assertEquals("access-token", ensuredMailAccount.getAccessToken());
+        assertEquals(0, googleOAuthQueryService.refreshCallCount);
+    }
+
+    @Test
+    void ensureValidGoogleAccessToken_만료가임박하면토큰을재발급한다() {
+        MailAccount mailAccount = createMailAccount(LocalDateTime.now().plusMinutes(5), "old-token", "refresh-token");
+        InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
+        FakeGoogleOAuthQueryService googleOAuthQueryService = new FakeGoogleOAuthQueryService();
+        GoogleAccessTokenEnsureService service = createService(repository, googleOAuthQueryService);
+
+        MailAccount ensuredMailAccount = service.ensureValidGoogleAccessToken(mailAccount);
+
+        assertEquals("refreshed-token", ensuredMailAccount.getAccessToken());
+        assertEquals("new-refresh-token", ensuredMailAccount.getRefreshToken());
+        assertEquals(1, googleOAuthQueryService.refreshCallCount);
+    }
+
+    private GoogleAccessTokenEnsureService createService(
+            InMemoryMailAccountRepository repository,
+            FakeGoogleOAuthQueryService googleOAuthQueryService
+    ) {
+        MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(repository);
+        MailAccountCommandService mailAccountCommandService = new MailAccountCommandService(repository, mailAccountQueryService);
+        return new GoogleAccessTokenEnsureService(
+                mailAccountQueryService,
+                mailAccountCommandService,
+                googleOAuthQueryService
+        );
+    }
+
+    private MailAccount createMailAccount(LocalDateTime expiresAt, String accessToken, String refreshToken) {
+        return MailAccount.builder()
+                .id(UUID.randomUUID())
+                .provider(MailProvider.GMAIL)
+                .emailAddress("user@example.com")
+                .alias("alias")
+                .icon("icon")
+                .color("#4285F4")
+                .accessToken(accessToken)
+                .accessTokenExpiresAt(expiresAt)
+                .refreshToken(refreshToken)
+                .active(true)
+                .build();
+    }
+
+    private static final class FakeGoogleOAuthQueryService extends GoogleOAuthQueryService {
+        private int refreshCallCount;
+
+        private FakeGoogleOAuthQueryService() {
+            super(new GoogleOAuthProperties(), RestClient.builder().build());
+        }
+
+        @Override
+        public GoogleOAuthTokenResult refreshAccessToken(String refreshToken) {
+            refreshCallCount++;
+            return new GoogleOAuthTokenResult("refreshed-token", "new-refresh-token", 3600L, null, "Bearer");
+        }
+    }
+
+    private static final class InMemoryMailAccountRepository implements MailAccountRepositoryPort {
+        private final MailAccount mailAccount;
+
+        private InMemoryMailAccountRepository(MailAccount mailAccount) {
+            this.mailAccount = mailAccount;
+        }
+
+        @Override
+        public MailAccount save(MailAccount mailAccount) {
+            return this.mailAccount;
+        }
+
+        @Override
+        public Optional<MailAccount> findByIdAndDeletedAtIsNull(UUID id) {
+            return Optional.of(mailAccount).filter(account -> id.equals(account.getId()));
+        }
+
+        @Override
+        public Optional<MailAccount> findByIdAndActiveAndDeletedAtIsNull(UUID id, boolean active) {
+            return Optional.of(mailAccount)
+                    .filter(account -> id.equals(account.getId()))
+                    .filter(account -> account.isActive() == active);
+        }
+
+        @Override
+        public Optional<MailAccount> findByEmailAddressAndDeletedAtIsNull(String emailAddress) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<MailAccount> findByUserIdAndProviderAndDeletedAtIsNull(UUID userId, MailProvider provider) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<MailAccount> findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(UUID userId, MailProvider provider, String emailAddress) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<MailAccount> findByUserIdAndEmailAddressAndActiveAndDeletedAtIsNull(UUID userId, String emailAddress, boolean active) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<MailAccount> findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<MailAccount> findAllByUserIdAndDeletedAtIsNull(UUID userId) {
+            return List.of();
+        }
+
+        @Override
+        public List<MailAccount> findRenewalTargetGmailAccounts(MailProvider provider, LocalDateTime watchExpiresAtThreshold, int limit) {
+            return List.of();
+        }
+
+        @Override
+        public List<MailAccount> findAllByUserIdAndActiveAndDeletedAtIsNull(UUID userId, boolean active) {
+            return List.of();
+        }
+    }
+}

--- a/core/src/test/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureServiceTest.java
@@ -1,60 +1,102 @@
 package com.mailsangja.core.service.mail;
 
-import com.mailsangja.core.dto.mail.GoogleOAuthTokenResult;
 import com.mailsangja.core.config.properties.GoogleOAuthProperties;
+import com.mailsangja.core.dto.mail.GoogleOAuthTokenResult;
 import com.mailsangja.core.service.google.GoogleOAuthQueryService;
 import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.MailProvider;
 import com.mailsangja.db.port.MailAccountRepositoryPort;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.RestClient;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class GoogleAccessTokenEnsureServiceTest {
 
     private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
 
+    @Mock
+    private MailAccountRepositoryPort mailAccountRepositoryPort;
+
     @Test
     void ensureValidGoogleAccessToken_만료가충분히남아있으면기존토큰을사용한다() {
-        MailAccount mailAccount = createMailAccount(LocalDateTime.now(KST_ZONE_ID).plusMinutes(30), "access-token", "refresh-token");
-        InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
+        MailAccount mailAccount = createMailAccount(
+                LocalDateTime.now(KST_ZONE_ID).plusMinutes(30),
+                "access-token",
+                "refresh-token"
+        );
         FakeGoogleOAuthQueryService googleOAuthQueryService = new FakeGoogleOAuthQueryService();
-        GoogleAccessTokenEnsureService service = createService(repository, googleOAuthQueryService);
+        GoogleAccessTokenEnsureService service = createService(googleOAuthQueryService);
 
         MailAccount ensuredMailAccount = service.ensureValidGoogleAccessToken(mailAccount);
 
-        assertEquals("access-token", ensuredMailAccount.getAccessToken());
+        assertSame(mailAccount, ensuredMailAccount);
         assertEquals(0, googleOAuthQueryService.refreshCallCount);
+        verify(mailAccountRepositoryPort, never()).findByIdAndActiveAndDeletedAtIsNull(any(), eq(true));
+        verify(mailAccountRepositoryPort, never()).updateGoogleTokenIfAccessTokenMatches(any(), any(), any(), any(), any());
     }
 
     @Test
     void ensureValidGoogleAccessToken_만료가임박하면토큰을재발급한다() {
-        MailAccount mailAccount = createMailAccount(LocalDateTime.now(KST_ZONE_ID).plusMinutes(5), "old-token", "refresh-token");
-        InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
+        MailAccount mailAccount = createMailAccount(
+                LocalDateTime.now(KST_ZONE_ID).plusMinutes(5),
+                "old-token",
+                "refresh-token"
+        );
+        when(mailAccountRepositoryPort.findByIdAndActiveAndDeletedAtIsNull(mailAccount.getId(), true))
+                .thenReturn(Optional.of(mailAccount));
+        when(mailAccountRepositoryPort.updateGoogleTokenIfAccessTokenMatches(
+                eq(mailAccount.getId()),
+                eq("old-token"),
+                eq("refreshed-token"),
+                any(LocalDateTime.class),
+                eq("new-refresh-token")
+        )).thenAnswer(invocation -> {
+            mailAccount.updateAccessToken(invocation.getArgument(2));
+            mailAccount.updateAccessTokenExpiresAt(invocation.getArgument(3));
+            mailAccount.updateRefreshToken(invocation.getArgument(4));
+            return 1;
+        });
+
         FakeGoogleOAuthQueryService googleOAuthQueryService = new FakeGoogleOAuthQueryService();
-        GoogleAccessTokenEnsureService service = createService(repository, googleOAuthQueryService);
+        GoogleAccessTokenEnsureService service = createService(googleOAuthQueryService);
 
         MailAccount ensuredMailAccount = service.ensureValidGoogleAccessToken(mailAccount);
 
+        ArgumentCaptor<LocalDateTime> expiresAtCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(mailAccountRepositoryPort).updateGoogleTokenIfAccessTokenMatches(
+                eq(mailAccount.getId()),
+                eq("old-token"),
+                eq("refreshed-token"),
+                expiresAtCaptor.capture(),
+                eq("new-refresh-token")
+        );
         assertEquals("refreshed-token", ensuredMailAccount.getAccessToken());
         assertEquals("new-refresh-token", ensuredMailAccount.getRefreshToken());
         assertEquals(1, googleOAuthQueryService.refreshCallCount);
+        assertSame(mailAccount, ensuredMailAccount);
     }
 
-    private GoogleAccessTokenEnsureService createService(
-            InMemoryMailAccountRepository repository,
-            FakeGoogleOAuthQueryService googleOAuthQueryService
-    ) {
-        MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(repository);
+    private GoogleAccessTokenEnsureService createService(FakeGoogleOAuthQueryService googleOAuthQueryService) {
+        MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(mailAccountRepositoryPort);
         MailAccountCommandService mailAccountCommandService = new MailAccountCommandService(
-                repository,
+                mailAccountRepositoryPort,
                 mailAccountQueryService
         );
         return new GoogleAccessTokenEnsureService(
@@ -90,102 +132,6 @@ class GoogleAccessTokenEnsureServiceTest {
         public GoogleOAuthTokenResult refreshAccessToken(String refreshToken) {
             refreshCallCount++;
             return new GoogleOAuthTokenResult("refreshed-token", "new-refresh-token", 3600L, null, "Bearer");
-        }
-    }
-
-    private static final class InMemoryMailAccountRepository implements MailAccountRepositoryPort {
-        private final MailAccount mailAccount;
-
-        private InMemoryMailAccountRepository(MailAccount mailAccount) {
-            this.mailAccount = mailAccount;
-        }
-
-        @Override
-        public MailAccount save(MailAccount mailAccount) {
-            return this.mailAccount;
-        }
-
-        @Override
-        public Optional<MailAccount> findByIdAndDeletedAtIsNull(UUID id) {
-            return Optional.of(mailAccount).filter(account -> id.equals(account.getId()));
-        }
-
-        @Override
-        public Optional<MailAccount> findByIdAndActiveAndDeletedAtIsNull(UUID id, boolean active) {
-            return Optional.of(mailAccount)
-                    .filter(account -> id.equals(account.getId()))
-                    .filter(account -> account.isActive() == active);
-        }
-
-        @Override
-        public Optional<MailAccount> findByEmailAddressAndDeletedAtIsNull(String emailAddress) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<MailAccount> findByUserIdAndProviderAndDeletedAtIsNull(UUID userId, MailProvider provider) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<MailAccount> findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(UUID userId, MailProvider provider, String emailAddress) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<MailAccount> findByUserIdAndEmailAddressAndActiveAndDeletedAtIsNull(UUID userId, String emailAddress, boolean active) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<MailAccount> findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress) {
-            return Optional.empty();
-        }
-
-        @Override
-        public List<MailAccount> findAllByUserIdAndDeletedAtIsNull(UUID userId) {
-            return List.of();
-        }
-
-        @Override
-        public int updateGoogleTokenIfAccessTokenMatches(
-                UUID id,
-                String expectedAccessToken,
-                String newAccessToken,
-                LocalDateTime newAccessTokenExpiresAt,
-                String newRefreshToken
-        ) {
-            if (!id.equals(mailAccount.getId()) || !expectedAccessToken.equals(mailAccount.getAccessToken())) {
-                return 0;
-            }
-
-            mailAccount.updateAccessToken(newAccessToken);
-            mailAccount.updateAccessTokenExpiresAt(newAccessTokenExpiresAt);
-            mailAccount.updateRefreshToken(newRefreshToken);
-            return 1;
-        }
-
-        @Override
-        public int renewGoogleWatchIfAccessTokenMatches(
-                UUID id,
-                String expectedAccessToken,
-                String newAccessToken,
-                LocalDateTime newAccessTokenExpiresAt,
-                String newRefreshToken,
-                String newSyncHistoryId,
-                LocalDateTime newWatchExpiresAt
-        ) {
-            return 0;
-        }
-
-        @Override
-        public List<MailAccount> findRenewalTargetGmailAccounts(MailProvider provider, LocalDateTime watchExpiresAtThreshold, int limit) {
-            return List.of();
-        }
-
-        @Override
-        public List<MailAccount> findAllByUserIdAndActiveAndDeletedAtIsNull(UUID userId, boolean active) {
-            return List.of();
         }
     }
 }

--- a/core/src/test/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureServiceTest.java
@@ -50,7 +50,10 @@ class GoogleAccessTokenEnsureServiceTest {
             FakeGoogleOAuthQueryService googleOAuthQueryService
     ) {
         MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(repository);
-        MailAccountCommandService mailAccountCommandService = new MailAccountCommandService(repository, mailAccountQueryService);
+        MailAccountCommandService mailAccountCommandService = new MailAccountCommandService(
+                repository,
+                mailAccountQueryService
+        );
         return new GoogleAccessTokenEnsureService(
                 mailAccountQueryService,
                 mailAccountCommandService,

--- a/core/src/test/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureServiceTest.java
@@ -145,6 +145,37 @@ class GoogleAccessTokenEnsureServiceTest {
         }
 
         @Override
+        public int updateGoogleTokenIfAccessTokenMatches(
+                UUID id,
+                String expectedAccessToken,
+                String newAccessToken,
+                LocalDateTime newAccessTokenExpiresAt,
+                String newRefreshToken
+        ) {
+            if (!id.equals(mailAccount.getId()) || !expectedAccessToken.equals(mailAccount.getAccessToken())) {
+                return 0;
+            }
+
+            mailAccount.updateAccessToken(newAccessToken);
+            mailAccount.updateAccessTokenExpiresAt(newAccessTokenExpiresAt);
+            mailAccount.updateRefreshToken(newRefreshToken);
+            return 1;
+        }
+
+        @Override
+        public int renewGoogleWatchIfAccessTokenMatches(
+                UUID id,
+                String expectedAccessToken,
+                String newAccessToken,
+                LocalDateTime newAccessTokenExpiresAt,
+                String newRefreshToken,
+                String newSyncHistoryId,
+                LocalDateTime newWatchExpiresAt
+        ) {
+            return 0;
+        }
+
+        @Override
         public List<MailAccount> findRenewalTargetGmailAccounts(MailProvider provider, LocalDateTime watchExpiresAtThreshold, int limit) {
             return List.of();
         }

--- a/core/src/test/resources/application.yaml
+++ b/core/src/test/resources/application.yaml
@@ -1,0 +1,39 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:core-test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        default_schema: public
+
+  data:
+    redis:
+      repositories:
+        enabled: false
+
+  session:
+    redis:
+      configure-action: none
+
+mailsangja:
+  rabbitmq:
+    task:
+      exchange: mailsangja.mail.task
+      dead-letter-exchange: mailsangja.mail.task.dlx
+      ttl: 30m
+      retry-max-attempts: 3
+      concurrency: 1
+      publisher-mandatory: true
+    initial-mail-sync:
+      task-name: sync.gmail.initial
+  oauth:
+    google:
+      client-id: test-client-id
+      client-secret: test-client-secret

--- a/core/src/test/resources/application.yaml
+++ b/core/src/test/resources/application.yaml
@@ -12,6 +12,9 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
         default_schema: public
+  sql:
+    init:
+      mode: never
 
   data:
     redis:

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/MailAccountRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/MailAccountRepositoryAdapter.java
@@ -64,6 +64,44 @@ public class MailAccountRepositoryAdapter implements MailAccountRepositoryPort {
     }
 
     @Override
+    public int updateGoogleTokenIfAccessTokenMatches(
+            UUID id,
+            String expectedAccessToken,
+            String newAccessToken,
+            LocalDateTime newAccessTokenExpiresAt,
+            String newRefreshToken
+    ) {
+        return mailAccountJpaRepositoryModule.updateGoogleTokenIfAccessTokenMatches(
+                id,
+                expectedAccessToken,
+                newAccessToken,
+                newAccessTokenExpiresAt,
+                newRefreshToken
+        );
+    }
+
+    @Override
+    public int renewGoogleWatchIfAccessTokenMatches(
+            UUID id,
+            String expectedAccessToken,
+            String newAccessToken,
+            LocalDateTime newAccessTokenExpiresAt,
+            String newRefreshToken,
+            String newSyncHistoryId,
+            LocalDateTime newWatchExpiresAt
+    ) {
+        return mailAccountJpaRepositoryModule.renewGoogleWatchIfAccessTokenMatches(
+                id,
+                expectedAccessToken,
+                newAccessToken,
+                newAccessTokenExpiresAt,
+                newRefreshToken,
+                newSyncHistoryId,
+                newWatchExpiresAt
+        );
+    }
+
+    @Override
     public List<MailAccount> findRenewalTargetGmailAccounts(MailProvider provider, LocalDateTime watchExpiresAtThreshold, int limit) {
         return mailAccountJpaRepositoryModule.findRenewalTargetGmailAccounts(provider, watchExpiresAtThreshold)
                 .stream()

--- a/db/src/main/java/com/mailsangja/db/module/mail/MailAccountJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MailAccountJpaRepositoryModule.java
@@ -4,6 +4,7 @@ import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.MailProvider;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -35,6 +36,46 @@ public interface MailAccountJpaRepositoryModule extends JpaRepository<MailAccoun
 
     @EntityGraph(attributePaths = {"user"})
     List<MailAccount> findAllByUserIdAndDeletedAtIsNull(UUID userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE MailAccount ma
+            SET ma.accessToken = :newAccessToken,
+                ma.accessTokenExpiresAt = :newAccessTokenExpiresAt,
+                ma.refreshToken = :newRefreshToken
+            WHERE ma.id = :id
+              AND ma.deletedAt IS NULL
+              AND ma.accessToken = :expectedAccessToken
+            """)
+    int updateGoogleTokenIfAccessTokenMatches(
+            @Param("id") UUID id,
+            @Param("expectedAccessToken") String expectedAccessToken,
+            @Param("newAccessToken") String newAccessToken,
+            @Param("newAccessTokenExpiresAt") LocalDateTime newAccessTokenExpiresAt,
+            @Param("newRefreshToken") String newRefreshToken
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE MailAccount ma
+            SET ma.accessToken = :newAccessToken,
+                ma.accessTokenExpiresAt = :newAccessTokenExpiresAt,
+                ma.refreshToken = :newRefreshToken,
+                ma.syncHistoryId = :newSyncHistoryId,
+                ma.watchExpiresAt = :newWatchExpiresAt
+            WHERE ma.id = :id
+              AND ma.deletedAt IS NULL
+              AND ma.accessToken = :expectedAccessToken
+            """)
+    int renewGoogleWatchIfAccessTokenMatches(
+            @Param("id") UUID id,
+            @Param("expectedAccessToken") String expectedAccessToken,
+            @Param("newAccessToken") String newAccessToken,
+            @Param("newAccessTokenExpiresAt") LocalDateTime newAccessTokenExpiresAt,
+            @Param("newRefreshToken") String newRefreshToken,
+            @Param("newSyncHistoryId") String newSyncHistoryId,
+            @Param("newWatchExpiresAt") LocalDateTime newWatchExpiresAt
+    );
 
     @EntityGraph(attributePaths = {"user"})
     List<MailAccount> findAllByUserIdAndActiveAndDeletedAtIsNull(UUID userId, boolean active);

--- a/db/src/main/java/com/mailsangja/db/port/MailAccountRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/MailAccountRepositoryPort.java
@@ -18,6 +18,22 @@ public interface MailAccountRepositoryPort {
     Optional<MailAccount> findByUserIdAndEmailAddressAndActiveAndDeletedAtIsNull(UUID userId, String emailAddress, boolean active);
     Optional<MailAccount> findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress);
     List<MailAccount> findAllByUserIdAndDeletedAtIsNull(UUID userId);
+    int updateGoogleTokenIfAccessTokenMatches(
+            UUID id,
+            String expectedAccessToken,
+            String newAccessToken,
+            LocalDateTime newAccessTokenExpiresAt,
+            String newRefreshToken
+    );
+    int renewGoogleWatchIfAccessTokenMatches(
+            UUID id,
+            String expectedAccessToken,
+            String newAccessToken,
+            LocalDateTime newAccessTokenExpiresAt,
+            String newRefreshToken,
+            String newSyncHistoryId,
+            LocalDateTime newWatchExpiresAt
+    );
     List<MailAccount> findRenewalTargetGmailAccounts(MailProvider provider, LocalDateTime watchExpiresAtThreshold, int limit);
     List<MailAccount> findAllByUserIdAndActiveAndDeletedAtIsNull(UUID userId, boolean active);
 }

--- a/worker/src/main/java/com/mailsangja/worker/common/exception/mail/MailPushErrorCode.java
+++ b/worker/src/main/java/com/mailsangja/worker/common/exception/mail/MailPushErrorCode.java
@@ -20,6 +20,7 @@ public enum MailPushErrorCode implements ErrorCode {
     INVALID_GMAIL_WATCH_RENEWAL_COMMAND(400, "MS-MAIL-INVALID-GMAIL-WATCH-RENEWAL-COMMAND", "Gmail watch 갱신 메시지 값이 올바르지 않습니다."),
     MAIL_ACCOUNT_NOT_FOUND(404, "MS-MAIL-ACCOUNT-NOT-FOUND", "메일 계정을 찾을 수 없습니다."),
     INVALID_MAIL_ACCOUNT_STATE(400, "MS-MAIL-INVALID-MAIL-ACCOUNT-STATE", "이벤트를 처리할 수 없는 메일 계정 상태입니다."),
+    GOOGLE_REFRESH_TOKEN_MISSING(400, "MS-MAIL-GOOGLE-REFRESH-TOKEN-MISSING", "Google 계정 재연동이 필요합니다. 다시 동의하고 계정을 연결해주세요."),
     GOOGLE_TOKEN_REFRESH_FAILED(502, "MS-MAIL-GOOGLE-TOKEN-REFRESH-FAILED", "Google access token 재발급에 실패했습니다."),
     GOOGLE_MAIL_WATCH_FAILED(502, "MS-MAIL-GOOGLE-MAIL-WATCH-FAILED", "Google Gmail watch 등록에 실패했습니다."),
     GOOGLE_MAIL_WATCH_RESULT_INVALID(502, "MS-MAIL-GOOGLE-MAIL-WATCH-RESULT-INVALID", "Google Gmail watch 응답값이 올바르지 않습니다."),

--- a/worker/src/main/java/com/mailsangja/worker/facade/GmailPushFacade.java
+++ b/worker/src/main/java/com/mailsangja/worker/facade/GmailPushFacade.java
@@ -13,6 +13,7 @@ import com.mailsangja.worker.handler.mail.GmailHistoryEventClassifier;
 import com.mailsangja.worker.handler.mail.GmailHistoryEventHandler;
 import com.mailsangja.worker.service.google.GooglePubsubOidcQueryService;
 import com.mailsangja.worker.service.google.GoogleMailHistoryQueryService;
+import com.mailsangja.worker.service.mail.GoogleAccessTokenEnsureService;
 import com.mailsangja.worker.service.mail.MailAccountCommandService;
 import com.mailsangja.worker.service.mail.MailAccountQueryService;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,7 @@ public class GmailPushFacade {
     private final GooglePubsubOidcQueryService googlePubsubOidcQueryService;
     private final MailAccountCommandService mailAccountCommandService;
     private final MailAccountQueryService mailAccountQueryService;
+    private final GoogleAccessTokenEnsureService googleAccessTokenEnsureService;
     private final GoogleMailHistoryQueryService googleMailHistoryQueryService;
     private final GmailHistoryEventClassifier gmailHistoryEventClassifier;
     private final List<GmailHistoryEventHandler> gmailHistoryEventHandlers;
@@ -43,7 +45,9 @@ public class GmailPushFacade {
         GoogleMailPushNotificationResult notification = decodeNotification(request.message());
         validateNotification(notification);
 
-        MailAccount mailAccount = mailAccountQueryService.findActiveGoogleMailAccountByEmailAddress(notification.emailAddress());
+        MailAccount mailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(
+                mailAccountQueryService.findActiveGoogleMailAccountByEmailAddress(notification.emailAddress())
+        );
         String startHistoryId = resolveStartHistoryId(mailAccount, notification.historyId());
 
         GoogleMailHistoryListResult historyResult = googleMailHistoryQueryService.getHistory(

--- a/worker/src/main/java/com/mailsangja/worker/facade/InitialMailSyncFacade.java
+++ b/worker/src/main/java/com/mailsangja/worker/facade/InitialMailSyncFacade.java
@@ -11,6 +11,7 @@ import com.mailsangja.worker.dto.mail.sync.InitialMailSyncMessage;
 import com.mailsangja.worker.dto.mail.sync.InitialMailSyncThreadResult;
 import com.mailsangja.worker.dto.mail.sync.InitialMailSyncThreadSaveCommand;
 import com.mailsangja.worker.service.google.GoogleMailMessageQueryService;
+import com.mailsangja.worker.service.mail.GoogleAccessTokenEnsureService;
 import com.mailsangja.worker.service.mail.InitialMailSyncCommandService;
 import com.mailsangja.worker.service.mail.MailAccountQueryService;
 import com.mailsangja.worker.service.messaging.MailTaskPublisherService;
@@ -28,6 +29,7 @@ import java.util.List;
 public class InitialMailSyncFacade {
 
     private final MailAccountQueryService mailAccountQueryService;
+    private final GoogleAccessTokenEnsureService googleAccessTokenEnsureService;
     private final GoogleMailMessageQueryService googleMailMessageQueryService;
     private final MailTaskPublisherService mailTaskPublisherService;
     private final GoogleMailInitialSyncProperties googleMailInitialSyncProperties;
@@ -36,7 +38,9 @@ public class InitialMailSyncFacade {
     public void handleInitialMailSync(InitialMailSyncMessage message) {
         validateMessage(message);
 
-        MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(message.mailAccountId());
+        MailAccount mailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(
+                mailAccountQueryService.findActiveMailAccountById(message.mailAccountId())
+        );
         GoogleMailMessageListResult result = googleMailMessageQueryService.getLatestMessages(mailAccount.getAccessToken());
         List<String> threadIds = extractThreadIds(result);
         List<List<String>> threadBatches = partitionThreadIds(threadIds);
@@ -66,7 +70,9 @@ public class InitialMailSyncFacade {
     public void handleInitialMailSyncThreadBatch(InitialMailSyncThreadBatchMessage message) {
         validateThreadBatchMessage(message);
 
-        MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(message.mailAccountId());
+        MailAccount mailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(
+                mailAccountQueryService.findActiveMailAccountById(message.mailAccountId())
+        );
         List<InitialMailSyncThreadResult> threadResults = googleMailMessageQueryService.getThreads(
                 mailAccount.getAccessToken(),
                 message.threadIds()

--- a/worker/src/main/java/com/mailsangja/worker/facade/InitialMailSyncFacade.java
+++ b/worker/src/main/java/com/mailsangja/worker/facade/InitialMailSyncFacade.java
@@ -38,9 +38,7 @@ public class InitialMailSyncFacade {
     public void handleInitialMailSync(InitialMailSyncMessage message) {
         validateMessage(message);
 
-        MailAccount mailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(
-                mailAccountQueryService.findActiveMailAccountById(message.mailAccountId())
-        );
+        MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(message.mailAccountId());
         GoogleMailMessageListResult result = googleMailMessageQueryService.getLatestMessages(mailAccount.getAccessToken());
         List<String> threadIds = extractThreadIds(result);
         List<List<String>> threadBatches = partitionThreadIds(threadIds);
@@ -70,9 +68,7 @@ public class InitialMailSyncFacade {
     public void handleInitialMailSyncThreadBatch(InitialMailSyncThreadBatchMessage message) {
         validateThreadBatchMessage(message);
 
-        MailAccount mailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(
-                mailAccountQueryService.findActiveMailAccountById(message.mailAccountId())
-        );
+        MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(message.mailAccountId());
         List<InitialMailSyncThreadResult> threadResults = googleMailMessageQueryService.getThreads(
                 mailAccount.getAccessToken(),
                 message.threadIds()

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/GmailHistoryStateCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/GmailHistoryStateCommandService.java
@@ -17,6 +17,7 @@ import java.util.List;
 public class GmailHistoryStateCommandService {
 
     private final MailAccountQueryService mailAccountQueryService;
+    private final GoogleAccessTokenEnsureService googleAccessTokenEnsureService;
     private final GmailHistoryStateQueryService gmailHistoryStateQueryService;
     private final GoogleMailMessageQueryService googleMailMessageQueryService;
     private final GmailHistoryStateApplyCommandService gmailHistoryStateApplyCommandService;
@@ -32,7 +33,9 @@ public class GmailHistoryStateCommandService {
     private void processMessageReadState(GmailHistoryEvent event, boolean read) {
         validateEvent(event);
 
-        MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(event.mailAccountId());
+        MailAccount mailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(
+                mailAccountQueryService.findActiveMailAccountById(event.mailAccountId())
+        );
         InitialMailSyncThreadSaveCommand syncCommand = prepareSyncCommandIfNeeded(mailAccount, event);
 
         gmailHistoryStateApplyCommandService.applyMessageReadState(mailAccount, event, read, syncCommand);

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageSyncCommandService.java
@@ -17,13 +17,16 @@ import java.util.List;
 public class GmailNewMessageSyncCommandService {
 
     private final MailAccountQueryService mailAccountQueryService;
+    private final GoogleAccessTokenEnsureService googleAccessTokenEnsureService;
     private final GoogleMailMessageQueryService googleMailMessageQueryService;
     private final GmailNewMessageApplyCommandService gmailNewMessageApplyCommandService;
 
     public void syncNewMessage(GmailHistoryEvent event) {
         validateEvent(event);
 
-        MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(event.mailAccountId());
+        MailAccount mailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(
+                mailAccountQueryService.findActiveMailAccountById(event.mailAccountId())
+        );
 
         List<InitialMailSyncThreadResult> threadResults = googleMailMessageQueryService.getThreads(
                 mailAccount.getAccessToken(),

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/GoogleAccessTokenEnsureService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/GoogleAccessTokenEnsureService.java
@@ -1,0 +1,75 @@
+package com.mailsangja.worker.service.mail;
+
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.MailProvider;
+import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
+import com.mailsangja.worker.common.exception.mail.MailPushException;
+import com.mailsangja.worker.service.google.GoogleOAuthQueryService;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class GoogleAccessTokenEnsureService {
+
+    private static final long REFRESH_WINDOW_MINUTES = 10L;
+
+    private final MailAccountQueryService mailAccountQueryService;
+    private final MailAccountCommandService mailAccountCommandService;
+    private final GoogleOAuthQueryService googleOAuthQueryService;
+
+    public GoogleAccessTokenEnsureService(
+            MailAccountQueryService mailAccountQueryService,
+            MailAccountCommandService mailAccountCommandService,
+            GoogleOAuthQueryService googleOAuthQueryService
+    ) {
+        this.mailAccountQueryService = mailAccountQueryService;
+        this.mailAccountCommandService = mailAccountCommandService;
+        this.googleOAuthQueryService = googleOAuthQueryService;
+    }
+
+    public MailAccount ensureValidGoogleAccessToken(MailAccount mailAccount) {
+        validateMailAccountInput(mailAccount);
+
+        MailAccount latestMailAccount = mailAccountQueryService.findActiveMailAccountById(mailAccount.getId());
+        validateGoogleMailAccount(latestMailAccount);
+
+        if (!needsRefresh(latestMailAccount)) {
+            return latestMailAccount;
+        }
+
+        if (isBlank(latestMailAccount.getRefreshToken())) {
+            throw new MailPushException(MailPushErrorCode.GOOGLE_REFRESH_TOKEN_MISSING);
+        }
+
+        return mailAccountCommandService.refreshGoogleAccessToken(
+                latestMailAccount.getId(),
+                googleOAuthQueryService.refreshAccessToken(latestMailAccount.getRefreshToken())
+        );
+    }
+
+    private boolean needsRefresh(MailAccount mailAccount) {
+        LocalDateTime refreshThreshold = mailAccountQueryService.getKstNow().plusMinutes(REFRESH_WINDOW_MINUTES);
+        return !mailAccount.getAccessTokenExpiresAt().isAfter(refreshThreshold);
+    }
+
+    private void validateMailAccountInput(MailAccount mailAccount) {
+        if (mailAccount == null || mailAccount.getId() == null) {
+            throw new MailPushException(MailPushErrorCode.MAIL_ACCOUNT_NOT_FOUND);
+        }
+    }
+
+    private void validateGoogleMailAccount(MailAccount mailAccount) {
+        if (mailAccount.getProvider() != MailProvider.GMAIL) {
+            throw new MailPushException(MailPushErrorCode.INVALID_MAIL_ACCOUNT_STATE);
+        }
+
+        if (mailAccount.getAccessTokenExpiresAt() == null || isBlank(mailAccount.getAccessToken())) {
+            throw new MailPushException(MailPushErrorCode.GOOGLE_TOKEN_REFRESH_FAILED);
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/GoogleAccessTokenEnsureService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/GoogleAccessTokenEnsureService.java
@@ -14,37 +14,35 @@ public class GoogleAccessTokenEnsureService {
 
     private static final long REFRESH_WINDOW_MINUTES = 10L;
 
-    private final MailAccountQueryService mailAccountQueryService;
     private final MailAccountCommandService mailAccountCommandService;
     private final GoogleOAuthQueryService googleOAuthQueryService;
+    private final MailAccountQueryService mailAccountQueryService;
 
     public GoogleAccessTokenEnsureService(
-            MailAccountQueryService mailAccountQueryService,
             MailAccountCommandService mailAccountCommandService,
-            GoogleOAuthQueryService googleOAuthQueryService
+            GoogleOAuthQueryService googleOAuthQueryService,
+            MailAccountQueryService mailAccountQueryService
     ) {
-        this.mailAccountQueryService = mailAccountQueryService;
         this.mailAccountCommandService = mailAccountCommandService;
         this.googleOAuthQueryService = googleOAuthQueryService;
+        this.mailAccountQueryService = mailAccountQueryService;
     }
 
     public MailAccount ensureValidGoogleAccessToken(MailAccount mailAccount) {
         validateMailAccountInput(mailAccount);
+        validateGoogleMailAccount(mailAccount);
 
-        MailAccount latestMailAccount = mailAccountQueryService.findActiveMailAccountById(mailAccount.getId());
-        validateGoogleMailAccount(latestMailAccount);
-
-        if (!needsRefresh(latestMailAccount)) {
-            return latestMailAccount;
+        if (!needsRefresh(mailAccount)) {
+            return mailAccount;
         }
 
-        if (isBlank(latestMailAccount.getRefreshToken())) {
+        if (isBlank(mailAccount.getRefreshToken())) {
             throw new MailPushException(MailPushErrorCode.GOOGLE_REFRESH_TOKEN_MISSING);
         }
 
         return mailAccountCommandService.refreshGoogleAccessToken(
-                latestMailAccount.getId(),
-                googleOAuthQueryService.refreshAccessToken(latestMailAccount.getRefreshToken())
+                mailAccount.getId(),
+                googleOAuthQueryService.refreshAccessToken(mailAccount.getRefreshToken())
         );
     }
 

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/MailAccountCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/MailAccountCommandService.java
@@ -1,6 +1,7 @@
 package com.mailsangja.worker.service.mail;
 
 import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.MailProvider;
 import com.mailsangja.worker.dto.gmail.watch.GoogleMailWatchResult;
 import com.mailsangja.worker.dto.gmail.oauth.GoogleOAuthTokenResult;
 import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
@@ -49,6 +50,22 @@ public class MailAccountCommandService {
         mailAccount.updateWatchExpiresAt(watchResult.expirationAt());
     }
 
+    @Transactional
+    public MailAccount refreshGoogleAccessToken(UUID mailAccountId, GoogleOAuthTokenResult tokenResult) {
+        validateRefreshGoogleAccessTokenInput(mailAccountId, tokenResult);
+
+        MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(mailAccountId);
+        validateRefreshableGoogleMailAccount(mailAccount);
+
+        mailAccount.updateAccessToken(tokenResult.accessToken());
+        mailAccount.updateAccessTokenExpiresAt(mailAccountQueryService.getKstNow().plusSeconds(tokenResult.expiresIn()));
+        if (!isBlank(tokenResult.refreshToken())) {
+            mailAccount.updateRefreshToken(tokenResult.refreshToken());
+        }
+
+        return mailAccount;
+    }
+
     private void validateRenewGoogleWatchCommand(RenewGoogleWatchCommand command) {
         if (command == null
                 || command.mailAccountId() == null
@@ -59,6 +76,26 @@ public class MailAccountCommandService {
 
         validateGoogleOAuthTokenResult(command.tokenResult());
         validateGoogleMailWatchResult(command.watchResult());
+    }
+
+    private void validateRefreshGoogleAccessTokenInput(UUID mailAccountId, GoogleOAuthTokenResult tokenResult) {
+        if (mailAccountId == null
+                || tokenResult == null
+                || isBlank(tokenResult.accessToken())
+                || tokenResult.expiresIn() == null
+                || tokenResult.expiresIn() <= 0) {
+            throw new MailPushException(MailPushErrorCode.GOOGLE_TOKEN_REFRESH_FAILED);
+        }
+    }
+
+    private void validateRefreshableGoogleMailAccount(MailAccount mailAccount) {
+        if (mailAccount.getProvider() != MailProvider.GMAIL) {
+            throw new MailPushException(MailPushErrorCode.INVALID_MAIL_ACCOUNT_STATE);
+        }
+
+        if (isBlank(mailAccount.getRefreshToken())) {
+            throw new MailPushException(MailPushErrorCode.GOOGLE_REFRESH_TOKEN_MISSING);
+        }
     }
 
     private void validateGoogleOAuthTokenResult(GoogleOAuthTokenResult tokenResult) {

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/MailAccountCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/MailAccountCommandService.java
@@ -2,6 +2,7 @@ package com.mailsangja.worker.service.mail;
 
 import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.MailProvider;
+import com.mailsangja.db.port.MailAccountRepositoryPort;
 import com.mailsangja.worker.dto.gmail.watch.GoogleMailWatchResult;
 import com.mailsangja.worker.dto.gmail.oauth.GoogleOAuthTokenResult;
 import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
@@ -17,6 +18,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class MailAccountCommandService {
 
+    private final MailAccountRepositoryPort mailAccountRepositoryPort;
     private final MailAccountQueryService mailAccountQueryService;
 
     @Transactional
@@ -41,13 +43,20 @@ public class MailAccountCommandService {
         GoogleMailWatchResult watchResult = command.watchResult();
 
         MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(mailAccountId);
-        mailAccount.updateAccessToken(tokenResult.accessToken());
-        mailAccount.updateAccessTokenExpiresAt(mailAccountQueryService.getKstNow().plusSeconds(tokenResult.expiresIn()));
-        if (!isBlank(tokenResult.refreshToken())) {
-            mailAccount.updateRefreshToken(tokenResult.refreshToken());
-        }
-        mailAccount.updateSyncHistoryId(watchResult.historyId());
-        mailAccount.updateWatchExpiresAt(watchResult.expirationAt());
+        validateRefreshableGoogleMailAccount(mailAccount);
+        String updatedRefreshToken = isBlank(tokenResult.refreshToken())
+                ? mailAccount.getRefreshToken()
+                : tokenResult.refreshToken();
+
+        mailAccountRepositoryPort.renewGoogleWatchIfAccessTokenMatches(
+                mailAccountId,
+                mailAccount.getAccessToken(),
+                tokenResult.accessToken(),
+                mailAccountQueryService.getKstNow().plusSeconds(tokenResult.expiresIn()),
+                updatedRefreshToken,
+                watchResult.historyId(),
+                watchResult.expirationAt()
+        );
     }
 
     @Transactional
@@ -56,14 +65,19 @@ public class MailAccountCommandService {
 
         MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(mailAccountId);
         validateRefreshableGoogleMailAccount(mailAccount);
+        String updatedRefreshToken = isBlank(tokenResult.refreshToken())
+                ? mailAccount.getRefreshToken()
+                : tokenResult.refreshToken();
 
-        mailAccount.updateAccessToken(tokenResult.accessToken());
-        mailAccount.updateAccessTokenExpiresAt(mailAccountQueryService.getKstNow().plusSeconds(tokenResult.expiresIn()));
-        if (!isBlank(tokenResult.refreshToken())) {
-            mailAccount.updateRefreshToken(tokenResult.refreshToken());
-        }
+        mailAccountRepositoryPort.updateGoogleTokenIfAccessTokenMatches(
+                mailAccountId,
+                mailAccount.getAccessToken(),
+                tokenResult.accessToken(),
+                mailAccountQueryService.getKstNow().plusSeconds(tokenResult.expiresIn()),
+                updatedRefreshToken
+        );
 
-        return mailAccount;
+        return mailAccountQueryService.findActiveMailAccountById(mailAccountId);
     }
 
     private void validateRenewGoogleWatchCommand(RenewGoogleWatchCommand command) {

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandServiceTest.java
@@ -1,7 +1,6 @@
 package com.mailsangja.worker.service.mail;
 
 import com.mailsangja.db.entity.mail.Direction;
-import com.mailsangja.db.entity.mail.GmailThreadLock;
 import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.Thread;
@@ -10,16 +9,16 @@ import com.mailsangja.db.port.MessageRepositoryPort;
 import com.mailsangja.db.port.ThreadRepositoryPort;
 import com.mailsangja.worker.dto.gmail.history.GmailHistoryEvent;
 import com.mailsangja.worker.dto.gmail.history.GmailHistoryEventType;
-import com.mailsangja.worker.dto.mail.sync.InitialMailSyncAttachmentResult;
 import com.mailsangja.worker.dto.mail.sync.InitialMailSyncMessageSaveCommand;
 import com.mailsangja.worker.dto.mail.sync.InitialMailSyncThreadSaveCommand;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -27,23 +26,44 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class GmailNewMessageApplyCommandServiceTest {
+
+    @Mock
+    private GmailThreadLockRepositoryPort gmailThreadLockRepositoryPort;
+
+    @Mock
+    private ThreadRepositoryPort threadRepositoryPort;
+
+    @Mock
+    private MessageRepositoryPort messageRepositoryPort;
+
+    private GmailNewMessageApplyCommandService service;
+
+    @BeforeEach
+    void setUp() {
+        InitialMailSyncCommandService initialMailSyncCommandService =
+                new InitialMailSyncCommandService(threadRepositoryPort, messageRepositoryPort);
+        service = new GmailNewMessageApplyCommandService(
+                gmailThreadLockRepositoryPort,
+                threadRepositoryPort,
+                initialMailSyncCommandService
+        );
+    }
 
     @Test
     void applyNewMessageSync_whenThreadIsDeleted_restoresOnlyThreadAndInsertsNewMessage() {
-        InMemoryThreadRepository threadRepository = new InMemoryThreadRepository();
-        InMemoryMessageRepository messageRepository = new InMemoryMessageRepository();
-        InitialMailSyncCommandService initialMailSyncCommandService =
-                new InitialMailSyncCommandService(threadRepository, messageRepository);
-        GmailNewMessageApplyCommandService service = new GmailNewMessageApplyCommandService(
-                new NoOpLockRepository(), threadRepository, initialMailSyncCommandService);
-
         MailAccount mailAccount = MailAccount.builder()
                 .id(UUID.randomUUID())
                 .build();
-
         Thread deletedThread = Thread.builder()
+                .id(UUID.randomUUID())
                 .mailAccount(mailAccount)
                 .gmailThreadId("thread-1")
                 .direction(Direction.INBOUND)
@@ -51,14 +71,30 @@ class GmailNewMessageApplyCommandServiceTest {
                 .messageCount(1)
                 .build();
         deletedThread.delete();
-        threadRepository.savedThreads.add(deletedThread);
 
         Message oldMessage = Message.from(deletedThread, new Message.CreateValues(
                 "message-old", Direction.INBOUND, "old subject", "sender@example.com", "Sender",
                 List.of("me@example.com"), List.of("Me"), List.of(), List.of(), "old snippet", false,
-                LocalDateTime.of(2026, 4, 10, 9, 0), null, null));
+                LocalDateTime.of(2026, 4, 10, 9, 0), null, null
+        ));
         oldMessage.delete();
-        messageRepository.savedMessages.add(oldMessage);
+
+        when(threadRepositoryPort.findAllByMailAccountIdAndGmailThreadId(mailAccount.getId(), "thread-1"))
+                .thenReturn(List.of(deletedThread));
+        when(threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccount.getId(), "thread-1", Direction.INBOUND
+        )).thenAnswer(invocation -> deletedThread.isDeleted() ? Optional.empty() : Optional.of(deletedThread));
+        when(threadRepositoryPort.bulkRestoreAndResetMessageCountByMailAccountIdAndGmailThreadId(mailAccount.getId(), "thread-1"))
+                .thenAnswer(invocation -> {
+                    deletedThread.restore();
+                    deletedThread.updateMessageCount(0);
+                    return 1;
+                });
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageId(deletedThread.getId(), "message-old"))
+                .thenReturn(Optional.of(oldMessage));
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageId(deletedThread.getId(), "message-new"))
+                .thenReturn(Optional.empty());
+        when(messageRepositoryPort.save(any(Message.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         GmailHistoryEvent event = new GmailHistoryEvent(
                 GmailHistoryEventType.MESSAGE_ADDED,
@@ -67,48 +103,18 @@ class GmailNewMessageApplyCommandServiceTest {
                 "thread-1",
                 "history-2"
         );
-
-        InitialMailSyncThreadSaveCommand syncCommand = new InitialMailSyncThreadSaveCommand(
-                "thread-1",
-                "history-2",
-                List.of(
-                        new InitialMailSyncMessageSaveCommand(
-                                "message-old", "history-1", Direction.INBOUND,
-                                "old subject", "sender@example.com", "Sender", List.of("me@example.com"),
-                                List.of("Me"), List.of(), List.of(), "old snippet", false,
-                                LocalDateTime.of(2026, 4, 10, 9, 0), null, null, List.of()),
-                        new InitialMailSyncMessageSaveCommand(
-                                "message-new", "history-2", Direction.INBOUND,
-                                "new subject", "sender@example.com", "Sender", List.of("me@example.com"),
-                                List.of("Me"), List.of(), List.of(), "new snippet", false,
-                                LocalDateTime.of(2026, 4, 14, 10, 0), null, null, List.of())
-                )
-        );
+        InitialMailSyncThreadSaveCommand syncCommand = createSyncCommand("thread-1", "history-2", "message-new", "new subject", "new snippet");
 
         service.applyNewMessageSync(mailAccount, event, syncCommand);
 
-        // Thread는 복구되어야 한다
-        assertFalse(deletedThread.isDeleted(), "Thread should be restored");
-
-        // 기존 message는 여전히 삭제 상태여야 한다
-        assertTrue(oldMessage.isDeleted(), "Old message should remain soft-deleted");
-
-        // 신규 메시지만 삽입되어야 한다
-        long activeMessages = messageRepository.savedMessages.stream()
-                .filter(m -> !m.isDeleted())
-                .count();
-        assertEquals(1, activeMessages, "Only the new message should be active");
-
-        Message insertedMessage = messageRepository.savedMessages.stream()
-                .filter(m -> !m.isDeleted())
-                .findFirst()
-                .orElseThrow();
-        assertEquals("message-new", insertedMessage.getGmailMessageId());
-
-        // Thread의 messageCount는 신규 메시지 1건만 반영해야 한다
+        ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(messageRepositoryPort).save(messageCaptor.capture());
+        verify(gmailThreadLockRepositoryPort).acquireThreadLock(mailAccount, "thread-1");
+        verify(threadRepositoryPort).bulkRestoreAndResetMessageCountByMailAccountIdAndGmailThreadId(mailAccount.getId(), "thread-1");
+        assertFalse(deletedThread.isDeleted());
+        assertTrue(oldMessage.isDeleted());
+        assertEquals("message-new", messageCaptor.getValue().getGmailMessageId());
         assertEquals(1, deletedThread.getMessageCount());
-
-        // Thread의 최신 정보는 신규 메시지로 업데이트되어야 한다
         assertEquals("new subject", deletedThread.getLatestSubject());
         assertEquals("new snippet", deletedThread.getLatestSnippet());
         assertEquals(LocalDateTime.of(2026, 4, 14, 10, 0), deletedThread.getLastMessageAt());
@@ -116,31 +122,34 @@ class GmailNewMessageApplyCommandServiceTest {
 
     @Test
     void applyNewMessageSync_whenThreadIsNotDeleted_insertsNewMessageAndUpdatesThreadInfo() {
-        InMemoryThreadRepository threadRepository = new InMemoryThreadRepository();
-        InMemoryMessageRepository messageRepository = new InMemoryMessageRepository();
-        InitialMailSyncCommandService initialMailSyncCommandService =
-                new InitialMailSyncCommandService(threadRepository, messageRepository);
-        GmailNewMessageApplyCommandService service = new GmailNewMessageApplyCommandService(
-                new NoOpLockRepository(), threadRepository, initialMailSyncCommandService);
-
         MailAccount mailAccount = MailAccount.builder()
                 .id(UUID.randomUUID())
                 .build();
-
         Thread activeThread = Thread.builder()
+                .id(UUID.randomUUID())
                 .mailAccount(mailAccount)
                 .gmailThreadId("thread-2")
                 .direction(Direction.INBOUND)
                 .read(false)
                 .messageCount(1)
                 .build();
-        threadRepository.savedThreads.add(activeThread);
 
         Message existingMessage = Message.from(activeThread, new Message.CreateValues(
                 "message-old", Direction.INBOUND, "old subject", "sender@example.com", "Sender",
                 List.of("me@example.com"), List.of("Me"), List.of(), List.of(), "old snippet", false,
-                LocalDateTime.of(2026, 4, 10, 9, 0), null, null));
-        messageRepository.savedMessages.add(existingMessage);
+                LocalDateTime.of(2026, 4, 10, 9, 0), null, null
+        ));
+
+        when(threadRepositoryPort.findAllByMailAccountIdAndGmailThreadId(mailAccount.getId(), "thread-2"))
+                .thenReturn(List.of(activeThread));
+        when(threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccount.getId(), "thread-2", Direction.INBOUND
+        )).thenReturn(Optional.of(activeThread));
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageId(activeThread.getId(), "message-old"))
+                .thenReturn(Optional.of(existingMessage));
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageId(activeThread.getId(), "message-new"))
+                .thenReturn(Optional.empty());
+        when(messageRepositoryPort.save(any(Message.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         GmailHistoryEvent event = new GmailHistoryEvent(
                 GmailHistoryEventType.MESSAGE_ADDED,
@@ -149,260 +158,42 @@ class GmailNewMessageApplyCommandServiceTest {
                 "thread-2",
                 "history-2"
         );
-
-        InitialMailSyncThreadSaveCommand syncCommand = new InitialMailSyncThreadSaveCommand(
-                "thread-2",
-                "history-2",
-                List.of(
-                        new InitialMailSyncMessageSaveCommand(
-                                "message-old", "history-1", Direction.INBOUND,
-                                "old subject", "sender@example.com", "Sender", List.of("me@example.com"),
-                                List.of("Me"), List.of(), List.of(), "old snippet", false,
-                                LocalDateTime.of(2026, 4, 10, 9, 0), null, null, List.of()),
-                        new InitialMailSyncMessageSaveCommand(
-                                "message-new", "history-2", Direction.INBOUND,
-                                "new subject", "sender@example.com", "Sender", List.of("me@example.com"),
-                                List.of("Me"), List.of(), List.of(), "new snippet", false,
-                                LocalDateTime.of(2026, 4, 14, 10, 0), null, null, List.of())
-                )
-        );
+        InitialMailSyncThreadSaveCommand syncCommand = createSyncCommand("thread-2", "history-2", "message-new", "new subject", "new snippet");
 
         service.applyNewMessageSync(mailAccount, event, syncCommand);
 
+        verify(gmailThreadLockRepositoryPort).acquireThreadLock(mailAccount, "thread-2");
+        verify(threadRepositoryPort, never()).bulkRestoreAndResetMessageCountByMailAccountIdAndGmailThreadId(any(), any());
         assertFalse(activeThread.isDeleted());
         assertEquals(2, activeThread.getMessageCount());
         assertEquals("new subject", activeThread.getLatestSubject());
         assertEquals(LocalDateTime.of(2026, 4, 14, 10, 0), activeThread.getLastMessageAt());
     }
 
-    private static final class NoOpLockRepository implements GmailThreadLockRepositoryPort {
-        @Override
-        public GmailThreadLock save(GmailThreadLock lock) {
-            return lock;
-        }
-
-        @Override
-        public void acquireThreadLock(MailAccount mailAccount, String gmailThreadId) {
-        }
-
-        @Override
-        public Optional<GmailThreadLock> findByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<GmailThreadLock> findByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullForUpdate(UUID mailAccountId, String gmailThreadId) {
-            return Optional.empty();
-        }
-    }
-
-    private static final class InMemoryThreadRepository implements ThreadRepositoryPort {
-        private final List<Thread> savedThreads = new ArrayList<>();
-
-        @Override
-        public Thread save(Thread thread) {
-            if (!savedThreads.contains(thread)) {
-                savedThreads.add(thread);
-            }
-            return thread;
-        }
-
-        @Override
-        public Optional<Thread> findByIdAndDeletedAtIsNull(UUID id) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<Thread> findByIdIncludingDeleted(UUID id) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<Thread> findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
-                UUID mailAccountId, String gmailThreadId, Direction direction) {
-            return savedThreads.stream()
-                    .filter(t -> t.getMailAccount() != null
-                            && mailAccountId.equals(t.getMailAccount().getId())
-                            && gmailThreadId.equals(t.getGmailThreadId())
-                            && direction == t.getDirection()
-                            && !t.isDeleted())
-                    .findFirst();
-        }
-
-        @Override
-        public List<Thread> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId) {
-            return savedThreads.stream()
-                    .filter(t -> t.getMailAccount() != null
-                            && mailAccountId.equals(t.getMailAccount().getId())
-                            && gmailThreadId.equals(t.getGmailThreadId())
-                            && !t.isDeleted())
-                    .toList();
-        }
-
-        @Override
-        public List<Thread> findAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return savedThreads.stream()
-                    .filter(t -> t.getMailAccount() != null
-                            && mailAccountId.equals(t.getMailAccount().getId())
-                            && gmailThreadId.equals(t.getGmailThreadId()))
-                    .toList();
-        }
-
-        @Override
-        public int bulkSoftDeleteByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId, LocalDateTime deletedAt) {
-            return 0;
-        }
-
-        @Override
-        public int bulkRestoreByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return 0;
-        }
-
-        @Override
-        public int bulkRestoreAndResetMessageCountByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            List<Thread> targets = savedThreads.stream()
-                    .filter(t -> t.getMailAccount() != null
-                            && mailAccountId.equals(t.getMailAccount().getId())
-                            && gmailThreadId.equals(t.getGmailThreadId())
-                            && t.isDeleted())
-                    .toList();
-            targets.forEach(t -> {
-                t.restore();
-                t.updateMessageCount(0);
-            });
-            return targets.size();
-        }
-
-        @Override
-        public Slice<Thread> findInboxByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Slice<Thread> findSentByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long countUnreadInboxByUserId(UUID userId) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Slice<Thread> findTrashByUserId(UUID userId, UUID markerId, Pageable pageable) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void hardDeleteAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-        }
-    }
-
-    private static final class InMemoryMessageRepository implements MessageRepositoryPort {
-        private final List<Message> savedMessages = new ArrayList<>();
-
-        @Override
-        public Message save(Message message) {
-            if (!savedMessages.contains(message)) {
-                savedMessages.add(message);
-            }
-            return message;
-        }
-
-        @Override
-        public Optional<Message> findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(UUID threadId, String gmailMessageId) {
-            return savedMessages.stream()
-                    .filter(m -> m.getThread() != null
-                            && gmailMessageId.equals(m.getGmailMessageId())
-                            && (threadId == null || threadId.equals(m.getThread().getId()))
-                            && !m.isDeleted())
-                    .findFirst();
-        }
-
-        @Override
-        public Optional<Message> findByThreadIdAndGmailMessageId(UUID threadId, String gmailMessageId) {
-            return savedMessages.stream()
-                    .filter(m -> m.getThread() != null
-                            && gmailMessageId.equals(m.getGmailMessageId())
-                            && (threadId == null || threadId.equals(m.getThread().getId())))
-                    .findFirst();
-        }
-
-        @Override
-        public Optional<Message> findByMailAccountIdAndGmailThreadIdAndGmailMessageIdAndDeletedAtIsNull(
-                UUID mailAccountId, String gmailThreadId, String gmailMessageId) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<Message> findByMailAccountIdAndGmailThreadIdAndGmailMessageId(
-                UUID mailAccountId, String gmailThreadId, String gmailMessageId) {
-            return Optional.empty();
-        }
-
-        @Override
-        public boolean existsByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullAndGmailMessageIdNot(
-                UUID mailAccountId, String gmailThreadId, String gmailMessageId) {
-            return false;
-        }
-
-        @Override
-        public Optional<Message> findByIdIncludingDeleted(UUID messageId) {
-            return Optional.empty();
-        }
-
-        @Override
-        public List<Message> findAllByThreadIdAndDeletedAtIsNull(UUID threadId) {
-            return List.of();
-        }
-
-        @Override
-        public List<Message> findAllByThreadIdIncludingDeleted(UUID threadId) {
-            return List.of();
-        }
-
-        @Override
-        public List<Message> findAllByThreadIdInAndDeletedAtIsNull(List<UUID> threadIds) {
-            return List.of();
-        }
-
-        @Override
-        public List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId) {
-            return List.of();
-        }
-
-        @Override
-        public List<Message> findAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return List.of();
-        }
-
-        @Override
-        public Slice<Message> findDeletedByUserId(UUID userId, UUID markerId, Pageable pageable) {
-            return new SliceImpl<>(List.of());
-        }
-
-        @Override
-        public List<Message> findAllDeletedByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return List.of();
-        }
-
-        @Override
-        public int bulkSoftDeleteByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId, LocalDateTime deletedAt) {
-            return 0;
-        }
-
-        @Override
-        public int bulkRestoreByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return 0;
-        }
-
-        @Override
-        public void hardDelete(Message message) {
-        }
-
-        @Override
-        public boolean existsByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return false;
-        }
+    private InitialMailSyncThreadSaveCommand createSyncCommand(
+            String gmailThreadId,
+            String historyId,
+            String newMessageId,
+            String newSubject,
+            String newSnippet
+    ) {
+        return new InitialMailSyncThreadSaveCommand(
+                gmailThreadId,
+                historyId,
+                List.of(
+                        new InitialMailSyncMessageSaveCommand(
+                                "message-old", "history-1", Direction.INBOUND,
+                                "old subject", "sender@example.com", "Sender", List.of("me@example.com"),
+                                List.of("Me"), List.of(), List.of(), "old snippet", false,
+                                LocalDateTime.of(2026, 4, 10, 9, 0), null, null, List.of()
+                        ),
+                        new InitialMailSyncMessageSaveCommand(
+                                newMessageId, historyId, Direction.INBOUND,
+                                newSubject, "sender@example.com", "Sender", List.of("me@example.com"),
+                                List.of("Me"), List.of(), List.of(), newSnippet, false,
+                                LocalDateTime.of(2026, 4, 14, 10, 0), null, null, List.of()
+                        )
+                )
+        );
     }
 }

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/GoogleAccessTokenEnsureServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/GoogleAccessTokenEnsureServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestClient;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -18,9 +19,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class GoogleAccessTokenEnsureServiceTest {
 
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
+
     @Test
     void ensureValidGoogleAccessToken_만료가충분히남아있으면기존토큰을사용한다() {
-        MailAccount mailAccount = createMailAccount(LocalDateTime.now().plusMinutes(30), "access-token", "refresh-token");
+        MailAccount mailAccount = createMailAccount(LocalDateTime.now(KST_ZONE_ID).plusMinutes(30), "access-token", "refresh-token");
         InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
         FakeGoogleOAuthQueryService googleOAuthQueryService = new FakeGoogleOAuthQueryService();
         GoogleAccessTokenEnsureService service = createService(repository, googleOAuthQueryService);
@@ -33,7 +36,7 @@ class GoogleAccessTokenEnsureServiceTest {
 
     @Test
     void ensureValidGoogleAccessToken_만료가임박하면토큰을재발급한다() {
-        MailAccount mailAccount = createMailAccount(LocalDateTime.now().plusMinutes(5), "old-token", "refresh-token");
+        MailAccount mailAccount = createMailAccount(LocalDateTime.now(KST_ZONE_ID).plusMinutes(5), "old-token", "refresh-token");
         InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
         FakeGoogleOAuthQueryService googleOAuthQueryService = new FakeGoogleOAuthQueryService();
         GoogleAccessTokenEnsureService service = createService(repository, googleOAuthQueryService);

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/GoogleAccessTokenEnsureServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/GoogleAccessTokenEnsureServiceTest.java
@@ -1,0 +1,154 @@
+package com.mailsangja.worker.service.mail;
+
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.MailProvider;
+import com.mailsangja.db.port.MailAccountRepositoryPort;
+import com.mailsangja.worker.config.properties.GoogleOAuthProperties;
+import com.mailsangja.worker.dto.gmail.oauth.GoogleOAuthTokenResult;
+import com.mailsangja.worker.service.google.GoogleOAuthQueryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GoogleAccessTokenEnsureServiceTest {
+
+    @Test
+    void ensureValidGoogleAccessToken_만료가충분히남아있으면기존토큰을사용한다() {
+        MailAccount mailAccount = createMailAccount(LocalDateTime.now().plusMinutes(30), "access-token", "refresh-token");
+        InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
+        FakeGoogleOAuthQueryService googleOAuthQueryService = new FakeGoogleOAuthQueryService();
+        GoogleAccessTokenEnsureService service = createService(repository, googleOAuthQueryService);
+
+        MailAccount ensuredMailAccount = service.ensureValidGoogleAccessToken(mailAccount);
+
+        assertEquals("access-token", ensuredMailAccount.getAccessToken());
+        assertEquals(0, googleOAuthQueryService.refreshCallCount);
+    }
+
+    @Test
+    void ensureValidGoogleAccessToken_만료가임박하면토큰을재발급한다() {
+        MailAccount mailAccount = createMailAccount(LocalDateTime.now().plusMinutes(5), "old-token", "refresh-token");
+        InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
+        FakeGoogleOAuthQueryService googleOAuthQueryService = new FakeGoogleOAuthQueryService();
+        GoogleAccessTokenEnsureService service = createService(repository, googleOAuthQueryService);
+
+        MailAccount ensuredMailAccount = service.ensureValidGoogleAccessToken(mailAccount);
+
+        assertEquals("refreshed-token", ensuredMailAccount.getAccessToken());
+        assertEquals("new-refresh-token", ensuredMailAccount.getRefreshToken());
+        assertEquals(1, googleOAuthQueryService.refreshCallCount);
+    }
+
+    private GoogleAccessTokenEnsureService createService(
+            InMemoryMailAccountRepository repository,
+            FakeGoogleOAuthQueryService googleOAuthQueryService
+    ) {
+        MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(repository);
+        MailAccountCommandService mailAccountCommandService = new MailAccountCommandService(mailAccountQueryService);
+        return new GoogleAccessTokenEnsureService(
+                mailAccountQueryService,
+                mailAccountCommandService,
+                googleOAuthQueryService
+        );
+    }
+
+    private MailAccount createMailAccount(LocalDateTime expiresAt, String accessToken, String refreshToken) {
+        return MailAccount.builder()
+                .id(UUID.randomUUID())
+                .provider(MailProvider.GMAIL)
+                .emailAddress("user@example.com")
+                .alias("alias")
+                .icon("icon")
+                .color("#4285F4")
+                .accessToken(accessToken)
+                .accessTokenExpiresAt(expiresAt)
+                .refreshToken(refreshToken)
+                .active(true)
+                .build();
+    }
+
+    private static final class FakeGoogleOAuthQueryService extends GoogleOAuthQueryService {
+        private int refreshCallCount;
+
+        private FakeGoogleOAuthQueryService() {
+            super(new GoogleOAuthProperties(), RestClient.builder().build());
+        }
+
+        @Override
+        public GoogleOAuthTokenResult refreshAccessToken(String refreshToken) {
+            refreshCallCount++;
+            return new GoogleOAuthTokenResult("refreshed-token", "new-refresh-token", 3600L, null, "Bearer");
+        }
+    }
+
+    private static final class InMemoryMailAccountRepository implements MailAccountRepositoryPort {
+        private final MailAccount mailAccount;
+
+        private InMemoryMailAccountRepository(MailAccount mailAccount) {
+            this.mailAccount = mailAccount;
+        }
+
+        @Override
+        public MailAccount save(MailAccount mailAccount) {
+            return this.mailAccount;
+        }
+
+        @Override
+        public Optional<MailAccount> findByIdAndDeletedAtIsNull(UUID id) {
+            return Optional.of(mailAccount).filter(account -> id.equals(account.getId()));
+        }
+
+        @Override
+        public Optional<MailAccount> findByIdAndActiveAndDeletedAtIsNull(UUID id, boolean active) {
+            return Optional.of(mailAccount)
+                    .filter(account -> id.equals(account.getId()))
+                    .filter(account -> account.isActive() == active);
+        }
+
+        @Override
+        public Optional<MailAccount> findByEmailAddressAndDeletedAtIsNull(String emailAddress) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<MailAccount> findByUserIdAndProviderAndDeletedAtIsNull(UUID userId, MailProvider provider) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<MailAccount> findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(UUID userId, MailProvider provider, String emailAddress) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<MailAccount> findByUserIdAndEmailAddressAndActiveAndDeletedAtIsNull(UUID userId, String emailAddress, boolean active) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<MailAccount> findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<MailAccount> findAllByUserIdAndDeletedAtIsNull(UUID userId) {
+            return List.of();
+        }
+
+        @Override
+        public List<MailAccount> findRenewalTargetGmailAccounts(MailProvider provider, LocalDateTime watchExpiresAtThreshold, int limit) {
+            return List.of();
+        }
+
+        @Override
+        public List<MailAccount> findAllByUserIdAndActiveAndDeletedAtIsNull(UUID userId, boolean active) {
+            return List.of();
+        }
+    }
+}

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/GoogleAccessTokenEnsureServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/GoogleAccessTokenEnsureServiceTest.java
@@ -52,9 +52,9 @@ class GoogleAccessTokenEnsureServiceTest {
         MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(repository);
         MailAccountCommandService mailAccountCommandService = new MailAccountCommandService(mailAccountQueryService);
         return new GoogleAccessTokenEnsureService(
-                mailAccountQueryService,
                 mailAccountCommandService,
-                googleOAuthQueryService
+                googleOAuthQueryService,
+                mailAccountQueryService
         );
     }
 

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/GoogleAccessTokenEnsureServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/GoogleAccessTokenEnsureServiceTest.java
@@ -7,54 +7,96 @@ import com.mailsangja.worker.config.properties.GoogleOAuthProperties;
 import com.mailsangja.worker.dto.gmail.oauth.GoogleOAuthTokenResult;
 import com.mailsangja.worker.service.google.GoogleOAuthQueryService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.RestClient;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class GoogleAccessTokenEnsureServiceTest {
 
     private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
 
+    @Mock
+    private MailAccountRepositoryPort mailAccountRepositoryPort;
+
     @Test
     void ensureValidGoogleAccessToken_만료가충분히남아있으면기존토큰을사용한다() {
-        MailAccount mailAccount = createMailAccount(LocalDateTime.now(KST_ZONE_ID).plusMinutes(30), "access-token", "refresh-token");
-        InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
+        MailAccount mailAccount = createMailAccount(
+                LocalDateTime.now(KST_ZONE_ID).plusMinutes(30),
+                "access-token",
+                "refresh-token"
+        );
         FakeGoogleOAuthQueryService googleOAuthQueryService = new FakeGoogleOAuthQueryService();
-        GoogleAccessTokenEnsureService service = createService(repository, googleOAuthQueryService);
+        GoogleAccessTokenEnsureService service = createService(googleOAuthQueryService);
 
         MailAccount ensuredMailAccount = service.ensureValidGoogleAccessToken(mailAccount);
 
-        assertEquals("access-token", ensuredMailAccount.getAccessToken());
+        assertSame(mailAccount, ensuredMailAccount);
         assertEquals(0, googleOAuthQueryService.refreshCallCount);
+        verify(mailAccountRepositoryPort, never()).findByIdAndDeletedAtIsNull(any());
+        verify(mailAccountRepositoryPort, never()).updateGoogleTokenIfAccessTokenMatches(any(), any(), any(), any(), any());
     }
 
     @Test
     void ensureValidGoogleAccessToken_만료가임박하면토큰을재발급한다() {
-        MailAccount mailAccount = createMailAccount(LocalDateTime.now(KST_ZONE_ID).plusMinutes(5), "old-token", "refresh-token");
-        InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
+        MailAccount mailAccount = createMailAccount(
+                LocalDateTime.now(KST_ZONE_ID).plusMinutes(5),
+                "old-token",
+                "refresh-token"
+        );
+        when(mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(mailAccount.getId()))
+                .thenReturn(Optional.of(mailAccount));
+        when(mailAccountRepositoryPort.updateGoogleTokenIfAccessTokenMatches(
+                eq(mailAccount.getId()),
+                eq("old-token"),
+                eq("refreshed-token"),
+                any(LocalDateTime.class),
+                eq("new-refresh-token")
+        )).thenAnswer(invocation -> {
+            mailAccount.updateAccessToken(invocation.getArgument(2));
+            mailAccount.updateAccessTokenExpiresAt(invocation.getArgument(3));
+            mailAccount.updateRefreshToken(invocation.getArgument(4));
+            return 1;
+        });
+
         FakeGoogleOAuthQueryService googleOAuthQueryService = new FakeGoogleOAuthQueryService();
-        GoogleAccessTokenEnsureService service = createService(repository, googleOAuthQueryService);
+        GoogleAccessTokenEnsureService service = createService(googleOAuthQueryService);
 
         MailAccount ensuredMailAccount = service.ensureValidGoogleAccessToken(mailAccount);
 
+        ArgumentCaptor<LocalDateTime> expiresAtCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(mailAccountRepositoryPort).updateGoogleTokenIfAccessTokenMatches(
+                eq(mailAccount.getId()),
+                eq("old-token"),
+                eq("refreshed-token"),
+                expiresAtCaptor.capture(),
+                eq("new-refresh-token")
+        );
         assertEquals("refreshed-token", ensuredMailAccount.getAccessToken());
         assertEquals("new-refresh-token", ensuredMailAccount.getRefreshToken());
         assertEquals(1, googleOAuthQueryService.refreshCallCount);
+        assertSame(mailAccount, ensuredMailAccount);
     }
 
-    private GoogleAccessTokenEnsureService createService(
-            InMemoryMailAccountRepository repository,
-            FakeGoogleOAuthQueryService googleOAuthQueryService
-    ) {
-        MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(repository);
+    private GoogleAccessTokenEnsureService createService(FakeGoogleOAuthQueryService googleOAuthQueryService) {
+        MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(mailAccountRepositoryPort);
         MailAccountCommandService mailAccountCommandService = new MailAccountCommandService(
-                repository,
+                mailAccountRepositoryPort,
                 mailAccountQueryService
         );
         return new GoogleAccessTokenEnsureService(
@@ -90,102 +132,6 @@ class GoogleAccessTokenEnsureServiceTest {
         public GoogleOAuthTokenResult refreshAccessToken(String refreshToken) {
             refreshCallCount++;
             return new GoogleOAuthTokenResult("refreshed-token", "new-refresh-token", 3600L, null, "Bearer");
-        }
-    }
-
-    private static final class InMemoryMailAccountRepository implements MailAccountRepositoryPort {
-        private final MailAccount mailAccount;
-
-        private InMemoryMailAccountRepository(MailAccount mailAccount) {
-            this.mailAccount = mailAccount;
-        }
-
-        @Override
-        public MailAccount save(MailAccount mailAccount) {
-            return this.mailAccount;
-        }
-
-        @Override
-        public Optional<MailAccount> findByIdAndDeletedAtIsNull(UUID id) {
-            return Optional.of(mailAccount).filter(account -> id.equals(account.getId()));
-        }
-
-        @Override
-        public Optional<MailAccount> findByIdAndActiveAndDeletedAtIsNull(UUID id, boolean active) {
-            return Optional.of(mailAccount)
-                    .filter(account -> id.equals(account.getId()))
-                    .filter(account -> account.isActive() == active);
-        }
-
-        @Override
-        public Optional<MailAccount> findByEmailAddressAndDeletedAtIsNull(String emailAddress) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<MailAccount> findByUserIdAndProviderAndDeletedAtIsNull(UUID userId, MailProvider provider) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<MailAccount> findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(UUID userId, MailProvider provider, String emailAddress) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<MailAccount> findByUserIdAndEmailAddressAndActiveAndDeletedAtIsNull(UUID userId, String emailAddress, boolean active) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<MailAccount> findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress) {
-            return Optional.empty();
-        }
-
-        @Override
-        public List<MailAccount> findAllByUserIdAndDeletedAtIsNull(UUID userId) {
-            return List.of();
-        }
-
-        @Override
-        public int updateGoogleTokenIfAccessTokenMatches(
-                UUID id,
-                String expectedAccessToken,
-                String newAccessToken,
-                LocalDateTime newAccessTokenExpiresAt,
-                String newRefreshToken
-        ) {
-            if (!id.equals(mailAccount.getId()) || !expectedAccessToken.equals(mailAccount.getAccessToken())) {
-                return 0;
-            }
-
-            mailAccount.updateAccessToken(newAccessToken);
-            mailAccount.updateAccessTokenExpiresAt(newAccessTokenExpiresAt);
-            mailAccount.updateRefreshToken(newRefreshToken);
-            return 1;
-        }
-
-        @Override
-        public int renewGoogleWatchIfAccessTokenMatches(
-                UUID id,
-                String expectedAccessToken,
-                String newAccessToken,
-                LocalDateTime newAccessTokenExpiresAt,
-                String newRefreshToken,
-                String newSyncHistoryId,
-                LocalDateTime newWatchExpiresAt
-        ) {
-            return 0;
-        }
-
-        @Override
-        public List<MailAccount> findRenewalTargetGmailAccounts(MailProvider provider, LocalDateTime watchExpiresAtThreshold, int limit) {
-            return List.of();
-        }
-
-        @Override
-        public List<MailAccount> findAllByUserIdAndActiveAndDeletedAtIsNull(UUID userId, boolean active) {
-            return List.of();
         }
     }
 }

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
@@ -8,489 +8,326 @@ import com.mailsangja.db.port.MessageRepositoryPort;
 import com.mailsangja.db.port.ThreadRepositoryPort;
 import com.mailsangja.worker.dto.mail.sync.InitialMailSyncMessageSaveCommand;
 import com.mailsangja.worker.dto.mail.sync.InitialMailSyncThreadSaveCommand;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class InitialMailSyncCommandServiceTest {
+
+    @Mock
+    private ThreadRepositoryPort threadRepositoryPort;
+
+    @Mock
+    private MessageRepositoryPort messageRepositoryPort;
+
+    private InitialMailSyncCommandService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new InitialMailSyncCommandService(threadRepositoryPort, messageRepositoryPort);
+    }
 
     @Test
     void saveThreadBatch_doesNotIncreaseMessageCountForUpdatedMessages() {
-        InMemoryThreadRepository threadRepository = new InMemoryThreadRepository();
-        InMemoryMessageRepository messageRepository = new InMemoryMessageRepository();
-        InitialMailSyncCommandService service = new InitialMailSyncCommandService(threadRepository, messageRepository);
+        MailAccount mailAccount = createMailAccount();
+        Thread thread = createThread(mailAccount, "thread-1", Direction.INBOUND);
+        AtomicReference<Message> storedMessage = new AtomicReference<>();
 
-        MailAccount mailAccount = MailAccount.builder()
-                .id(UUID.randomUUID())
-                .build();
+        when(threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccount.getId(), "thread-1", Direction.INBOUND
+        )).thenReturn(Optional.of(thread));
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageId(thread.getId(), "message-1"))
+                .thenAnswer(invocation -> Optional.ofNullable(storedMessage.get()));
+        when(messageRepositoryPort.save(any(Message.class))).thenAnswer(invocation -> {
+            Message message = invocation.getArgument(0);
+            storedMessage.set(message);
+            return message;
+        });
 
-        service.saveThreadBatch(mailAccount, List.of(new InitialMailSyncThreadSaveCommand(
+        service.saveThreadBatch(mailAccount, java.util.List.of(new InitialMailSyncThreadSaveCommand(
                 "thread-1",
                 "history-1",
-                List.of(new InitialMailSyncMessageSaveCommand(
+                java.util.List.of(new InitialMailSyncMessageSaveCommand(
                         "message-1",
                         "history-1",
                         Direction.INBOUND,
                         "subject",
                         "alice@example.com",
                         "Alice",
-                        List.of("bob@example.com"),
-                        List.of("Bob"),
-                        List.of(),
-                        List.of(),
+                        java.util.List.of("bob@example.com"),
+                        java.util.List.of("Bob"),
+                        java.util.List.of(),
+                        java.util.List.of(),
                         "snippet",
                         false,
                         LocalDateTime.of(2026, 4, 11, 10, 0),
                         "body",
                         null,
-                        List.of()
+                        java.util.List.of()
                 ))
         )));
 
-        service.saveThreadBatch(mailAccount, List.of(new InitialMailSyncThreadSaveCommand(
+        service.saveThreadBatch(mailAccount, java.util.List.of(new InitialMailSyncThreadSaveCommand(
                 "thread-1",
                 "history-2",
-                List.of(new InitialMailSyncMessageSaveCommand(
+                java.util.List.of(new InitialMailSyncMessageSaveCommand(
                         "message-1",
                         "history-2",
                         Direction.INBOUND,
                         "updated subject",
                         "alice@example.com",
                         "Alice",
-                        List.of("bob@example.com"),
-                        List.of("Bob"),
-                        List.of(),
-                        List.of(),
+                        java.util.List.of("bob@example.com"),
+                        java.util.List.of("Bob"),
+                        java.util.List.of(),
+                        java.util.List.of(),
                         "updated snippet",
                         true,
                         LocalDateTime.of(2026, 4, 11, 11, 0),
                         "updated body",
                         null,
-                        List.of()
+                        java.util.List.of()
                 ))
         )));
 
-        Thread savedThread = threadRepository.savedThreads.getFirst();
-        assertEquals(1, savedThread.getMessageCount());
-        assertEquals("updated subject", savedThread.getLatestSubject());
-        assertEquals("updated snippet", savedThread.getLatestSnippet());
+        assertEquals(1, thread.getMessageCount());
+        assertEquals("updated subject", thread.getLatestSubject());
+        assertEquals("updated snippet", thread.getLatestSnippet());
+        verify(messageRepositoryPort, times(1)).save(any(Message.class));
     }
 
     @Test
     void saveThreadBatch_doesNotReplaceLatestMessageWhenSentAtIsNull() {
-        InMemoryThreadRepository threadRepository = new InMemoryThreadRepository();
-        InMemoryMessageRepository messageRepository = new InMemoryMessageRepository();
-        InitialMailSyncCommandService service = new InitialMailSyncCommandService(threadRepository, messageRepository);
+        MailAccount mailAccount = createMailAccount();
+        Thread thread = createThread(mailAccount, "thread-1", Direction.INBOUND);
+        AtomicReference<Message> firstMessage = new AtomicReference<>();
 
-        MailAccount mailAccount = MailAccount.builder()
-                .id(UUID.randomUUID())
-                .build();
+        when(threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccount.getId(), "thread-1", Direction.INBOUND
+        )).thenReturn(Optional.of(thread));
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageId(thread.getId(), "message-1"))
+                .thenAnswer(invocation -> Optional.ofNullable(firstMessage.get()));
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageId(thread.getId(), "message-2"))
+                .thenReturn(Optional.empty());
+        when(messageRepositoryPort.save(any(Message.class))).thenAnswer(invocation -> {
+            Message message = invocation.getArgument(0);
+            if ("message-1".equals(message.getGmailMessageId())) {
+                firstMessage.set(message);
+            }
+            return message;
+        });
 
-        service.saveThreadBatch(mailAccount, List.of(new InitialMailSyncThreadSaveCommand(
+        service.saveThreadBatch(mailAccount, java.util.List.of(new InitialMailSyncThreadSaveCommand(
                 "thread-1",
                 "history-1",
-                List.of(new InitialMailSyncMessageSaveCommand(
+                java.util.List.of(new InitialMailSyncMessageSaveCommand(
                         "message-1",
                         "history-1",
                         Direction.INBOUND,
                         "subject-1",
                         "alice@example.com",
                         "Alice",
-                        List.of(),
-                        List.of(),
-                        List.of(),
-                        List.of(),
+                        java.util.List.of(),
+                        java.util.List.of(),
+                        java.util.List.of(),
+                        java.util.List.of(),
                         "snippet-1",
                         false,
                         LocalDateTime.of(2026, 4, 11, 10, 0),
                         null,
                         null,
-                        List.of()
+                        java.util.List.of()
                 ))
         )));
 
-        service.saveThreadBatch(mailAccount, List.of(new InitialMailSyncThreadSaveCommand(
+        service.saveThreadBatch(mailAccount, java.util.List.of(new InitialMailSyncThreadSaveCommand(
                 "thread-1",
                 "history-2",
-                List.of(new InitialMailSyncMessageSaveCommand(
+                java.util.List.of(new InitialMailSyncMessageSaveCommand(
                         "message-2",
                         "history-2",
                         Direction.INBOUND,
                         "subject-2",
                         "carol@example.com",
                         "Carol",
-                        List.of(),
-                        List.of(),
-                        List.of(),
-                        List.of(),
+                        java.util.List.of(),
+                        java.util.List.of(),
+                        java.util.List.of(),
+                        java.util.List.of(),
                         "snippet-2",
                         true,
                         null,
                         null,
                         null,
-                        List.of()
+                        java.util.List.of()
                 ))
         )));
 
-        Thread savedThread = threadRepository.savedThreads.getFirst();
-        assertEquals("subject-1", savedThread.getLatestSubject());
-        assertEquals("snippet-1", savedThread.getLatestSnippet());
-        assertEquals(LocalDateTime.of(2026, 4, 11, 10, 0), savedThread.getLastMessageAt());
-        assertEquals(2, savedThread.getMessageCount());
+        assertEquals("subject-1", thread.getLatestSubject());
+        assertEquals("snippet-1", thread.getLatestSnippet());
+        assertEquals(LocalDateTime.of(2026, 4, 11, 10, 0), thread.getLastMessageAt());
+        assertEquals(2, thread.getMessageCount());
     }
 
     @Test
     void saveThreadBatch_fillsMessageNamesAndLatestParticipantNameWithAddressFallback() {
-        InMemoryThreadRepository threadRepository = new InMemoryThreadRepository();
-        InMemoryMessageRepository messageRepository = new InMemoryMessageRepository();
-        InitialMailSyncCommandService service = new InitialMailSyncCommandService(threadRepository, messageRepository);
+        MailAccount mailAccount = createMailAccount();
+        Thread thread = createThread(mailAccount, "thread-1", Direction.OUTBOUND);
+        ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
 
-        MailAccount mailAccount = MailAccount.builder()
-                .id(UUID.randomUUID())
-                .build();
+        when(threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccount.getId(), "thread-1", Direction.OUTBOUND
+        )).thenReturn(Optional.of(thread));
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageId(thread.getId(), "message-1"))
+                .thenReturn(Optional.empty());
+        when(messageRepositoryPort.save(any(Message.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        service.saveThreadBatch(mailAccount, List.of(new InitialMailSyncThreadSaveCommand(
+        service.saveThreadBatch(mailAccount, java.util.List.of(new InitialMailSyncThreadSaveCommand(
                 "thread-1",
                 "history-1",
-                List.of(new InitialMailSyncMessageSaveCommand(
+                java.util.List.of(new InitialMailSyncMessageSaveCommand(
                         "message-1",
                         "history-1",
                         Direction.OUTBOUND,
                         "subject",
                         "sender@example.com",
                         null,
-                        List.of("first@example.com", "second@example.com"),
+                        java.util.List.of("first@example.com", "second@example.com"),
                         Arrays.asList((String) null),
-                        List.of("cc@example.com"),
-                        List.of(""),
+                        java.util.List.of("cc@example.com"),
+                        java.util.List.of(""),
                         "snippet",
                         true,
                         LocalDateTime.of(2026, 4, 11, 10, 0),
                         "body",
                         null,
-                        List.of()
+                        java.util.List.of()
                 ))
         )));
 
-        Message savedMessage = messageRepository.savedMessages.getFirst();
-        Thread savedThread = threadRepository.savedThreads.getFirst();
-
+        verify(messageRepositoryPort).save(messageCaptor.capture());
+        Message savedMessage = messageCaptor.getValue();
         assertEquals("sender@example.com", savedMessage.getFromName());
-        assertEquals(List.of("first@example.com", "second@example.com"), savedMessage.getToNames());
-        assertEquals(List.of("cc@example.com"), savedMessage.getCcNames());
-        assertEquals("first@example.com", savedThread.getLatestParticipantAddress());
-        assertEquals("first@example.com", savedThread.getLatestParticipantName());
+        assertEquals(java.util.List.of("first@example.com", "second@example.com"), savedMessage.getToNames());
+        assertEquals(java.util.List.of("cc@example.com"), savedMessage.getCcNames());
+        assertEquals("first@example.com", thread.getLatestParticipantAddress());
+        assertEquals("first@example.com", thread.getLatestParticipantName());
     }
 
     @Test
     void saveThreadBatch_trimsNamesBeforeSaving() {
-        InMemoryThreadRepository threadRepository = new InMemoryThreadRepository();
-        InMemoryMessageRepository messageRepository = new InMemoryMessageRepository();
-        InitialMailSyncCommandService service = new InitialMailSyncCommandService(threadRepository, messageRepository);
+        MailAccount mailAccount = createMailAccount();
+        Thread thread = createThread(mailAccount, "thread-1", Direction.OUTBOUND);
+        ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
 
-        MailAccount mailAccount = MailAccount.builder()
-                .id(UUID.randomUUID())
-                .build();
+        when(threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccount.getId(), "thread-1", Direction.OUTBOUND
+        )).thenReturn(Optional.of(thread));
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageId(thread.getId(), "message-1"))
+                .thenReturn(Optional.empty());
+        when(messageRepositoryPort.save(any(Message.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        service.saveThreadBatch(mailAccount, List.of(new InitialMailSyncThreadSaveCommand(
+        service.saveThreadBatch(mailAccount, java.util.List.of(new InitialMailSyncThreadSaveCommand(
                 "thread-1",
                 "history-1",
-                List.of(new InitialMailSyncMessageSaveCommand(
+                java.util.List.of(new InitialMailSyncMessageSaveCommand(
                         "message-1",
                         "history-1",
                         Direction.OUTBOUND,
                         "subject",
                         "sender@example.com",
                         "  Sender Name  ",
-                        List.of("first@example.com"),
-                        List.of("  First Receiver  "),
-                        List.of("cc@example.com"),
-                        List.of("  "),
+                        java.util.List.of("first@example.com"),
+                        java.util.List.of("  First Receiver  "),
+                        java.util.List.of("cc@example.com"),
+                        java.util.List.of("  "),
                         "snippet",
                         true,
                         LocalDateTime.of(2026, 4, 11, 10, 0),
                         "body",
                         null,
-                        List.of()
+                        java.util.List.of()
                 ))
         )));
 
-        Message savedMessage = messageRepository.savedMessages.getFirst();
-        Thread savedThread = threadRepository.savedThreads.getFirst();
-
+        verify(messageRepositoryPort).save(messageCaptor.capture());
+        Message savedMessage = messageCaptor.getValue();
         assertEquals("Sender Name", savedMessage.getFromName());
-        assertEquals(List.of("First Receiver"), savedMessage.getToNames());
-        assertEquals(List.of("cc@example.com"), savedMessage.getCcNames());
-        assertEquals("First Receiver", savedThread.getLatestParticipantName());
+        assertEquals(java.util.List.of("First Receiver"), savedMessage.getToNames());
+        assertEquals(java.util.List.of("cc@example.com"), savedMessage.getCcNames());
+        assertEquals("First Receiver", thread.getLatestParticipantName());
     }
 
     @Test
     void saveThreadBatch_usesCcAsLatestParticipantWhenToIsEmpty() {
-        InMemoryThreadRepository threadRepository = new InMemoryThreadRepository();
-        InMemoryMessageRepository messageRepository = new InMemoryMessageRepository();
-        InitialMailSyncCommandService service = new InitialMailSyncCommandService(threadRepository, messageRepository);
+        MailAccount mailAccount = createMailAccount();
+        Thread thread = createThread(mailAccount, "thread-1", Direction.OUTBOUND);
 
-        MailAccount mailAccount = MailAccount.builder()
-                .id(UUID.randomUUID())
-                .build();
+        when(threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccount.getId(), "thread-1", Direction.OUTBOUND
+        )).thenReturn(Optional.of(thread));
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageId(thread.getId(), "message-1"))
+                .thenReturn(Optional.empty());
+        when(messageRepositoryPort.save(any(Message.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        service.saveThreadBatch(mailAccount, List.of(new InitialMailSyncThreadSaveCommand(
+        service.saveThreadBatch(mailAccount, java.util.List.of(new InitialMailSyncThreadSaveCommand(
                 "thread-1",
                 "history-1",
-                List.of(new InitialMailSyncMessageSaveCommand(
+                java.util.List.of(new InitialMailSyncMessageSaveCommand(
                         "message-1",
                         "history-1",
                         Direction.OUTBOUND,
                         "subject",
                         "sender@example.com",
                         "Sender",
-                        List.of(),
-                        List.of(),
-                        List.of("cc@example.com"),
-                        List.of("CC Receiver"),
+                        java.util.List.of(),
+                        java.util.List.of(),
+                        java.util.List.of("cc@example.com"),
+                        java.util.List.of("CC Receiver"),
                         "snippet",
                         true,
                         LocalDateTime.of(2026, 4, 11, 10, 0),
                         "body",
                         null,
-                        List.of()
+                        java.util.List.of()
                 ))
         )));
 
-        Thread savedThread = threadRepository.savedThreads.getFirst();
-
-        assertEquals("cc@example.com", savedThread.getLatestParticipantAddress());
-        assertEquals("CC Receiver", savedThread.getLatestParticipantName());
+        assertEquals("cc@example.com", thread.getLatestParticipantAddress());
+        assertEquals("CC Receiver", thread.getLatestParticipantName());
     }
 
-    private static final class InMemoryThreadRepository implements ThreadRepositoryPort {
-        private final List<Thread> savedThreads = new ArrayList<>();
-
-        @Override
-        public Thread save(Thread thread) {
-            if (!savedThreads.contains(thread)) {
-                savedThreads.add(thread);
-            }
-            return thread;
-        }
-
-        @Override
-        public Optional<Thread> findByIdAndDeletedAtIsNull(UUID id) {
-            return savedThreads.stream().filter(thread -> id.equals(thread.getId())).findFirst();
-        }
-
-        @Override
-        public Optional<Thread> findByIdIncludingDeleted(UUID id) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<Thread> findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId, Direction direction) {
-            return savedThreads.stream()
-                    .filter(thread -> thread.getMailAccount() != null
-                            && mailAccountId.equals(thread.getMailAccount().getId())
-                            && gmailThreadId.equals(thread.getGmailThreadId())
-                            && direction == thread.getDirection())
-                    .findFirst();
-        }
-
-        @Override
-        public List<Thread> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId) {
-            return savedThreads.stream()
-                    .filter(thread -> thread.getMailAccount() != null)
-                    .filter(thread -> mailAccountId.equals(thread.getMailAccount().getId()))
-                    .filter(thread -> gmailThreadId.equals(thread.getGmailThreadId()))
-                    .toList();
-        }
-
-        @Override
-        public List<Thread> findAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return List.of();
-        }
-
-        @Override
-        public int bulkSoftDeleteByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId, LocalDateTime deletedAt) {
-            return 0;
-        }
-
-        @Override
-        public int bulkRestoreByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return 0;
-        }
-
-        @Override
-        public int bulkRestoreAndResetMessageCountByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return 0;
-        }
-
-        @Override
-        public void hardDeleteAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-        }
-
-        @Override
-        public Slice<Thread> findInboxByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Slice<Thread> findSentByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long countUnreadInboxByUserId(UUID userId) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Slice<Thread> findTrashByUserId(UUID userId, UUID markerId, Pageable pageable) {
-            return null;
-        }
+    private MailAccount createMailAccount() {
+        return MailAccount.builder()
+                .id(UUID.randomUUID())
+                .build();
     }
 
-    private static final class InMemoryMessageRepository implements MessageRepositoryPort {
-        private final List<Message> savedMessages = new ArrayList<>();
-
-        @Override
-        public Message save(Message message) {
-            if (!savedMessages.contains(message)) {
-                savedMessages.add(message);
-            }
-            return message;
-        }
-
-        @Override
-        public Optional<Message> findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(UUID threadId, String gmailMessageId) {
-            return savedMessages.stream()
-                    .filter(message -> message.getThread() != null
-                            && gmailMessageId.equals(message.getGmailMessageId())
-                            && (threadId == null || threadId.equals(message.getThread().getId()))
-                            && !message.isDeleted())
-                    .findFirst();
-        }
-
-        @Override
-        public Optional<Message> findByThreadIdAndGmailMessageId(UUID threadId, String gmailMessageId) {
-            return savedMessages.stream()
-                    .filter(message -> message.getThread() != null
-                            && gmailMessageId.equals(message.getGmailMessageId())
-                            && (threadId == null || threadId.equals(message.getThread().getId())))
-                    .findFirst();
-        }
-
-        @Override
-        public Optional<Message> findByMailAccountIdAndGmailThreadIdAndGmailMessageIdAndDeletedAtIsNull(
-                UUID mailAccountId,
-                String gmailThreadId,
-                String gmailMessageId
-        ) {
-            return savedMessages.stream()
-                    .filter(message -> message.getThread() != null)
-                    .filter(message -> message.getThread().getMailAccount() != null)
-                    .filter(message -> mailAccountId.equals(message.getThread().getMailAccount().getId()))
-                    .filter(message -> gmailThreadId.equals(message.getThread().getGmailThreadId()))
-                    .filter(message -> gmailMessageId.equals(message.getGmailMessageId()))
-                    .findFirst();
-        }
-
-        @Override
-        public Optional<Message> findByMailAccountIdAndGmailThreadIdAndGmailMessageId(
-                UUID mailAccountId,
-                String gmailThreadId,
-                String gmailMessageId
-        ) {
-            return savedMessages.stream()
-                    .filter(message -> message.getThread() != null)
-                    .filter(message -> message.getThread().getMailAccount() != null)
-                    .filter(message -> mailAccountId.equals(message.getThread().getMailAccount().getId()))
-                    .filter(message -> gmailThreadId.equals(message.getThread().getGmailThreadId()))
-                    .filter(message -> gmailMessageId.equals(message.getGmailMessageId()))
-                    .findFirst();
-        }
-
-        @Override
-        public boolean existsByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullAndGmailMessageIdNot(
-                UUID mailAccountId,
-                String gmailThreadId,
-                String gmailMessageId
-        ) {
-            return savedMessages.stream()
-                    .filter(message -> message.getThread() != null)
-                    .filter(message -> message.getThread().getMailAccount() != null)
-                    .filter(message -> mailAccountId.equals(message.getThread().getMailAccount().getId()))
-                    .filter(message -> gmailThreadId.equals(message.getThread().getGmailThreadId()))
-                    .filter(message -> !gmailMessageId.equals(message.getGmailMessageId()))
-                    .anyMatch(message -> !message.isDeleted());
-        }
-
-        @Override
-        public Optional<Message> findByIdIncludingDeleted(UUID messageId) {
-            return Optional.empty();
-        }
-
-        @Override
-        public List<Message> findAllByThreadIdAndDeletedAtIsNull(UUID threadId) {
-            return List.of();
-        }
-
-        @Override
-        public List<Message> findAllByThreadIdIncludingDeleted(UUID threadId) {
-            return List.of();
-        }
-
-        @Override
-        public List<Message> findAllByThreadIdInAndDeletedAtIsNull(List<UUID> threadIds) {
-            return List.of();
-        }
-
-        @Override
-        public List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId) {
-            return List.of();
-        }
-
-        @Override
-        public List<Message> findAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return List.of();
-        }
-
-        @Override
-        public Slice<Message> findDeletedByUserId(UUID userId, UUID markerId, Pageable pageable) {
-            return new SliceImpl<>(List.of());
-        }
-
-        @Override
-        public List<Message> findAllDeletedByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return List.of();
-        }
-
-        @Override
-        public int bulkSoftDeleteByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId, LocalDateTime deletedAt) {
-            return 0;
-        }
-
-        @Override
-        public int bulkRestoreByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return 0;
-        }
-
-        @Override
-        public void hardDelete(Message message) {
-        }
-
-        @Override
-        public boolean existsByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
-            return false;
-        }
+    private Thread createThread(MailAccount mailAccount, String gmailThreadId, Direction direction) {
+        return Thread.builder()
+                .id(UUID.randomUUID())
+                .mailAccount(mailAccount)
+                .gmailThreadId(gmailThreadId)
+                .direction(direction)
+                .read(true)
+                .messageCount(0)
+                .build();
     }
 }

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/MailAccountCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/MailAccountCommandServiceTest.java
@@ -3,11 +3,10 @@ package com.mailsangja.worker.service.mail;
 import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.MailProvider;
 import com.mailsangja.db.port.MailAccountRepositoryPort;
-import com.mailsangja.worker.config.properties.GoogleOAuthProperties;
 import com.mailsangja.worker.dto.gmail.oauth.GoogleOAuthTokenResult;
-import com.mailsangja.worker.service.google.GoogleOAuthQueryService;
+import com.mailsangja.worker.dto.gmail.watch.GoogleMailWatchResult;
+import com.mailsangja.worker.dto.mail.watch.RenewGoogleWatchCommand;
 import org.junit.jupiter.api.Test;
-import org.springframework.web.client.RestClient;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,52 +15,50 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class GoogleAccessTokenEnsureServiceTest {
+class MailAccountCommandServiceTest {
 
     @Test
-    void ensureValidGoogleAccessToken_만료가충분히남아있으면기존토큰을사용한다() {
-        MailAccount mailAccount = createMailAccount(LocalDateTime.now().plusMinutes(30), "access-token", "refresh-token");
+    void renewGoogleWatch_액세스토큰이일치하면토큰과워치정보를함께갱신한다() {
+        MailAccount mailAccount = createMailAccount("old-access-token", "old-refresh-token");
         InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
-        FakeGoogleOAuthQueryService googleOAuthQueryService = new FakeGoogleOAuthQueryService();
-        GoogleAccessTokenEnsureService service = createService(repository, googleOAuthQueryService);
-
-        MailAccount ensuredMailAccount = service.ensureValidGoogleAccessToken(mailAccount);
-
-        assertEquals("access-token", ensuredMailAccount.getAccessToken());
-        assertEquals(0, googleOAuthQueryService.refreshCallCount);
-    }
-
-    @Test
-    void ensureValidGoogleAccessToken_만료가임박하면토큰을재발급한다() {
-        MailAccount mailAccount = createMailAccount(LocalDateTime.now().plusMinutes(5), "old-token", "refresh-token");
-        InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
-        FakeGoogleOAuthQueryService googleOAuthQueryService = new FakeGoogleOAuthQueryService();
-        GoogleAccessTokenEnsureService service = createService(repository, googleOAuthQueryService);
-
-        MailAccount ensuredMailAccount = service.ensureValidGoogleAccessToken(mailAccount);
-
-        assertEquals("refreshed-token", ensuredMailAccount.getAccessToken());
-        assertEquals("new-refresh-token", ensuredMailAccount.getRefreshToken());
-        assertEquals(1, googleOAuthQueryService.refreshCallCount);
-    }
-
-    private GoogleAccessTokenEnsureService createService(
-            InMemoryMailAccountRepository repository,
-            FakeGoogleOAuthQueryService googleOAuthQueryService
-    ) {
         MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(repository);
-        MailAccountCommandService mailAccountCommandService = new MailAccountCommandService(
-                repository,
-                mailAccountQueryService
+        MailAccountCommandService service = new MailAccountCommandService(repository, mailAccountQueryService);
+
+        service.renewGoogleWatch(
+                RenewGoogleWatchCommand.of(
+                        mailAccount.getId(),
+                        new GoogleOAuthTokenResult("new-access-token", "new-refresh-token", 3600L, null, "Bearer"),
+                        new GoogleMailWatchResult("history-123", LocalDateTime.now().plusDays(7))
+                )
         );
-        return new GoogleAccessTokenEnsureService(
-                mailAccountCommandService,
-                googleOAuthQueryService,
-                mailAccountQueryService
-        );
+
+        assertEquals("new-access-token", mailAccount.getAccessToken());
+        assertEquals("new-refresh-token", mailAccount.getRefreshToken());
+        assertEquals("history-123", mailAccount.getSyncHistoryId());
     }
 
-    private MailAccount createMailAccount(LocalDateTime expiresAt, String accessToken, String refreshToken) {
+    @Test
+    void renewGoogleWatch_경쟁상황으로조건부업데이트에실패하면기존값을유지한다() {
+        MailAccount mailAccount = createMailAccount("latest-access-token", "latest-refresh-token");
+        InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
+        MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(repository);
+        MailAccountCommandService service = new MailAccountCommandService(repository, mailAccountQueryService);
+        repository.expectedAccessTokenOverride = "different-access-token";
+
+        service.renewGoogleWatch(
+                RenewGoogleWatchCommand.of(
+                        mailAccount.getId(),
+                        new GoogleOAuthTokenResult("stale-new-access-token", "stale-new-refresh-token", 3600L, null, "Bearer"),
+                        new GoogleMailWatchResult("stale-history", LocalDateTime.now().plusDays(1))
+                )
+        );
+
+        assertEquals("latest-access-token", mailAccount.getAccessToken());
+        assertEquals("latest-refresh-token", mailAccount.getRefreshToken());
+        assertEquals("sync-history-id", mailAccount.getSyncHistoryId());
+    }
+
+    private MailAccount createMailAccount(String accessToken, String refreshToken) {
         return MailAccount.builder()
                 .id(UUID.randomUUID())
                 .provider(MailProvider.GMAIL)
@@ -70,28 +67,17 @@ class GoogleAccessTokenEnsureServiceTest {
                 .icon("icon")
                 .color("#4285F4")
                 .accessToken(accessToken)
-                .accessTokenExpiresAt(expiresAt)
+                .accessTokenExpiresAt(LocalDateTime.now().plusMinutes(30))
                 .refreshToken(refreshToken)
+                .syncHistoryId("sync-history-id")
+                .watchExpiresAt(LocalDateTime.now().plusDays(3))
                 .active(true)
                 .build();
     }
 
-    private static final class FakeGoogleOAuthQueryService extends GoogleOAuthQueryService {
-        private int refreshCallCount;
-
-        private FakeGoogleOAuthQueryService() {
-            super(new GoogleOAuthProperties(), RestClient.builder().build());
-        }
-
-        @Override
-        public GoogleOAuthTokenResult refreshAccessToken(String refreshToken) {
-            refreshCallCount++;
-            return new GoogleOAuthTokenResult("refreshed-token", "new-refresh-token", 3600L, null, "Bearer");
-        }
-    }
-
     private static final class InMemoryMailAccountRepository implements MailAccountRepositoryPort {
         private final MailAccount mailAccount;
+        private String expectedAccessTokenOverride;
 
         private InMemoryMailAccountRepository(MailAccount mailAccount) {
             this.mailAccount = mailAccount;
@@ -152,14 +138,7 @@ class GoogleAccessTokenEnsureServiceTest {
                 LocalDateTime newAccessTokenExpiresAt,
                 String newRefreshToken
         ) {
-            if (!id.equals(mailAccount.getId()) || !expectedAccessToken.equals(mailAccount.getAccessToken())) {
-                return 0;
-            }
-
-            mailAccount.updateAccessToken(newAccessToken);
-            mailAccount.updateAccessTokenExpiresAt(newAccessTokenExpiresAt);
-            mailAccount.updateRefreshToken(newRefreshToken);
-            return 1;
+            return 0;
         }
 
         @Override
@@ -172,7 +151,20 @@ class GoogleAccessTokenEnsureServiceTest {
                 String newSyncHistoryId,
                 LocalDateTime newWatchExpiresAt
         ) {
-            return 0;
+            String matchedAccessToken = expectedAccessTokenOverride == null
+                    ? mailAccount.getAccessToken()
+                    : expectedAccessTokenOverride;
+
+            if (!id.equals(mailAccount.getId()) || !expectedAccessToken.equals(matchedAccessToken)) {
+                return 0;
+            }
+
+            mailAccount.updateAccessToken(newAccessToken);
+            mailAccount.updateAccessTokenExpiresAt(newAccessTokenExpiresAt);
+            mailAccount.updateRefreshToken(newRefreshToken);
+            mailAccount.updateSyncHistoryId(newSyncHistoryId);
+            mailAccount.updateWatchExpiresAt(newWatchExpiresAt);
+            return 1;
         }
 
         @Override

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/MailAccountCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/MailAccountCommandServiceTest.java
@@ -7,43 +7,82 @@ import com.mailsangja.worker.dto.gmail.oauth.GoogleOAuthTokenResult;
 import com.mailsangja.worker.dto.gmail.watch.GoogleMailWatchResult;
 import com.mailsangja.worker.dto.mail.watch.RenewGoogleWatchCommand;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class MailAccountCommandServiceTest {
+
+    @Mock
+    private MailAccountRepositoryPort mailAccountRepositoryPort;
 
     @Test
     void renewGoogleWatch_액세스토큰이일치하면토큰과워치정보를함께갱신한다() {
         MailAccount mailAccount = createMailAccount("old-access-token", "old-refresh-token");
-        InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
-        MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(repository);
-        MailAccountCommandService service = new MailAccountCommandService(repository, mailAccountQueryService);
+        when(mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(mailAccount.getId()))
+                .thenReturn(Optional.of(mailAccount));
+        when(mailAccountRepositoryPort.renewGoogleWatchIfAccessTokenMatches(
+                eq(mailAccount.getId()),
+                eq("old-access-token"),
+                eq("new-access-token"),
+                any(LocalDateTime.class),
+                eq("new-refresh-token"),
+                eq("history-123"),
+                any(LocalDateTime.class)
+        )).thenReturn(1);
+
+        MailAccountCommandService service = createService();
+        LocalDateTime newWatchExpiresAt = LocalDateTime.now().plusDays(7);
 
         service.renewGoogleWatch(
                 RenewGoogleWatchCommand.of(
                         mailAccount.getId(),
                         new GoogleOAuthTokenResult("new-access-token", "new-refresh-token", 3600L, null, "Bearer"),
-                        new GoogleMailWatchResult("history-123", LocalDateTime.now().plusDays(7))
+                        new GoogleMailWatchResult("history-123", newWatchExpiresAt)
                 )
         );
 
-        assertEquals("new-access-token", mailAccount.getAccessToken());
-        assertEquals("new-refresh-token", mailAccount.getRefreshToken());
-        assertEquals("history-123", mailAccount.getSyncHistoryId());
+        ArgumentCaptor<LocalDateTime> tokenExpiresAtCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(mailAccountRepositoryPort).renewGoogleWatchIfAccessTokenMatches(
+                eq(mailAccount.getId()),
+                eq("old-access-token"),
+                eq("new-access-token"),
+                tokenExpiresAtCaptor.capture(),
+                eq("new-refresh-token"),
+                eq("history-123"),
+                eq(newWatchExpiresAt)
+        );
     }
 
     @Test
     void renewGoogleWatch_경쟁상황으로조건부업데이트에실패하면기존값을유지한다() {
         MailAccount mailAccount = createMailAccount("latest-access-token", "latest-refresh-token");
-        InMemoryMailAccountRepository repository = new InMemoryMailAccountRepository(mailAccount);
-        MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(repository);
-        MailAccountCommandService service = new MailAccountCommandService(repository, mailAccountQueryService);
-        repository.expectedAccessTokenOverride = "different-access-token";
+        when(mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(mailAccount.getId()))
+                .thenReturn(Optional.of(mailAccount));
+        when(mailAccountRepositoryPort.renewGoogleWatchIfAccessTokenMatches(
+                eq(mailAccount.getId()),
+                eq("latest-access-token"),
+                eq("stale-new-access-token"),
+                any(LocalDateTime.class),
+                eq("stale-new-refresh-token"),
+                eq("stale-history"),
+                any(LocalDateTime.class)
+        )).thenReturn(0);
+
+        MailAccountCommandService service = createService();
 
         service.renewGoogleWatch(
                 RenewGoogleWatchCommand.of(
@@ -53,9 +92,24 @@ class MailAccountCommandServiceTest {
                 )
         );
 
+        verify(mailAccountRepositoryPort).renewGoogleWatchIfAccessTokenMatches(
+                eq(mailAccount.getId()),
+                eq("latest-access-token"),
+                eq("stale-new-access-token"),
+                any(LocalDateTime.class),
+                eq("stale-new-refresh-token"),
+                eq("stale-history"),
+                any(LocalDateTime.class)
+        );
+        verify(mailAccountRepositoryPort, never()).save(any());
         assertEquals("latest-access-token", mailAccount.getAccessToken());
         assertEquals("latest-refresh-token", mailAccount.getRefreshToken());
         assertEquals("sync-history-id", mailAccount.getSyncHistoryId());
+    }
+
+    private MailAccountCommandService createService() {
+        MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(mailAccountRepositoryPort);
+        return new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
     }
 
     private MailAccount createMailAccount(String accessToken, String refreshToken) {
@@ -73,108 +127,5 @@ class MailAccountCommandServiceTest {
                 .watchExpiresAt(LocalDateTime.now().plusDays(3))
                 .active(true)
                 .build();
-    }
-
-    private static final class InMemoryMailAccountRepository implements MailAccountRepositoryPort {
-        private final MailAccount mailAccount;
-        private String expectedAccessTokenOverride;
-
-        private InMemoryMailAccountRepository(MailAccount mailAccount) {
-            this.mailAccount = mailAccount;
-        }
-
-        @Override
-        public MailAccount save(MailAccount mailAccount) {
-            return this.mailAccount;
-        }
-
-        @Override
-        public Optional<MailAccount> findByIdAndDeletedAtIsNull(UUID id) {
-            return Optional.of(mailAccount).filter(account -> id.equals(account.getId()));
-        }
-
-        @Override
-        public Optional<MailAccount> findByIdAndActiveAndDeletedAtIsNull(UUID id, boolean active) {
-            return Optional.of(mailAccount)
-                    .filter(account -> id.equals(account.getId()))
-                    .filter(account -> account.isActive() == active);
-        }
-
-        @Override
-        public Optional<MailAccount> findByEmailAddressAndDeletedAtIsNull(String emailAddress) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<MailAccount> findByUserIdAndProviderAndDeletedAtIsNull(UUID userId, MailProvider provider) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<MailAccount> findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(UUID userId, MailProvider provider, String emailAddress) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<MailAccount> findByUserIdAndEmailAddressAndActiveAndDeletedAtIsNull(UUID userId, String emailAddress, boolean active) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<MailAccount> findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress) {
-            return Optional.empty();
-        }
-
-        @Override
-        public List<MailAccount> findAllByUserIdAndDeletedAtIsNull(UUID userId) {
-            return List.of();
-        }
-
-        @Override
-        public int updateGoogleTokenIfAccessTokenMatches(
-                UUID id,
-                String expectedAccessToken,
-                String newAccessToken,
-                LocalDateTime newAccessTokenExpiresAt,
-                String newRefreshToken
-        ) {
-            return 0;
-        }
-
-        @Override
-        public int renewGoogleWatchIfAccessTokenMatches(
-                UUID id,
-                String expectedAccessToken,
-                String newAccessToken,
-                LocalDateTime newAccessTokenExpiresAt,
-                String newRefreshToken,
-                String newSyncHistoryId,
-                LocalDateTime newWatchExpiresAt
-        ) {
-            String matchedAccessToken = expectedAccessTokenOverride == null
-                    ? mailAccount.getAccessToken()
-                    : expectedAccessTokenOverride;
-
-            if (!id.equals(mailAccount.getId()) || !expectedAccessToken.equals(matchedAccessToken)) {
-                return 0;
-            }
-
-            mailAccount.updateAccessToken(newAccessToken);
-            mailAccount.updateAccessTokenExpiresAt(newAccessTokenExpiresAt);
-            mailAccount.updateRefreshToken(newRefreshToken);
-            mailAccount.updateSyncHistoryId(newSyncHistoryId);
-            mailAccount.updateWatchExpiresAt(newWatchExpiresAt);
-            return 1;
-        }
-
-        @Override
-        public List<MailAccount> findRenewalTargetGmailAccounts(MailProvider provider, LocalDateTime watchExpiresAtThreshold, int limit) {
-            return List.of();
-        }
-
-        @Override
-        public List<MailAccount> findAllByUserIdAndActiveAndDeletedAtIsNull(UUID userId, boolean active) {
-            return List.of();
-        }
     }
 }


### PR DESCRIPTION
  ## 🔗 관련 작업

  ### 👤 User Story
  - mailsangja/docs4capstone#2

  ### 📌 Task
  - Closes #9


  ## 💡 작업 내용

  - Gmail API 호출 전에 access token 만료 임박 여부를 확인하고 필요 시 refresh token으로 선갱신하는 로직을 추가했습니다.
  - `core`/`worker` 각각에 `GoogleAccessTokenEnsureService`를 추가하고, 실제 Gmail 호출 경로가 저장된 토큰을 직접 사용하지 않도록 변경했습니다.
  - access token refresh 실패 및 refresh token 누락 상황에 대한 예외 코드를 추가하고 테스트를 보강했습니다.


  ## 📝 추가 설명

  ### 1. core Gmail 호출 경로 선갱신 적용
  - `GoogleOAuthQueryService`에 refresh token 기반 access token 재발급 메서드를 추가했습니다.
  - `MailCommandService`, `MailFacade`, `InboxFacade`, `TrashFacade`가 Gmail API 호출 전에 `GoogleAccessTokenEnsureService`를 통해 최신 토큰을 보장하도록 변경했습니
  다.

  ### 2. worker 비동기 동기화 경로 선갱신 적용
  - `InitialMailSyncFacade`, `GmailPushFacade`, `GmailNewMessageSyncCommandService`, `GmailHistoryStateCommandService`에 토큰 보장 로직을 연결했습니다.
  - Gmail watch 갱신과 별개로, 실제 worker Gmail API 호출 시점에도 access token 만료를 방지할 수 있도록 수정했습니다.

  ### 3. 예외 처리 및 테스트 추가
  - `GOOGLE_TOKEN_REFRESH_FAILED`, `GOOGLE_REFRESH_TOKEN_MISSING` 예외 흐름을 반영했습니다.
  - `core`/`worker` 각각에 `GoogleAccessTokenEnsureServiceTest`를 추가해
    만료 여유가 충분한 경우와 만료 임박 시 refresh 되는 경우를 검증했습니다.
  - `MailFacadeTest`도 최신 토큰 보장 서비스가 반영된 구조에 맞게 수정했습니다.