### PR TITLE
[STORY-203] Thread, Message 삭제 동기화 문제 해결

### DIFF
--- a/core/src/main/java/com/mailsangja/core/facade/TrashFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/TrashFacade.java
@@ -100,7 +100,7 @@ public class TrashFacade {
         validateThreadAccess(user, message.getThread());
         trashCommandService.restoreMessage(message);
         MailAccount ensuredMailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(message.getThread().getMailAccount());
-        googleGmailApiService.untrashMessage(ensuredMailAccount.getAccessToken(), message.getGmailMessageId());
+        googleGmailApiService.untrashThread(ensuredMailAccount.getAccessToken(), message.getThread().getGmailThreadId());
     }
 
     private void validateThreadAccess(User user, Thread thread) {

--- a/core/src/main/java/com/mailsangja/core/facade/TrashFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/TrashFacade.java
@@ -100,7 +100,7 @@ public class TrashFacade {
         validateThreadAccess(user, message.getThread());
         trashCommandService.restoreMessage(message);
         MailAccount ensuredMailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(message.getThread().getMailAccount());
-        googleGmailApiService.untrashThread(ensuredMailAccount.getAccessToken(), message.getThread().getGmailThreadId());
+        googleGmailApiService.untrashMessage(ensuredMailAccount.getAccessToken(), message.getGmailMessageId());
     }
 
     private void validateThreadAccess(User user, Thread thread) {

--- a/core/src/main/java/com/mailsangja/core/service/trash/TrashCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/trash/TrashCommandService.java
@@ -66,10 +66,7 @@ public class TrashCommandService {
         String gmailThreadId = message.getThread().getGmailThreadId();
         gmailThreadLockRepositoryPort.acquireThreadLock(message.getThread().getMailAccount(), gmailThreadId);
 
-        message.restore();
-        messageRepositoryPort.save(message);
-
-        // Thread가 삭제 상태였다면 복원 (활성 메시지가 생겼으므로)
+        messageRepositoryPort.bulkRestoreByMailAccountIdAndGmailThreadId(mailAccountId, gmailThreadId);
         threadRepositoryPort.bulkRestoreByMailAccountIdAndGmailThreadId(mailAccountId, gmailThreadId);
     }
 }

--- a/core/src/main/java/com/mailsangja/core/service/trash/TrashCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/trash/TrashCommandService.java
@@ -66,7 +66,8 @@ public class TrashCommandService {
         String gmailThreadId = message.getThread().getGmailThreadId();
         gmailThreadLockRepositoryPort.acquireThreadLock(message.getThread().getMailAccount(), gmailThreadId);
 
-        messageRepositoryPort.bulkRestoreByMailAccountIdAndGmailThreadId(mailAccountId, gmailThreadId);
+        message.restore();
+        messageRepositoryPort.save(message);
         threadRepositoryPort.bulkRestoreByMailAccountIdAndGmailThreadId(mailAccountId, gmailThreadId);
     }
 }

