### PR TITLE
[STORY-401] PostgreSQL Unique 제약 추가

### DIFF
--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -20,6 +20,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+    defer-datasource-initialization: true
     show-sql: true
     properties:
       hibernate:
@@ -29,7 +30,8 @@ spring:
 
   sql:
     init:
-      mode: never
+      mode: always
+      schema-locations: classpath:init.sql
 
   data:
     redis:

--- a/db/src/main/resources/init.sql
+++ b/db/src/main/resources/init.sql
@@ -1,0 +1,12 @@
+CREATE UNIQUE INDEX IF NOT EXISTS uq_user_devices_fcm_token_active
+    ON user_devices (fcm_token)
+    WHERE deleted_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_threads_account_gmail_direction
+    ON threads (mail_account_id, gmail_thread_id, direction);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_gmail_thread_locks_account_thread
+    ON gmail_thread_locks (mail_account_id, gmail_thread_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_messages_thread_gmail
+    ON messages (thread_id, gmail_message_id);


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#16

### 📌 Task
- Closes #67 


## 💡 작업 내용

- core/src/main/resources/application.yaml
   - spring.jpa.defer-datasource-initialization: true
   - spring.sql.init.mode: always
   - spring.sql.init.schema-locations: classpath:init.sql
- init.sql에 unique 제약 추가
  - 이는 기존의 schema.sql을 바탕으로 작성하였습니다.