### PR TITLE
[STORY-206] FCM 페이로드 data-only로 수정

### DIFF
--- a/worker/src/main/java/com/mailsangja/worker/service/notification/FcmPushCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/notification/FcmPushCommandService.java
@@ -1,7 +1,12 @@
 package com.mailsangja.worker.service.notification;
 
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.messaging.*;
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.SendResponse;
 import com.mailsangja.worker.config.properties.FcmProperties;
 import com.mailsangja.worker.dto.notification.NewMailPushContext;
 import lombok.RequiredArgsConstructor;
@@ -32,22 +37,20 @@ public class FcmPushCommandService {
         String title = StringUtils.hasText(context.subject()) ? context.subject() : DEFAULT_NOTIFICATION_TITLE;
         String threadDetailUrl = buildThreadDetailUrl(context);
 
-        Notification.Builder notificationBuilder = Notification.builder()
-                .setTitle(title)
-                .setBody(context.snippet());
-        if (StringUtils.hasText(fcmProperties.getLogoImageUrl())) {
-            notificationBuilder.setImage(fcmProperties.getLogoImageUrl());
-        }
-
-        MulticastMessage message = MulticastMessage.builder()
-                .setNotification(notificationBuilder.build())
+        MulticastMessage.Builder messageBuilder = MulticastMessage.builder()
+                .putData("title", title)
+                .putData("body", context.snippet() != null ? context.snippet() : "")
                 .putData("mailAccountId", context.mailAccountId().toString())
                 .putData("alias", context.alias())
                 .putData("threadId", context.threadId() != null ? context.threadId().toString() : "")
                 .putData("messageId", context.messageId() != null ? context.messageId().toString() : "")
                 .putData("threadDetailUrl", threadDetailUrl)
-                .addAllTokens(tokens)
-                .build();
+                .addAllTokens(tokens);
+        if (StringUtils.hasText(fcmProperties.getLogoImageUrl())) {
+            messageBuilder.putData("image", fcmProperties.getLogoImageUrl());
+        }
+
+        MulticastMessage message = messageBuilder.build();
 
         try {
             BatchResponse response = FirebaseMessaging.getInstance(firebaseApp).sendEachForMulticast(message);


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#9

### 📌 Task
- Closes #47 


## 💡 작업 내용

- Notification 객체와 setNotification() 호출을 제거하고, title / body / image를 모두 data 페이로드로 이동했습니다.
                                                                                                                                                                                                                   - 변경 전후 차이
  - FCM 메시지 타입 : notification + data 혼합 -> data-only
  - 백그라운드 앱 동작 : OS가 자동으로 알림 표시 -> 프론트 background handler 호출
  - 포그라운드 앱 동작 : 프론트 onMessage 호출 -> 프론트 onMessage 호출
- 프론트엔드에서는 FCM의 onBackgroundMessage (서비스 워커) 또는 앱의 background message handler에서 data.title, data.body, data.image 등을 읽어 직접 알림을 구성하면 됩니다.


| 키 | 값 | 비고 |
| :--- | :--- | :--- |
| `title` | 메일 제목 (없으면 "새 메일이 도착했습니다") | |
| `body` | 메일 snippet | null이면 `""` |
| `image` | FCM 로고 이미지 URL | `fcmProperties.getLogoImageUrl()` 값이 있을 때만 포함 |
| `mailAccountId` | 메일 계정 UUID | |
| `alias` | 메일 계정 별칭 | |
| `threadId` | 스레드 UUID | null이면 `""` |
| `messageId` | 메시지 UUID | null이면 `""` |
| `threadDetailUrl` | 스레드 상세 URL | 템플릿 미설정 또는 threadId null이면 `""` |