### PR TITLE
[STORY-206] 신규 메일만 알림을 수신하도록 수정

### DIFF
--- a/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
@@ -2,7 +2,6 @@ package com.mailsangja.worker.handler.mail;
 
 import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.worker.dto.gmail.history.GmailHistoryEvent;
-import com.mailsangja.worker.dto.notification.NewMailPushContext;
 import com.mailsangja.worker.service.mail.GmailNewMessageSyncCommandService;
 import com.mailsangja.worker.service.notification.FcmPushCommandService;
 import lombok.RequiredArgsConstructor;
@@ -18,11 +17,12 @@ public class MessageAddedHistoryEventHandler {
     private final FcmPushCommandService fcmPushCommandService;
 
     public void handle(MailAccount mailAccount, GmailHistoryEvent event) {
-        NewMailPushContext context = gmailNewMessageSyncCommandService.syncNewMessage(mailAccount, event);
-        try {
-            fcmPushCommandService.sendNewMailPush(context);
-        } catch (Exception e) {
-            log.warn("FCM push skipped due to unexpected error: mailAccountId={} error={}", context.mailAccountId(), e.getMessage());
-        }
+        gmailNewMessageSyncCommandService.syncNewMessage(mailAccount, event).ifPresent(context -> {
+            try {
+                fcmPushCommandService.sendNewMailPush(context);
+            } catch (Exception e) {
+                log.warn("FCM push skipped due to unexpected error: mailAccountId={} error={}", context.mailAccountId(), e.getMessage());
+            }
+        });
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageSyncCommandService.java
@@ -1,6 +1,8 @@
 package com.mailsangja.worker.service.mail;
 
+import com.mailsangja.db.entity.mail.Direction;
 import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.port.MessageRepositoryPort;
 import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
 import com.mailsangja.worker.common.exception.mail.MailPushException;
 import com.mailsangja.worker.dto.gmail.history.GmailHistoryEvent;
@@ -14,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,8 +24,13 @@ public class GmailNewMessageSyncCommandService {
 
     private final GmailMessageApiService gmailMessageApiService;
     private final GmailNewMessageApplyCommandService gmailNewMessageApplyCommandService;
+    private final MessageRepositoryPort messageRepositoryPort;
 
-    public NewMailPushContext syncNewMessage(MailAccount mailAccount, GmailHistoryEvent event) {
+    public Optional<NewMailPushContext> syncNewMessage(MailAccount mailAccount, GmailHistoryEvent event) {
+        boolean isNewMessage = messageRepositoryPort.findByMailAccountIdAndGmailThreadIdAndGmailMessageIdAndDeletedAtIsNull(
+                mailAccount.getId(), event.gmailThreadId(), event.gmailMessageId()
+        ).isEmpty();
+
         List<InitialMailSyncThreadResult> threadResults = gmailMessageApiService.getThreads(
                 mailAccount.getAccessToken(),
                 List.of(event.gmailThreadId())
@@ -34,27 +42,31 @@ public class GmailNewMessageSyncCommandService {
 
         InitialMailSyncThreadSaveCommand syncCommand = InitialMailSyncThreadSaveCommand.from(threadResults.getFirst());
         gmailNewMessageApplyCommandService.applyNewMessageSync(mailAccount, event, syncCommand);
+
+        if (!isNewMessage) {
+            return Optional.empty();
+        }
+
         NewMessageApplyResult applyResult = gmailNewMessageApplyCommandService.findNewMessageApplyResult(
                 mailAccount.getId(), event.gmailThreadId(), event.gmailMessageId()
         );
 
-        String subject = null;
-        String snippet = null;
         for (InitialMailSyncMessageSaveCommand message : syncCommand.messages()) {
             if (event.gmailMessageId().equals(message.gmailMessageId())) {
-                subject = message.subject();
-                snippet = message.snippet();
-                break;
+                if (message.direction() != Direction.INBOUND) {
+                    return Optional.empty();
+                }
+                return Optional.of(new NewMailPushContext(
+                        mailAccount.getId(),
+                        mailAccount.getAlias(),
+                        message.subject(),
+                        message.snippet(),
+                        applyResult.threadId(),
+                        applyResult.messageId()
+                ));
             }
         }
 
-        return new NewMailPushContext(
-                mailAccount.getId(),
-                mailAccount.getAlias(),
-                subject,
-                snippet,
-                applyResult.threadId(),
-                applyResult.messageId()
-        );
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#9

### 📌 Task
- Closes #47 


## 💡 작업 내용

- applyNewMessageSync() 호출 전에 해당 gmailMessageId가 DB에 이미 존재하는지 확인
- 기존 메시지(update)면 sync는 정상 수행하되 Optional.empty() 반환 → 푸시 스킵
- 신규 메시지(insert)이고 INBOUND일 때만 NewMailPushContext 반환 → 푸시 전송