### PR TITLE
[STORY-206] 메시지 저장 실패시 푸시 알림 전송 하지 않도록 수정

### DIFF
--- a/worker/src/main/java/com/mailsangja/worker/common/exception/mail/MailPushErrorCode.java
+++ b/worker/src/main/java/com/mailsangja/worker/common/exception/mail/MailPushErrorCode.java
@@ -27,7 +27,8 @@ public enum MailPushErrorCode implements ErrorCode {
     GMAIL_HISTORY_FETCH_FAILED(502, "MS-MAIL-GMAIL-HISTORY-FETCH-FAILED", "Gmail History 조회에 실패했습니다."),
     GMAIL_HISTORY_RESULT_INVALID(502, "MS-MAIL-GMAIL-HISTORY-RESULT-INVALID", "Gmail History 응답값이 올바르지 않습니다."),
     GMAIL_MESSAGES_FETCH_FAILED(502, "MS-MAIL-GMAIL-MESSAGES-FETCH-FAILED", "Gmail 최신 메일 조회에 실패했습니다."),
-    GMAIL_MESSAGES_RESULT_INVALID(502, "MS-MAIL-GMAIL-MESSAGES-RESULT-INVALID", "Gmail 최신 메일 응답값이 올바르지 않습니다.");
+    GMAIL_MESSAGES_RESULT_INVALID(502, "MS-MAIL-GMAIL-MESSAGES-RESULT-INVALID", "Gmail 최신 메일 응답값이 올바르지 않습니다."),
+    NEW_MESSAGE_NOT_SAVED(500, "MS-MAIL-NEW-MESSAGE-NOT-SAVED", "새 메시지 저장에 실패했습니다.");
 
     private final int status;
     private final String code;

--- a/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
@@ -6,8 +6,10 @@ import com.mailsangja.worker.dto.notification.NewMailPushContext;
 import com.mailsangja.worker.service.mail.GmailNewMessageSyncCommandService;
 import com.mailsangja.worker.service.notification.FcmPushCommandService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MessageAddedHistoryEventHandler implements GmailHistoryEventHandler {
@@ -23,6 +25,10 @@ public class MessageAddedHistoryEventHandler implements GmailHistoryEventHandler
     @Override
     public void handle(GmailHistoryEvent event) {
         NewMailPushContext context = gmailNewMessageSyncCommandService.syncNewMessage(event);
-        fcmPushCommandService.sendNewMailPush(context);
+        try {
+            fcmPushCommandService.sendNewMailPush(context);
+        } catch (Exception e) {
+            log.warn("FCM push skipped due to unexpected error: mailAccountId={} error={}", context.mailAccountId(), e.getMessage());
+        }
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandService.java
@@ -8,6 +8,8 @@ import com.mailsangja.db.port.MessageRepositoryPort;
 import com.mailsangja.db.port.ThreadRepositoryPort;
 import com.mailsangja.worker.dto.gmail.history.GmailHistoryEvent;
 import com.mailsangja.worker.dto.mail.sync.InitialMailSyncThreadSaveCommand;
+import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
+import com.mailsangja.worker.common.exception.mail.MailPushException;
 import com.mailsangja.worker.dto.mail.sync.NewMessageApplyResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,7 +52,7 @@ public class GmailNewMessageApplyCommandService {
         if (messageOpt.isEmpty()) {
             log.warn("저장된 메시지를 찾을 수 없습니다: mailAccountId={} gmailThreadId={} gmailMessageId={}",
                     mailAccountId, gmailThreadId, gmailMessageId);
-            return new NewMessageApplyResult(null, null);
+            throw new MailPushException(MailPushErrorCode.NEW_MESSAGE_NOT_SAVED);
         }
         Message message = messageOpt.get();
         return new NewMessageApplyResult(message.getId(), message.getThread().getId());

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandService.java
@@ -31,7 +31,7 @@ public class GmailNewMessageApplyCommandService {
     private final InitialMailSyncCommandService initialMailSyncCommandService;
 
     @Transactional
-    public NewMessageApplyResult applyNewMessageSync(
+    public void applyNewMessageSync(
             MailAccount mailAccount,
             GmailHistoryEvent event,
             InitialMailSyncThreadSaveCommand syncCommand
@@ -41,11 +41,9 @@ public class GmailNewMessageApplyCommandService {
         restoreIfDeleted(mailAccount, event.gmailThreadId());
 
         initialMailSyncCommandService.saveThreadBatch(mailAccount, List.of(syncCommand));
-
-        return findNewMessageApplyResult(mailAccount.getId(), event.gmailThreadId(), event.gmailMessageId());
     }
 
-    private NewMessageApplyResult findNewMessageApplyResult(UUID mailAccountId, String gmailThreadId, String gmailMessageId) {
+    public NewMessageApplyResult findNewMessageApplyResult(UUID mailAccountId, String gmailThreadId, String gmailMessageId) {
         Optional<Message> messageOpt = messageRepositoryPort.findByMailAccountIdAndGmailThreadIdAndGmailMessageIdAndDeletedAtIsNull(
                 mailAccountId, gmailThreadId, gmailMessageId
         );

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageSyncCommandService.java
@@ -41,7 +41,10 @@ public class GmailNewMessageSyncCommandService {
         }
 
         InitialMailSyncThreadSaveCommand syncCommand = InitialMailSyncThreadSaveCommand.from(threadResults.getFirst());
-        NewMessageApplyResult applyResult = gmailNewMessageApplyCommandService.applyNewMessageSync(mailAccount, event, syncCommand);
+        gmailNewMessageApplyCommandService.applyNewMessageSync(mailAccount, event, syncCommand);
+        NewMessageApplyResult applyResult = gmailNewMessageApplyCommandService.findNewMessageApplyResult(
+                mailAccount.getId(), event.gmailThreadId(), event.gmailMessageId()
+        );
 
         String subject = null;
         String snippet = null;


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#9

### 📌 Task
- Closes #47


## 💡 작업 내용

- Message 저장 후 Message를 찾지 못하면 null 반환 대신 MailPushException(NEW_MESSAGE_NOT_SAVED) throw
  - 메시지 저장 실패가 명시적인 오류로 전파
- sendNewMailPush 호출을 try-catch (Exception)으로 감싸서, FCM 관련 예외(DB 조회 실패, 네트워크 오류 등)가 메시지 동기화 결과에 영향을 주지 않도록 격리.
  - 실패 시 log.warn으로만 기록합니다.