--- a/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
@@ -66,7 +66,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             @Param("deletedAt") LocalDateTime deletedAt
     );
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Thread t SET t.deletedAt = NULL WHERE t.mailAccount.id = :mailAccountId AND t.gmailThreadId = :gmailThreadId AND t.deletedAt IS NOT NULL")
     int bulkRestoreByMailAccountIdAndGmailThreadId(
             @Param("mailAccountId") UUID mailAccountId,


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#6

### 📌 Task
- Closes #37
- Closes #36  

## 💡 작업 내용 (문제 상황)

휴지통 메시지 복원(`POST /api/v1/trash/messages/{messageId}/restore`) 호출 후 세 가지 버그가 함께 나타났다.


- **버그 1: 받은 편지함에서 메시지 배열이 비어 있음**
  - 스레드는 복원되어 받은 편지함에 노출되지만, 스레드를 열면 메시지가 하나도 없다.
  - 메시지 개수와 무관하게 항상 재현된다.

- **버그 2: 휴지통 목록에 복원한 메시지가 그대로 남음**
  - `GET /api/v1/trash/threads`를 다시 조회하면 방금 복원한 메시지가 여전히 `deletedAt IS NOT NULL` 상태로 반환된다.

- **버그 3: 이어서 스레드 복원을 시도하면 409 Conflict**
  - 버그 1·2로 인해 빈 스레드가 보인 사용자가 `POST /api/v1/trash/threads/{threadId}/restore`를 추가로 호출하면, 이미 스레드는 복원된 상태여서 `THREAD_NOT_DELETED(409)`가 반환된다.


> 세 버그의 근본 원인은 하나다. `restoreMessage()` 내에서 메시지 엔티티 변경이 DB에 반영되지 않은 채 Persistence Context(PC)가 초기화된다.

---

## 📝 추가 설명 (원인 분석)

### 코드 흐름

```java
// TrashCommandService.restoreMessage() — 수정 전
@Transactional
public void restoreMessage(Message message) {
    ...
    message.restore();                                                // 1. 엔티티 deletedAt = null
    messageRepositoryPort.save(message);                             // 2. PC에 dirty 상태로 등록
    threadRepositoryPort.bulkRestoreByMailAccountIdAndGmailThreadId( // 3. @Modifying JPQL UPDATE
        mailAccountId, gmailThreadId                                 //    clearAutomatically = true
    );
}
```

### Hibernate 6의 AUTO flush 동작

- Hibernate 6은 `FlushMode.AUTO`에서 JPQL SELECT 실행 전에는 관련 엔티티 타입의 dirty state를 flush한다.
- 그러나 **`@Modifying` JPQL UPDATE/DELETE 실행 전에는 자동 flush가 보장되지 않는다.**
- flush 여부가 "해당 쿼리의 결과에 영향을 미치는 엔티티 타입"을 기준으로 판단되는데, `UPDATE Thread` 쿼리와 dirty `Message` 엔티티는 서로 다른 타입이므로 flush가 트리거되지 않는다.

```
1. message.restore()  → PC 내 Message 엔티티 dirty (deletedAt = null)
2. save(message)      → em.merge() 후 managed 상태, PC에 dirty로 남음
3. UPDATE Thread ...  → @Modifying JPQL 실행
                       ↑ Hibernate 6: flush 없이 바로 SQL 실행
4. clearAutomatically = true → PC 초기화
                       ↑ dirty Message 엔티티가 flush 없이 증발
5. 트랜잭션 커밋      → flush 시점에 Message는 이미 PC에 없음
                         → UPDATE Message SET deletedAt = null 미실행
```

결과적으로 DB의 메시지는 `deletedAt IS NOT NULL` 상태 그대로 유지되고, 스레드만 `deletedAt = NULL`로 복원된다. 버그 1(메시지 없는 스레드)과 버그 2(휴지통에 잔류)가 동시에 발생하며, 이 불일치 상태를 해소하려는 재시도가 버그 3(409)으로 이어진다.

### `softDeleteMessage()`가 같은 구조에서도 정상인 이유

```java
// TrashCommandService.softDeleteMessage()
message.delete();
messageRepositoryPort.save(message);   // dirty Message → PC

List<Message> activeMessages =
    messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(...);
    // ↑ SELECT 쿼리 실행 전 AUTO flush → Message dirty state 포함 flush ✓

if (activeMessages.isEmpty()) {
    threadRepositoryPort.bulkSoftDeleteByMailAccountIdAndGmailThreadId(...);
}
```

- 삭제 흐름에서는 Thread를 삭제하기 전에 **SELECT**로 활성 메시지를 조회한다.
- Hibernate 6은 SELECT 실행 전에 같은 엔티티 타입(`Message`)의 dirty state를 flush하므로, 이 시점에 `message.delete()`가 DB에 반영된다.
- Thread bulk delete가 실행될 때는 Message가 이미 DB에 저장된 상태다.

> 삭제와 복원이 겉보기에 유사한 구조임에도 복원만 깨지는 것은 **SELECT 유무**가 flush를 트리거하느냐 아니냐의 차이였다.

---

## ✅ 설계 결정

### 삭제·복원의 대칭 규칙

> 버그 수정 과정에서 네 가지 규칙을 명시적으로 정의했다.

| 작업 | 동작 |
|---|---|
| **메시지 삭제** | 해당 메시지만 소프트 삭제. 스레드 내 활성 메시지가 모두 없어지면 Thread도 소프트 삭제 |
| **메시지 복원** | 해당 메시지만 복원. Thread는 **무조건** 복원 (삭제 여부와 관계없이) |
| **Thread 삭제** | Thread와 속한 **모든** 메시지 소프트 삭제 |
| **Thread 복원** | Thread와 속한 **모든** 메시지 복원 |


### 해결 방법: `flushAutomatically = true`

> Thread bulk restore 쿼리에 `flushAutomatically = true`를 추가했다.

```java
// ThreadJpaRepositoryModule.java — 수정 후
@Modifying(flushAutomatically = true, clearAutomatically = true)
@Query("UPDATE Thread t SET t.deletedAt = NULL WHERE ...")
int bulkRestoreByMailAccountIdAndGmailThreadId(...);
```

- `flushAutomatically = true`는 `@Modifying` 쿼리 실행 직전에 PC 전체를 강제 flush한다.
- dirty `Message` 엔티티가 flush를 통해 DB에 먼저 기록된 뒤, Thread UPDATE가 실행된다.
- 이후 `clearAutomatically = true`로 PC를 초기화해도 Message 변경은 이미 DB에 반영되어 있다.

```
수정 후 실행 순서:
1. message.restore()  → dirty Message in PC
2. save(message)      → managed dirty Message in PC
3. UPDATE Thread ...  → flushAutomatically = true
                       → PC 전체 flush 먼저
                         → UPDATE Message SET deletedAt = null ... ✓
                       → UPDATE Thread SET deletedAt = null ...  ✓
                       → clearAutomatically = true → PC 초기화
4. 트랜잭션 커밋      → 이미 모두 반영됨
```

### Gmail API 호출 범위

메시지 복원 시 Gmail API 호출도 복원 단위에 맞춰 조정했다.

| 작업 | Gmail API |
|---|---|
| **Thread 삭제** | `trashThread(gmailThreadId)` — 스레드 전체를 trash |
| **메시지 삭제** | `trashMessage(gmailMessageId)` — 해당 메시지만 trash |
| **Thread 복원** | `untrashThread(gmailThreadId)` — 스레드 전체를 untrash |
| **메시지 복원** | `untrashMessage(gmailMessageId)` — 해당 메시지만 untrash |

> 메시지 복원 시 `untrashThread()`를 호출하면 DB에서 삭제 상태로 남아 있는 다른 메시지까지 Gmail에서 untrash되어 DB·Gmail 간 불일치가 발생한다. 복원 단위와 Gmail API 호출 범위를 일치시켜 이를 방지한다.

---

## 🔥 Trade-Off

- **`flushAutomatically = true`의 비용**
  - `flushAutomatically = true`는 PC 전체를 flush한다.
  - PC에 dirty 엔티티가 많을수록 불필요한 UPDATE가 발생할 수 있다.
  - 현재 `restoreMessage()` 흐름은 PC에 단 하나의 dirty 엔티티(복원 대상 Message)만 존재하므로 실질적인 오버헤드는 없다.
  - 향후 같은 트랜잭션에서 다수의 엔티티 변경이 선행된다면 이 비용을 재검토해야 한다.

- **`flushAutomatically` 위치를 쿼리 수준에 두는 것의 한계**
  - 같은 `bulkRestoreByMailAccountIdAndGmailThreadId` 메서드를 `restoreThread()`도 호출한다.
  - `restoreThread()`에서는 선행 dirty 엔티티가 없어 flush가 no-op이므로 문제없지만, 메서드 시그니처만 보면 "왜 flush가 필요한가"가 드러나지 않는다.
  - flush 필요성은 호출 측의 PC 상태에 있는데, 그 제어가 피호출 메서드의 어노테이션에 있어 의도가 분산된다. 이 점은 팀 내 공유가 필요하다.