### PR TITLE
[STORY-401] 라벨 CRUD API 구현 및 라벨 재분류 작업

### DIFF
--- a/.claude/agents/backend-developer.md
+++ b/.claude/agents/backend-developer.md
@@ -3,13 +3,20 @@ name: backend-developer
 description: User Story를 기반으로 서버 비즈니스 로직, 외부 API 연동(메일, LLM), DB 설계를 수행하는 백엔드 개발자 에이전트입니다.
 tools: Read, Write, Edit, Glob, Grep, Bash
 model: inherit
-skills: product-requirements, spring-api-rules
+skills: product-requirements, spring-api-rules, db-conventions, core-conventions, worker-conventions, rabbitmq-queue-registration, new-module-guide
 ---
 
 You are a senior Spring Boot backend developer for the "Mailbox(메일상자)" project.
 
 When invoked:
 1. `product-requirements.md`를 읽어 요청받은 User Story의 목적과 페르소나를 명확히 이해합니다.
-2. `spring-api-rules.md`에 따라 도메인 설계(Controller, Service, Repository, DTO)를 계획합니다.
+2. 아래 라우팅 규칙에 따라 필요한 skills를 선택해 함께 읽습니다.
+   - 공통 규칙: `spring-api-rules.md`
+   - 기획/스토리 기준: `product-requirements.md`
+   - db 모듈, Entity/Repository/Port/Adapter 변경: `db-conventions.md`
+   - core 모듈, Controller/Auth/OAuth/Redis 변경: `core-conventions.md`
+   - worker 모듈, Listener/Handler/Publisher/RabbitMQ 소비 흐름 변경: `worker-conventions.md`
+   - RabbitMQ 신규 큐 추가: `rabbitmq-queue-registration.md`
+   - 신규 Spring 모듈 추가: `new-module-guide.md`
 3. 메일 연동(Gmail API 등)이나 LLM 호출이 필요한 기능인지 파악하고 적절한 외부 통신 인터페이스를 고려합니다.
 4. 구현할 파일 목록과 설계 방향을 먼저 요약하여 출력한 뒤, 동의를 구하고 코드를 작성합니다.

--- a/core/src/main/java/com/mailsangja/core/common/exception/label/LabelErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/label/LabelErrorCode.java
@@ -1,0 +1,27 @@
+package com.mailsangja.core.common.exception.label;
+
+import com.mailsangja.core.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum LabelErrorCode implements ErrorCode {
+
+    LABEL_NOT_FOUND(404, "MS-LABEL-NOT-FOUND", "라벨을 찾을 수 없습니다."),
+    LABEL_ACCESS_DENIED(403, "MS-LABEL-ACCESS-DENIED", "해당 라벨에 접근할 권한이 없습니다."),
+    LABEL_NAME_BLANK(400, "MS-LABEL-NAME-BLANK", "라벨 이름은 비어있을 수 없습니다."),
+    LABEL_COLOR_CODE_BLANK(400, "MS-LABEL-COLOR-CODE-BLANK", "라벨 색상 코드는 비어있을 수 없습니다."),
+    LABEL_NAME_DUPLICATE(409, "MS-LABEL-NAME-DUPLICATE", "동일한 이름의 라벨이 이미 존재합니다."),
+    LABEL_RULE_INVALID_FIELD(400, "MS-LABEL-RULE-INVALID-FIELD", "허용되지 않는 규칙 field 값입니다."),
+    LABEL_RULE_INVALID_OPERATOR(400, "MS-LABEL-RULE-INVALID-OPERATOR", "허용되지 않는 규칙 operator 값입니다."),
+    LABEL_RULE_FIELD_OPERATOR_MISMATCH(400, "MS-LABEL-RULE-FIELD-OPERATOR-MISMATCH", "field와 operator 조합이 올바르지 않습니다."),
+    LABEL_RULE_VALUE_TOO_LONG(400, "MS-LABEL-RULE-VALUE-TOO-LONG", "규칙 value가 허용 길이를 초과했습니다."),
+    LABEL_RULE_VALUE_BLANK(400, "MS-LABEL-RULE-VALUE-BLANK", "규칙 value가 비어있습니다."),
+    LABEL_RULE_INVALID_JSON(400, "MS-LABEL-RULE-INVALID-JSON", "규칙 JSON 형식이 올바르지 않습니다."),
+    LABEL_RULE_INVALID_BOOLEAN_VALUE(400, "MS-LABEL-RULE-INVALID-BOOLEAN-VALUE", "BOOLEAN operator의 value는 'true' 또는 'false'이어야 합니다.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/core/src/main/java/com/mailsangja/core/common/exception/label/LabelException.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/label/LabelException.java
@@ -1,0 +1,10 @@
+package com.mailsangja.core.common.exception.label;
+
+import com.mailsangja.core.common.exception.BaseException;
+
+public class LabelException extends BaseException {
+
+    public LabelException(LabelErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/common/util/LabelRuleValidator.java
+++ b/core/src/main/java/com/mailsangja/core/common/util/LabelRuleValidator.java
@@ -1,0 +1,77 @@
+package com.mailsangja.core.common.util;
+
+import com.mailsangja.core.common.exception.label.LabelErrorCode;
+import com.mailsangja.core.common.exception.label.LabelException;
+import com.mailsangja.db.common.label.LabelRule;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Set;
+
+@Component
+public class LabelRuleValidator {
+
+    private static final int MAX_VALUE_LENGTH = 200;
+
+    private static final Map<LabelRule.Field, Set<LabelRule.Operator>> FIELD_OPERATOR_MAP = Map.of(
+            LabelRule.Field.MAIL_ACCOUNT,   Set.of(LabelRule.Operator.EQUALS),
+            LabelRule.Field.FROM_ADDRESS,   Set.of(LabelRule.Operator.EQUALS, LabelRule.Operator.CONTAINS, LabelRule.Operator.NOT_CONTAINS),
+            LabelRule.Field.FROM_DOMAIN,    Set.of(LabelRule.Operator.EQUALS, LabelRule.Operator.CONTAINS, LabelRule.Operator.NOT_CONTAINS),
+            LabelRule.Field.TO_ADDRESS,     Set.of(LabelRule.Operator.EQUALS, LabelRule.Operator.CONTAINS, LabelRule.Operator.NOT_CONTAINS),
+            LabelRule.Field.CC_ADDRESS,     Set.of(LabelRule.Operator.EQUALS, LabelRule.Operator.CONTAINS, LabelRule.Operator.NOT_CONTAINS),
+            LabelRule.Field.SUBJECT,        Set.of(LabelRule.Operator.CONTAINS, LabelRule.Operator.NOT_CONTAINS),
+            LabelRule.Field.BODY_TEXT,      Set.of(LabelRule.Operator.CONTAINS, LabelRule.Operator.NOT_CONTAINS),
+            LabelRule.Field.HAS_ATTACHMENT, Set.of(LabelRule.Operator.BOOLEAN)
+    );
+
+    public void validate(LabelRule rule) {
+        if (rule == null) {
+            return;
+        }
+
+        if (rule.groups() == null) {
+            return;
+        }
+
+        for (LabelRule.Group group : rule.groups()) {
+            if (group == null || group.conditions() == null) {
+                continue;
+            }
+            for (LabelRule.Condition condition : group.conditions()) {
+                validateCondition(condition);
+            }
+        }
+    }
+
+    private void validateCondition(LabelRule.Condition condition) {
+        LabelRule.Field field = condition.field();
+        LabelRule.Operator operator = condition.operator();
+        String value = condition.value();
+
+        if (field == null) {
+            throw new LabelException(LabelErrorCode.LABEL_RULE_INVALID_FIELD);
+        }
+
+        if (operator == null) {
+            throw new LabelException(LabelErrorCode.LABEL_RULE_INVALID_OPERATOR);
+        }
+
+        Set<LabelRule.Operator> allowedOperators = FIELD_OPERATOR_MAP.get(field);
+        if (allowedOperators == null || !allowedOperators.contains(operator)) {
+            throw new LabelException(LabelErrorCode.LABEL_RULE_FIELD_OPERATOR_MISMATCH);
+        }
+
+        if (operator == LabelRule.Operator.BOOLEAN) {
+            if (!"true".equalsIgnoreCase(value) && !"false".equalsIgnoreCase(value)) {
+                throw new LabelException(LabelErrorCode.LABEL_RULE_INVALID_BOOLEAN_VALUE);
+            }
+        } else {
+            if (value == null || value.isBlank()) {
+                throw new LabelException(LabelErrorCode.LABEL_RULE_VALUE_BLANK);
+            }
+            if (value.length() > MAX_VALUE_LENGTH) {
+                throw new LabelException(LabelErrorCode.LABEL_RULE_VALUE_TOO_LONG);
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/common/util/LabelRuleValidator.java
+++ b/core/src/main/java/com/mailsangja/core/common/util/LabelRuleValidator.java
@@ -44,6 +44,9 @@ public class LabelRuleValidator {
     }
 
     private void validateCondition(LabelRule.Condition condition) {
+        if (condition == null) {
+            throw new LabelException(LabelErrorCode.LABEL_RULE_INVALID_FIELD);
+        }
         LabelRule.Field field = condition.field();
         LabelRule.Operator operator = condition.operator();
         String value = condition.value();

--- a/core/src/main/java/com/mailsangja/core/config/properties/LabelReclassifyRabbitProperties.java
+++ b/core/src/main/java/com/mailsangja/core/config/properties/LabelReclassifyRabbitProperties.java
@@ -1,0 +1,35 @@
+package com.mailsangja.core.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "mailsangja.rabbitmq.label-reclassify")
+public class LabelReclassifyRabbitProperties {
+
+    private String taskName;
+
+    public String getTaskName() {
+        return taskName;
+    }
+
+    public String getQueueName() {
+        return "mailsangja." + taskName;
+    }
+
+    public String getRoutingKey() {
+        return "mail." + taskName;
+    }
+
+    public String getDeadLetterQueueName() {
+        return getQueueName() + ".dlq";
+    }
+
+    public String getDeadLetterRoutingKey() {
+        return getRoutingKey() + ".dlq";
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/config/properties/LabelReclassifyRabbitProperties.java
+++ b/core/src/main/java/com/mailsangja/core/config/properties/LabelReclassifyRabbitProperties.java
@@ -1,28 +1,22 @@
 package com.mailsangja.core.config.properties;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-@Getter
-@Setter
 @Component
-@ConfigurationProperties(prefix = "mailsangja.rabbitmq.label-reclassify")
 public class LabelReclassifyRabbitProperties {
 
-    private String taskName;
+    private static final String TASK_NAME = "label.reclassify";
 
     public String getTaskName() {
-        return taskName;
+        return TASK_NAME;
     }
 
     public String getQueueName() {
-        return "mailsangja." + taskName;
+        return "mailsangja." + TASK_NAME;
     }
 
     public String getRoutingKey() {
-        return "mail." + taskName;
+        return "mail." + TASK_NAME;
     }
 
     public String getDeadLetterQueueName() {

--- a/core/src/main/java/com/mailsangja/core/controller/LabelController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/LabelController.java
@@ -1,0 +1,84 @@
+package com.mailsangja.core.controller;
+
+import com.mailsangja.core.common.auth.AuthUser;
+import com.mailsangja.core.controller.docs.LabelControllerDocs;
+import com.mailsangja.core.dto.label.LabelCreateRequest;
+import com.mailsangja.core.dto.label.LabelDetailResponse;
+import com.mailsangja.core.dto.label.LabelListResponse;
+import com.mailsangja.core.dto.label.LabelRuleUpdateRequest;
+import com.mailsangja.core.dto.label.LabelUpdateRequest;
+import com.mailsangja.core.facade.LabelFacade;
+import com.mailsangja.db.entity.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+public class LabelController implements LabelControllerDocs {
+
+    private final LabelFacade labelFacade;
+
+    @Override
+    @GetMapping("/api/v1/labels")
+    public ResponseEntity<List<LabelListResponse>> getLabels(@AuthUser User user) {
+        return ResponseEntity.ok(labelFacade.getLabels(user));
+    }
+
+    @Override
+    @GetMapping("/api/v1/labels/{labelId}")
+    public ResponseEntity<LabelDetailResponse> getLabelDetail(
+            @AuthUser User user,
+            @PathVariable UUID labelId
+    ) {
+        return ResponseEntity.ok(labelFacade.getLabelDetail(user, labelId));
+    }
+
+    @Override
+    @PostMapping("/api/v1/labels")
+    public ResponseEntity<LabelDetailResponse> createLabel(
+            @AuthUser User user,
+            @RequestBody LabelCreateRequest request
+    ) {
+        return ResponseEntity.ok(labelFacade.createLabel(user, request));
+    }
+
+    @Override
+    @PatchMapping("/api/v1/labels/{labelId}")
+    public ResponseEntity<LabelDetailResponse> updateLabel(
+            @AuthUser User user,
+            @PathVariable UUID labelId,
+            @RequestBody LabelUpdateRequest request
+    ) {
+        return ResponseEntity.ok(labelFacade.updateLabel(user, labelId, request));
+    }
+
+    @Override
+    @PatchMapping("/api/v1/labels/{labelId}/rule")
+    public ResponseEntity<LabelDetailResponse> updateLabelRule(
+            @AuthUser User user,
+            @PathVariable UUID labelId,
+            @RequestBody LabelRuleUpdateRequest request
+    ) {
+        return ResponseEntity.ok(labelFacade.updateLabelRule(user, labelId, request));
+    }
+
+    @Override
+    @DeleteMapping("/api/v1/labels/{labelId}")
+    public ResponseEntity<Void> deleteLabel(
+            @AuthUser User user,
+            @PathVariable UUID labelId
+    ) {
+        labelFacade.deleteLabel(user, labelId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/controller/docs/LabelControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/LabelControllerDocs.java
@@ -1,0 +1,136 @@
+package com.mailsangja.core.controller.docs;
+
+import com.mailsangja.core.common.auth.AuthUser;
+import com.mailsangja.core.dto.label.LabelCreateRequest;
+import com.mailsangja.core.dto.label.LabelDetailResponse;
+import com.mailsangja.core.dto.label.LabelListResponse;
+import com.mailsangja.core.dto.label.LabelRuleUpdateRequest;
+import com.mailsangja.core.dto.label.LabelUpdateRequest;
+import com.mailsangja.db.entity.user.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag(name = "Label", description = "라벨 CRUD API")
+public interface LabelControllerDocs {
+
+    @Operation(
+            summary = "라벨 목록 조회",
+            description = "로그인한 사용자의 활성 라벨 목록을 displayOrder ASC 정렬로 반환합니다. 라벨별 읽지 않은 스레드 수를 포함합니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "라벨 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<List<LabelListResponse>> getLabels(
+            @Parameter(hidden = true) @AuthUser User user
+    );
+
+    @Operation(
+            summary = "라벨 상세 조회",
+            description = "특정 라벨의 메타 정보와 타입이 고정된 rule 객체를 반환합니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "라벨 상세 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "라벨을 찾을 수 없음",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<LabelDetailResponse> getLabelDetail(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "라벨 ID", required = true) @PathVariable UUID labelId
+    );
+
+    @Operation(
+            summary = "라벨 생성",
+            description = "새 라벨을 생성합니다. rule이 존재하면 과거 메일 재분류 작업이 비동기로 발행됩니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "라벨 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 요청",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "409", description = "동일한 이름의 라벨이 이미 존재함",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<LabelDetailResponse> createLabel(
+            @Parameter(hidden = true) @AuthUser User user,
+            @RequestBody LabelCreateRequest request
+    );
+
+    @Operation(
+            summary = "라벨 수정",
+            description = "라벨의 이름, 색상, 알림 설정, 순서를 수정합니다. null 필드는 변경하지 않습니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "라벨 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 요청",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "라벨을 찾을 수 없음",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "409", description = "동일한 이름의 라벨이 이미 존재함",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<LabelDetailResponse> updateLabel(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "라벨 ID", required = true) @PathVariable UUID labelId,
+            @RequestBody LabelUpdateRequest request
+    );
+
+    @Operation(
+            summary = "라벨 규칙 수정",
+            description = "라벨의 자동 분류 규칙(rule JSON)을 수정합니다. 수정 후 과거 메일 재분류 작업이 비동기로 발행됩니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "라벨 규칙 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 규칙 JSON",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "라벨을 찾을 수 없음",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<LabelDetailResponse> updateLabelRule(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "라벨 ID", required = true) @PathVariable UUID labelId,
+            @RequestBody LabelRuleUpdateRequest request
+    );
+
+    @Operation(
+            summary = "라벨 삭제",
+            description = "라벨을 soft delete 처리합니다. 삭제 시 해당 라벨의 Message/Thread 라벨 매핑을 즉시 제거합니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "라벨 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "라벨을 찾을 수 없음",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<Void> deleteLabel(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "라벨 ID", required = true) @PathVariable UUID labelId
+    );
+}

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadListResult.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadListResult.java
@@ -2,6 +2,7 @@ package com.mailsangja.core.dto.inbox;
 
 import com.mailsangja.db.entity.mail.Attachment;
 import com.mailsangja.db.entity.mail.Thread;
+import com.mailsangja.db.port.ThreadLabelView;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
@@ -11,5 +12,6 @@ import java.util.UUID;
 public record ThreadListResult(
         Slice<Thread> threads,
         Map<UUID, List<Attachment>> attachmentsByThreadId,
-        Map<String, String> contactNameByEmail
+        Map<String, String> contactNameByEmail,
+        Map<UUID, List<ThreadLabelView>> labelsByThreadId
 ) {}

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponse.java
@@ -2,6 +2,7 @@ package com.mailsangja.core.dto.inbox;
 
 import com.mailsangja.db.entity.mail.Attachment;
 import com.mailsangja.db.entity.mail.Thread;
+import com.mailsangja.db.port.ThreadLabelView;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -30,13 +31,22 @@ public record ThreadSummaryResponse(
         @Schema(description = "스레드 내 첨부파일 목록")
         List<AttachmentResponse> attachments,
         @Schema(description = "스레드 내 메시지 수", example = "3")
-        int messageCount
+        int messageCount,
+        @Schema(description = "스레드에 적용된 라벨 목록")
+        List<LabelSummary> labels
 ) {
-    public static ThreadSummaryResponse from(Thread thread, List<Attachment> attachments, Map<String, String> contactNameByEmail) {
-        List<AttachmentResponse> attachmentResponses = attachments.stream()
-                .map(AttachmentResponse::from)
-                .toList();
+    public record LabelSummary(
+            @Schema(description = "라벨 ID") UUID labelId,
+            @Schema(description = "라벨 이름") String name,
+            @Schema(description = "라벨 색상 코드", example = "#FF5733") String colorCode
+    ) {}
 
+    public static ThreadSummaryResponse from(
+            Thread thread,
+            List<Attachment> attachments,
+            Map<String, String> contactNameByEmail,
+            List<ThreadLabelView> labelViews
+    ) {
         return new ThreadSummaryResponse(
                 thread.getId(),
                 thread.getGmailThreadId(),
@@ -46,8 +56,11 @@ public record ThreadSummaryResponse(
                 thread.getLatestSnippet(),
                 thread.isRead(),
                 thread.getLastMessageAt(),
-                attachmentResponses,
-                thread.getMessageCount()
+                attachments.stream().map(AttachmentResponse::from).toList(),
+                thread.getMessageCount(),
+                labelViews.stream()
+                        .map(v -> new LabelSummary(v.labelId(), v.labelName(), v.colorCode()))
+                        .toList()
         );
     }
 }

--- a/core/src/main/java/com/mailsangja/core/dto/label/LabelCreateRequest.java
+++ b/core/src/main/java/com/mailsangja/core/dto/label/LabelCreateRequest.java
@@ -1,0 +1,24 @@
+package com.mailsangja.core.dto.label;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mailsangja.db.common.label.LabelRule;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "라벨 생성 요청")
+public record LabelCreateRequest(
+        @Schema(description = "라벨 이름", example = "업무")
+        String name,
+
+        @Schema(description = "HEX 색상 코드", example = "#3366FF")
+        String colorCode,
+
+        @Schema(description = "알림 활성화 여부", example = "true")
+        @JsonProperty("notificationEnabled") boolean notificationEnabled,
+
+        @Schema(description = "표시 순서", example = "0")
+        int order,
+
+        @Schema(description = "라벨 자동 분류 규칙")
+        LabelRule rule
+) {
+}

--- a/core/src/main/java/com/mailsangja/core/dto/label/LabelDetailResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/label/LabelDetailResponse.java
@@ -1,0 +1,40 @@
+package com.mailsangja.core.dto.label;
+
+import com.mailsangja.db.common.label.LabelRule;
+import com.mailsangja.db.entity.label.Label;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "라벨 상세 응답")
+public record LabelDetailResponse(
+        @Schema(description = "라벨 ID", format = "uuid", example = "2fd8a795-5ca5-47ad-b6a4-63c45f6f1c9b")
+        UUID id,
+
+        @Schema(description = "라벨 이름", example = "업무")
+        String name,
+
+        @Schema(description = "HEX 색상 코드", example = "#3366FF")
+        String colorCode,
+
+        @Schema(description = "표시 순서", example = "0")
+        int order,
+
+        @Schema(description = "알림 활성화 여부", example = "true")
+        boolean notificationEnabled,
+
+        @Schema(description = "라벨 자동 분류 규칙")
+        LabelRule rule
+) {
+
+    public static LabelDetailResponse of(Label label, LabelRule rule) {
+        return new LabelDetailResponse(
+                label.getId(),
+                label.getName(),
+                label.getColorCode(),
+                label.getDisplayOrder(),
+                label.isNotificationEnabled(),
+                rule
+        );
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/label/LabelListResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/label/LabelListResponse.java
@@ -1,0 +1,35 @@
+package com.mailsangja.core.dto.label;
+
+import com.mailsangja.db.entity.label.Label;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "라벨 목록 응답")
+public record LabelListResponse(
+        @Schema(description = "라벨 ID", format = "uuid", example = "2fd8a795-5ca5-47ad-b6a4-63c45f6f1c9b")
+        UUID id,
+
+        @Schema(description = "라벨 이름", example = "업무")
+        String name,
+
+        @Schema(description = "HEX 색상 코드", example = "#3366FF")
+        String colorCode,
+
+        @Schema(description = "표시 순서", example = "0")
+        int order,
+
+        @Schema(description = "읽지 않은 스레드 수", example = "12")
+        long unreadThreadCount
+) {
+
+    public static LabelListResponse of(Label label, long unreadThreadCount) {
+        return new LabelListResponse(
+                label.getId(),
+                label.getName(),
+                label.getColorCode(),
+                label.getDisplayOrder(),
+                unreadThreadCount
+        );
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/label/LabelReclassifyMessage.java
+++ b/core/src/main/java/com/mailsangja/core/dto/label/LabelReclassifyMessage.java
@@ -1,0 +1,23 @@
+package com.mailsangja.core.dto.label;
+
+import java.util.Set;
+import java.util.UUID;
+
+public record LabelReclassifyMessage(
+        UUID userId,
+        Set<UUID> labelIds
+) {
+
+    public LabelReclassifyMessage {
+        if (userId == null) {
+            throw new IllegalArgumentException("userId must not be null");
+        }
+        if (labelIds == null || labelIds.isEmpty()) {
+            throw new IllegalArgumentException("labelIds must not be null or empty");
+        }
+        if (labelIds.stream().anyMatch(id -> id == null)) {
+            throw new IllegalArgumentException("labelIds must not contain null");
+        }
+        labelIds = Set.copyOf(labelIds);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/label/LabelRuleUpdateRequest.java
+++ b/core/src/main/java/com/mailsangja/core/dto/label/LabelRuleUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.mailsangja.core.dto.label;
+
+import com.mailsangja.db.common.label.LabelRule;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "라벨 규칙 수정 요청")
+public record LabelRuleUpdateRequest(
+        @Schema(description = "라벨 자동 분류 규칙")
+        LabelRule rule
+) {
+}

--- a/core/src/main/java/com/mailsangja/core/dto/label/LabelUpdateRequest.java
+++ b/core/src/main/java/com/mailsangja/core/dto/label/LabelUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.mailsangja.core.dto.label;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "라벨 수정 요청 (null 필드는 변경하지 않음)")
+public record LabelUpdateRequest(
+        @Schema(description = "라벨 이름", example = "업무")
+        String name,
+
+        @Schema(description = "HEX 색상 코드", example = "#3366FF")
+        String colorCode,
+
+        @Schema(description = "알림 활성화 여부", example = "false")
+        @JsonProperty("notificationEnabled") Boolean notificationEnabled,
+
+        @Schema(description = "표시 순서", example = "1")
+        Integer order
+) {
+}

--- a/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/InboxFacade.java
@@ -110,7 +110,8 @@ public class InboxFacade {
                 .map(thread -> ThreadSummaryResponse.from(
                         thread,
                         result.attachmentsByThreadId().getOrDefault(thread.getId(), List.of()),
-                        result.contactNameByEmail()))
+                        result.contactNameByEmail(),
+                        result.labelsByThreadId().getOrDefault(thread.getId(), List.of())))
                 .toList();
         UUID nextMarker = result.threads().hasNext() ? result.threads().getContent().getLast().getId() : null;
         return MarkerSliceResponse.of(content, nextMarker, result.threads().hasNext());

--- a/core/src/main/java/com/mailsangja/core/facade/LabelFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/LabelFacade.java
@@ -15,6 +15,7 @@ import com.mailsangja.core.service.label.LabelReclassifyPublisher;
 import com.mailsangja.db.entity.label.Label;
 import com.mailsangja.db.entity.user.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -46,7 +47,12 @@ public class LabelFacade {
 
     public LabelDetailResponse createLabel(User user, LabelCreateRequest request) {
         validateCreateRequest(user, request);
-        Label label = labelCommandService.create(user, request);
+        Label label;
+        try {
+            label = labelCommandService.create(user, request);
+        } catch (DataIntegrityViolationException e) {
+            throw new LabelException(LabelErrorCode.LABEL_NAME_DUPLICATE);
+        }
         if (request.rule() != null) {
             labelReclassifyPublisher.publish(new LabelReclassifyMessage(user.getId(), Set.of(label.getId())));
         }
@@ -56,7 +62,12 @@ public class LabelFacade {
     public LabelDetailResponse updateLabel(User user, UUID labelId, LabelUpdateRequest request) {
         Label label = labelQueryService.findActiveByIdAndUserId(labelId, user.getId());
         validateUpdateRequest(user, label, request);
-        Label updated = labelCommandService.update(label, request);
+        Label updated;
+        try {
+            updated = labelCommandService.update(label, request);
+        } catch (DataIntegrityViolationException e) {
+            throw new LabelException(LabelErrorCode.LABEL_NAME_DUPLICATE);
+        }
         return toDetailResponse(updated);
     }
 

--- a/core/src/main/java/com/mailsangja/core/facade/LabelFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/LabelFacade.java
@@ -1,0 +1,116 @@
+package com.mailsangja.core.facade;
+
+import com.mailsangja.core.common.exception.label.LabelErrorCode;
+import com.mailsangja.core.common.exception.label.LabelException;
+import com.mailsangja.core.common.util.LabelRuleValidator;
+import com.mailsangja.core.dto.label.LabelCreateRequest;
+import com.mailsangja.core.dto.label.LabelDetailResponse;
+import com.mailsangja.core.dto.label.LabelListResponse;
+import com.mailsangja.core.dto.label.LabelReclassifyMessage;
+import com.mailsangja.core.dto.label.LabelRuleUpdateRequest;
+import com.mailsangja.core.dto.label.LabelUpdateRequest;
+import com.mailsangja.core.service.label.LabelCommandService;
+import com.mailsangja.core.service.label.LabelQueryService;
+import com.mailsangja.core.service.label.LabelReclassifyPublisher;
+import com.mailsangja.db.entity.label.Label;
+import com.mailsangja.db.entity.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class LabelFacade {
+
+    private final LabelQueryService labelQueryService;
+    private final LabelCommandService labelCommandService;
+    private final LabelReclassifyPublisher labelReclassifyPublisher;
+    private final LabelRuleValidator labelRuleValidator;
+
+    public List<LabelListResponse> getLabels(User user) {
+        List<Label> labels = labelQueryService.findAllActiveByUserId(user.getId());
+        Map<UUID, Long> unreadCounts = labelQueryService.findUnreadThreadCountsByUserId(user.getId());
+        return labels.stream()
+                .map(label -> LabelListResponse.of(label, unreadCounts.getOrDefault(label.getId(), 0L)))
+                .toList();
+    }
+
+    public LabelDetailResponse getLabelDetail(User user, UUID labelId) {
+        Label label = labelQueryService.findActiveByIdAndUserId(labelId, user.getId());
+        return toDetailResponse(label);
+    }
+
+    public LabelDetailResponse createLabel(User user, LabelCreateRequest request) {
+        validateCreateRequest(user, request);
+        Label label = labelCommandService.create(user, request);
+        if (request.rule() != null) {
+            labelReclassifyPublisher.publish(new LabelReclassifyMessage(user.getId(), Set.of(label.getId())));
+        }
+        return toDetailResponse(label);
+    }
+
+    public LabelDetailResponse updateLabel(User user, UUID labelId, LabelUpdateRequest request) {
+        Label label = labelQueryService.findActiveByIdAndUserId(labelId, user.getId());
+        validateUpdateRequest(user, label, request);
+        Label updated = labelCommandService.update(label, request);
+        return toDetailResponse(updated);
+    }
+
+    public LabelDetailResponse updateLabelRule(User user, UUID labelId, LabelRuleUpdateRequest request) {
+        validateRuleRequest(request);
+        Label label = labelQueryService.findActiveByIdAndUserId(labelId, user.getId());
+        Label updated = labelCommandService.updateRule(label, request.rule());
+        labelReclassifyPublisher.publish(new LabelReclassifyMessage(user.getId(), Set.of(updated.getId())));
+        return toDetailResponse(updated);
+    }
+
+    public void deleteLabel(User user, UUID labelId) {
+        Label label = labelQueryService.findActiveByIdAndUserId(labelId, user.getId());
+        labelCommandService.delete(label);
+    }
+
+    private void validateCreateRequest(User user, LabelCreateRequest request) {
+        validateNameNotBlank(request.name());
+        validateColorCode(request.colorCode());
+        if (labelQueryService.existsByUserIdAndName(user.getId(), request.name().trim())) {
+            throw new LabelException(LabelErrorCode.LABEL_NAME_DUPLICATE);
+        }
+        labelRuleValidator.validate(request.rule());
+    }
+
+    private void validateUpdateRequest(User user, Label label, LabelUpdateRequest request) {
+        if (request.name() != null) {
+            validateNameNotBlank(request.name());
+            if (labelQueryService.existsByUserIdAndNameExcludingId(user.getId(), request.name().trim(), label.getId())) {
+                throw new LabelException(LabelErrorCode.LABEL_NAME_DUPLICATE);
+            }
+        }
+        if (request.colorCode() != null) {
+            validateColorCode(request.colorCode());
+        }
+    }
+
+    private void validateRuleRequest(LabelRuleUpdateRequest request) {
+        labelRuleValidator.validate(request.rule());
+    }
+
+    private void validateNameNotBlank(String name) {
+        if (name == null || name.isBlank()) {
+            throw new LabelException(LabelErrorCode.LABEL_NAME_BLANK);
+        }
+    }
+
+    private void validateColorCode(String colorCode) {
+        if (colorCode == null || colorCode.isBlank()) {
+            throw new LabelException(LabelErrorCode.LABEL_COLOR_CODE_BLANK);
+        }
+    }
+
+    private LabelDetailResponse toDetailResponse(Label label) {
+        return LabelDetailResponse.of(label, label.getRule());
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
@@ -10,6 +10,7 @@ import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.Thread;
 import com.mailsangja.db.port.ContactRepositoryPort;
 import com.mailsangja.db.port.MessageRepositoryPort;
+import com.mailsangja.db.port.ThreadLabelView;
 import com.mailsangja.db.port.ThreadRepositoryPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -69,6 +70,7 @@ public class InboxQueryService {
     private ThreadListResult buildThreadListResult(Slice<Thread> threads) {
         List<UUID> threadIds = threads.getContent().stream().map(Thread::getId).toList();
         Map<UUID, List<Attachment>> attachmentsByThreadId = findAttachmentsByThreadIds(threadIds);
+        Map<UUID, List<ThreadLabelView>> labelsByThreadId = findLabelsByThreadIds(threadIds);
 
         List<String> participantEmails = threads.getContent().stream()
                 .map(Thread::getLatestParticipantAddress)
@@ -77,7 +79,16 @@ public class InboxQueryService {
                 .toList();
         Map<String, String> contactNameByEmail = findContactNamesByEmails(participantEmails);
 
-        return new ThreadListResult(threads, attachmentsByThreadId, contactNameByEmail);
+        return new ThreadListResult(threads, attachmentsByThreadId, contactNameByEmail, labelsByThreadId);
+    }
+
+    private Map<UUID, List<ThreadLabelView>> findLabelsByThreadIds(List<UUID> threadIds) {
+        if (threadIds.isEmpty()) {
+            return Map.of();
+        }
+        return messageRepositoryPort.findLabelsByThreadIdIn(threadIds)
+                .stream()
+                .collect(Collectors.groupingBy(ThreadLabelView::threadId));
     }
 
     private Map<UUID, List<Attachment>> findAttachmentsByThreadIds(List<UUID> threadIds) {

--- a/core/src/main/java/com/mailsangja/core/service/label/LabelCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/label/LabelCommandService.java
@@ -1,0 +1,67 @@
+package com.mailsangja.core.service.label;
+
+import com.mailsangja.core.dto.label.LabelCreateRequest;
+import com.mailsangja.core.dto.label.LabelUpdateRequest;
+import com.mailsangja.db.common.label.LabelRule;
+import com.mailsangja.db.entity.label.Label;
+import com.mailsangja.db.entity.user.User;
+import com.mailsangja.db.port.LabelRepositoryPort;
+import com.mailsangja.db.port.MessageRepositoryPort;
+import com.mailsangja.db.port.ThreadRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LabelCommandService {
+
+    private final LabelRepositoryPort labelRepositoryPort;
+    // ⚠️ 라벨 삭제 유스케이스에서 message/thread 라벨 매핑 삭제가 필요해 cross-domain Repository를 함께 참조한다.
+    private final MessageRepositoryPort messageRepositoryPort;
+    private final ThreadRepositoryPort threadRepositoryPort;
+
+    @Transactional
+    public Label create(User user, LabelCreateRequest request) {
+        Label label = Label.builder()
+                .user(user)
+                .name(request.name().trim())
+                .colorCode(request.colorCode())
+                .notificationEnabled(request.notificationEnabled())
+                .displayOrder(request.order())
+                .rule(request.rule())
+                .build();
+        return labelRepositoryPort.save(label);
+    }
+
+    @Transactional
+    public Label update(Label label, LabelUpdateRequest request) {
+        if (request.name() != null) {
+            label.updateName(request.name().trim());
+        }
+        if (request.colorCode() != null) {
+            label.updateColorCode(request.colorCode());
+        }
+        if (request.notificationEnabled() != null) {
+            label.updateNotificationEnabled(request.notificationEnabled());
+        }
+        if (request.order() != null) {
+            label.updateDisplayOrder(request.order());
+        }
+        return labelRepositoryPort.save(label);
+    }
+
+    @Transactional
+    public Label updateRule(Label label, LabelRule rule) {
+        label.updateRule(rule);
+        return labelRepositoryPort.save(label);
+    }
+
+    @Transactional
+    public void delete(Label label) {
+        messageRepositoryPort.deleteMessageLabelsByLabelId(label.getId());
+        threadRepositoryPort.deleteThreadLabelsByLabelId(label.getId());
+        label.delete();
+        labelRepositoryPort.save(label);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/service/label/LabelQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/label/LabelQueryService.java
@@ -1,0 +1,40 @@
+package com.mailsangja.core.service.label;
+
+import com.mailsangja.core.common.exception.label.LabelErrorCode;
+import com.mailsangja.core.common.exception.label.LabelException;
+import com.mailsangja.db.entity.label.Label;
+import com.mailsangja.db.port.LabelRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class LabelQueryService {
+
+    private final LabelRepositoryPort labelRepositoryPort;
+
+    public List<Label> findAllActiveByUserId(UUID userId) {
+        return labelRepositoryPort.findAllByUserIdAndDeletedAtIsNullOrderByDisplayOrder(userId);
+    }
+
+    public Label findActiveByIdAndUserId(UUID labelId, UUID userId) {
+        return labelRepositoryPort.findByIdAndUserIdAndDeletedAtIsNull(labelId, userId)
+                .orElseThrow(() -> new LabelException(LabelErrorCode.LABEL_NOT_FOUND));
+    }
+
+    public Map<UUID, Long> findUnreadThreadCountsByUserId(UUID userId) {
+        return labelRepositoryPort.findUnreadThreadCountsByUserId(userId);
+    }
+
+    public boolean existsByUserIdAndName(UUID userId, String name) {
+        return labelRepositoryPort.existsByUserIdAndNameIgnoreCaseAndDeletedAtIsNull(userId, name);
+    }
+
+    public boolean existsByUserIdAndNameExcludingId(UUID userId, String name, UUID excludeId) {
+        return labelRepositoryPort.existsByUserIdAndNameIgnoreCaseAndIdNotAndDeletedAtIsNull(userId, name, excludeId);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/service/label/LabelReclassifyPublisher.java
+++ b/core/src/main/java/com/mailsangja/core/service/label/LabelReclassifyPublisher.java
@@ -1,0 +1,45 @@
+package com.mailsangja.core.service.label;
+
+import com.mailsangja.core.config.properties.LabelReclassifyRabbitProperties;
+import com.mailsangja.core.config.properties.MailTaskRabbitProperties;
+import com.mailsangja.core.dto.label.LabelReclassifyMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LabelReclassifyPublisher {
+
+    private final RabbitTemplate rabbitTemplate;
+    private final MailTaskRabbitProperties mailTaskRabbitProperties;
+    private final LabelReclassifyRabbitProperties labelReclassifyRabbitProperties;
+
+    public void publish(LabelReclassifyMessage message) {
+        try {
+            rabbitTemplate.convertAndSend(
+                    mailTaskRabbitProperties.getExchange(),
+                    labelReclassifyRabbitProperties.getRoutingKey(),
+                    message,
+                    new CorrelationData(message.userId() + ":" + message.labelIds().size())
+            );
+            log.info(
+                    "Published label reclassify request for userId={} labelCount={}",
+                    message.userId(),
+                    message.labelIds().size()
+            );
+        } catch (AmqpException e) {
+            log.warn(
+                    "Failed to publish label reclassify request for userId={} labelCount={}",
+                    message.userId(),
+                    message.labelIds().size(),
+                    e
+            );
+            throw e;
+        }
+    }
+}

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -59,6 +59,8 @@ mailsangja:
       retry-max-attempts: ${MAIL_TASK_RETRY_MAX_ATTEMPTS:3}
       concurrency: ${MAIL_TASK_CONCURRENCY:1}
       publisher-mandatory: ${MAIL_TASK_PUBLISHER_MANDATORY:true}
+    label-reclassify:
+      task-name: ${LABEL_RECLASSIFY_TASK_NAME:label.reclassify}
     initial-mail-sync:
       task-name: ${MAIL_SYNC_TASK_NAME:sync.gmail.initial}
   inbox:

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -59,8 +59,6 @@ mailsangja:
       retry-max-attempts: ${MAIL_TASK_RETRY_MAX_ATTEMPTS:3}
       concurrency: ${MAIL_TASK_CONCURRENCY:1}
       publisher-mandatory: ${MAIL_TASK_PUBLISHER_MANDATORY:true}
-    label-reclassify:
-      task-name: ${LABEL_RECLASSIFY_TASK_NAME:label.reclassify}
     initial-mail-sync:
       task-name: ${MAIL_SYNC_TASK_NAME:sync.gmail.initial}
   inbox:

--- a/db/src/main/java/com/mailsangja/db/adapter/label/LabelRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/label/LabelRepositoryAdapter.java
@@ -7,8 +7,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -27,6 +29,11 @@ public class LabelRepositoryAdapter implements LabelRepositoryPort {
     }
 
     @Override
+    public List<Label> findAllByUserIdAndDeletedAtIsNullOrderByDisplayOrder(UUID userId) {
+        return labelJpaRepositoryModule.findAllByUserIdAndDeletedAtIsNullOrderByDisplayOrder(userId);
+    }
+
+    @Override
     public Optional<Label> findByIdAndDeletedAtIsNull(UUID id) {
         return labelJpaRepositoryModule.findByIdAndDeletedAtIsNull(id);
     }
@@ -34,5 +41,25 @@ public class LabelRepositoryAdapter implements LabelRepositoryPort {
     @Override
     public Optional<Label> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId) {
         return labelJpaRepositoryModule.findByIdAndUserIdAndDeletedAtIsNull(id, userId);
+    }
+
+    @Override
+    public boolean existsByUserIdAndNameIgnoreCaseAndDeletedAtIsNull(UUID userId, String name) {
+        return labelJpaRepositoryModule.existsByUserIdAndNameIgnoreCaseAndDeletedAtIsNull(userId, name);
+    }
+
+    @Override
+    public boolean existsByUserIdAndNameIgnoreCaseAndIdNotAndDeletedAtIsNull(UUID userId, String name, UUID excludeId) {
+        return labelJpaRepositoryModule.existsByUserIdAndNameIgnoreCaseAndIdNotAndDeletedAtIsNull(userId, name, excludeId);
+    }
+
+    @Override
+    public Map<UUID, Long> findUnreadThreadCountsByUserId(UUID userId) {
+        return labelJpaRepositoryModule.findUnreadThreadCountsByUserId(userId)
+                .stream()
+                .collect(Collectors.toMap(
+                        p -> p.getLabelId(),
+                        p -> p.getUnreadCount()
+                ));
     }
 }

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
@@ -3,6 +3,7 @@ package com.mailsangja.db.adapter.mail;
 import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.module.mail.MessageJpaRepositoryModule;
 import com.mailsangja.db.port.MessageRepositoryPort;
+import com.mailsangja.db.port.ThreadLabelView;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -131,5 +132,36 @@ public class MessageRepositoryAdapter implements MessageRepositoryPort {
     @Override
     public boolean existsByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId) {
         return messageJpaRepositoryModule.existsByMailAccountIdAndGmailThreadId(mailAccountId, gmailThreadId);
+    }
+
+    @Override
+    public List<Message> findAllByUserIdAndDeletedAtIsNullWithLabels(UUID userId) {
+        return messageJpaRepositoryModule.findAllByUserIdAndDeletedAtIsNullWithLabels(userId);
+    }
+
+    @Override
+    public List<Message> findAllByUserIdAndDeletedAtIsNullWithAttachments(UUID userId) {
+        return messageJpaRepositoryModule.findAllByUserIdAndDeletedAtIsNullWithAttachments(userId);
+    }
+
+    @Override
+    public List<Message> saveAll(List<Message> messages) {
+        return messageJpaRepositoryModule.saveAll(messages);
+    }
+
+    @Override
+    public List<ThreadLabelView> findLabelsByThreadIdIn(List<UUID> threadIds) {
+        if (threadIds.isEmpty()) {
+            return List.of();
+        }
+        return messageJpaRepositoryModule.findLabelsByThreadIdIn(threadIds)
+                .stream()
+                .map(p -> new ThreadLabelView(p.getThreadId(), p.getLabelId(), p.getLabelName(), p.getLabelColorCode()))
+                .toList();
+    }
+
+    @Override
+    public int deleteMessageLabelsByLabelId(UUID labelId) {
+        return messageJpaRepositoryModule.deleteMessageLabelsByLabelId(labelId);
     }
 }

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/ThreadRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/ThreadRepositoryAdapter.java
@@ -94,4 +94,17 @@ public class ThreadRepositoryAdapter implements ThreadRepositoryPort {
         List<Thread> threads = threadJpaRepositoryModule.findAllByMailAccountIdAndGmailThreadId(mailAccountId, gmailThreadId);
         threadJpaRepositoryModule.deleteAll(threads);
     }
+
+    @Override
+    public Slice<Thread> findInboxByUserIdAndLabelIdsAndDeletedAtIsNull(UUID userId, List<UUID> labelIds, UUID markerId, Pageable pageable) {
+        if (labelIds == null || labelIds.isEmpty()) {
+            return threadJpaRepositoryModule.findInboxByUserIdAndDeletedAtIsNull(userId, markerId, pageable);
+        }
+        return threadJpaRepositoryModule.findInboxByUserIdAndLabelIdsAndDeletedAtIsNull(userId, labelIds, markerId, pageable);
+    }
+
+    @Override
+    public int deleteThreadLabelsByLabelId(UUID labelId) {
+        return threadJpaRepositoryModule.deleteThreadLabelsByLabelId(labelId);
+    }
 }

--- a/db/src/main/java/com/mailsangja/db/common/label/LabelRule.java
+++ b/db/src/main/java/com/mailsangja/db/common/label/LabelRule.java
@@ -1,0 +1,28 @@
+package com.mailsangja.db.common.label;
+
+import java.util.List;
+
+public record LabelRule(List<Group> groups) {
+
+    public record Group(List<Condition> conditions) {}
+
+    public record Condition(Field field, Operator operator, String value) {}
+
+    public enum Field {
+        MAIL_ACCOUNT,
+        FROM_ADDRESS,
+        FROM_DOMAIN,
+        TO_ADDRESS,
+        CC_ADDRESS,
+        SUBJECT,
+        BODY_TEXT,
+        HAS_ATTACHMENT
+    }
+
+    public enum Operator {
+        EQUALS,
+        CONTAINS,
+        NOT_CONTAINS,
+        BOOLEAN
+    }
+}

--- a/db/src/main/java/com/mailsangja/db/entity/label/Label.java
+++ b/db/src/main/java/com/mailsangja/db/entity/label/Label.java
@@ -11,7 +11,6 @@ import org.hibernate.type.SqlTypes;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 @Entity
@@ -41,10 +40,12 @@ public class Label extends BaseEntity {
     @Column(name = "notification_enabled", nullable = false)
     private boolean notificationEnabled;
 
-    // 자동 분류 규칙 (e.g. {"from": "noreply@github.com", "subject_contains": "PR"})
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
     @Column(name = "rule", columnDefinition = "jsonb")
     @JdbcTypeCode(SqlTypes.JSON)
-    private Map<String, Object> rule;
+    private String rule;
 
     @Builder.Default
     @ManyToMany(mappedBy = "labels", fetch = FetchType.LAZY)
@@ -66,7 +67,11 @@ public class Label extends BaseEntity {
         this.notificationEnabled = notificationEnabled;
     }
 
-    public void updateRule(Map<String, Object> rule) {
+    public void updateDisplayOrder(int displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+
+    public void updateRule(String rule) {
         this.rule = rule;
     }
 }

--- a/db/src/main/java/com/mailsangja/db/entity/label/Label.java
+++ b/db/src/main/java/com/mailsangja/db/entity/label/Label.java
@@ -1,16 +1,13 @@
 package com.mailsangja.db.entity.label;
 
+import com.mailsangja.db.common.label.LabelRule;
 import com.mailsangja.db.entity.common.BaseEntity;
-import com.mailsangja.db.entity.mail.Message;
-import com.mailsangja.db.entity.mail.Thread;
 import com.mailsangja.db.entity.user.User;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -45,15 +42,7 @@ public class Label extends BaseEntity {
 
     @Column(name = "rule", columnDefinition = "jsonb")
     @JdbcTypeCode(SqlTypes.JSON)
-    private String rule;
-
-    @Builder.Default
-    @ManyToMany(mappedBy = "labels", fetch = FetchType.LAZY)
-    private List<Thread> threads = new ArrayList<>();
-
-    @Builder.Default
-    @ManyToMany(mappedBy = "labels", fetch = FetchType.LAZY)
-    private List<Message> messages = new ArrayList<>();
+    private LabelRule rule;
 
     public void updateName(String name) {
         this.name = name;
@@ -71,7 +60,7 @@ public class Label extends BaseEntity {
         this.displayOrder = displayOrder;
     }
 
-    public void updateRule(String rule) {
+    public void updateRule(LabelRule rule) {
         this.rule = rule;
     }
 }

--- a/db/src/main/java/com/mailsangja/db/entity/label/MessageLabel.java
+++ b/db/src/main/java/com/mailsangja/db/entity/label/MessageLabel.java
@@ -1,0 +1,35 @@
+package com.mailsangja.db.entity.label;
+
+import com.mailsangja.db.entity.mail.Message;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "message_labels")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MessageLabel {
+
+    @EmbeddedId
+    private MessageLabelId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("messageId")
+    @JoinColumn(name = "message_id")
+    private Message message;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("labelId")
+    @JoinColumn(name = "label_id")
+    private Label label;
+
+    public static MessageLabel of(Message message, Label label) {
+        MessageLabel ml = new MessageLabel();
+        ml.id = new MessageLabelId(message.getId(), label.getId());
+        ml.message = message;
+        ml.label = label;
+        return ml;
+    }
+}

--- a/db/src/main/java/com/mailsangja/db/entity/label/MessageLabel.java
+++ b/db/src/main/java/com/mailsangja/db/entity/label/MessageLabel.java
@@ -1,5 +1,6 @@
 package com.mailsangja.db.entity.label;
 
+import com.mailsangja.db.entity.common.BaseEntity;
 import com.mailsangja.db.entity.mail.Message;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "message_labels")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MessageLabel {
+public class MessageLabel extends BaseEntity {
 
     @EmbeddedId
     private MessageLabelId id;

--- a/db/src/main/java/com/mailsangja/db/entity/label/MessageLabelId.java
+++ b/db/src/main/java/com/mailsangja/db/entity/label/MessageLabelId.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.io.Serializable;
 import java.util.UUID;
@@ -18,8 +20,10 @@ import java.util.UUID;
 public class MessageLabelId implements Serializable {
 
     @Column(name = "message_id")
+    @JdbcTypeCode(SqlTypes.CHAR)
     private UUID messageId;
 
     @Column(name = "label_id")
+    @JdbcTypeCode(SqlTypes.CHAR)
     private UUID labelId;
 }

--- a/db/src/main/java/com/mailsangja/db/entity/label/MessageLabelId.java
+++ b/db/src/main/java/com/mailsangja/db/entity/label/MessageLabelId.java
@@ -1,0 +1,25 @@
+package com.mailsangja.db.entity.label;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class MessageLabelId implements Serializable {
+
+    @Column(name = "message_id")
+    private UUID messageId;
+
+    @Column(name = "label_id")
+    private UUID labelId;
+}

--- a/db/src/main/java/com/mailsangja/db/entity/label/ThreadLabel.java
+++ b/db/src/main/java/com/mailsangja/db/entity/label/ThreadLabel.java
@@ -1,5 +1,6 @@
 package com.mailsangja.db.entity.label;
 
+import com.mailsangja.db.entity.common.BaseEntity;
 import com.mailsangja.db.entity.mail.Thread;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "thread_labels")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ThreadLabel {
+public class ThreadLabel extends BaseEntity {
 
     @EmbeddedId
     private ThreadLabelId id;

--- a/db/src/main/java/com/mailsangja/db/entity/label/ThreadLabel.java
+++ b/db/src/main/java/com/mailsangja/db/entity/label/ThreadLabel.java
@@ -1,0 +1,35 @@
+package com.mailsangja.db.entity.label;
+
+import com.mailsangja.db.entity.mail.Thread;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "thread_labels")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ThreadLabel {
+
+    @EmbeddedId
+    private ThreadLabelId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("threadId")
+    @JoinColumn(name = "thread_id")
+    private Thread thread;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("labelId")
+    @JoinColumn(name = "label_id")
+    private Label label;
+
+    public static ThreadLabel of(Thread thread, Label label) {
+        ThreadLabel tl = new ThreadLabel();
+        tl.id = new ThreadLabelId(thread.getId(), label.getId());
+        tl.thread = thread;
+        tl.label = label;
+        return tl;
+    }
+}

--- a/db/src/main/java/com/mailsangja/db/entity/label/ThreadLabelId.java
+++ b/db/src/main/java/com/mailsangja/db/entity/label/ThreadLabelId.java
@@ -1,0 +1,25 @@
+package com.mailsangja.db.entity.label;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ThreadLabelId implements Serializable {
+
+    @Column(name = "thread_id")
+    private UUID threadId;
+
+    @Column(name = "label_id")
+    private UUID labelId;
+}

--- a/db/src/main/java/com/mailsangja/db/entity/label/ThreadLabelId.java
+++ b/db/src/main/java/com/mailsangja/db/entity/label/ThreadLabelId.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.io.Serializable;
 import java.util.UUID;
@@ -18,8 +20,10 @@ import java.util.UUID;
 public class ThreadLabelId implements Serializable {
 
     @Column(name = "thread_id")
+    @JdbcTypeCode(SqlTypes.CHAR)
     private UUID threadId;
 
     @Column(name = "label_id")
+    @JdbcTypeCode(SqlTypes.CHAR)
     private UUID labelId;
 }

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
@@ -1,7 +1,7 @@
 package com.mailsangja.db.entity.mail;
 
 import com.mailsangja.db.entity.common.BaseEntity;
-import com.mailsangja.db.entity.label.Label;
+import com.mailsangja.db.entity.label.MessageLabel;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -89,7 +89,6 @@ public class Message extends BaseEntity {
     @Column(name = "is_read", nullable = false)
     private boolean read;
 
-
     @Column(name = "sent_at")
     private LocalDateTime sentAt;
 
@@ -104,13 +103,8 @@ public class Message extends BaseEntity {
     private List<Attachment> attachments = new ArrayList<>();
 
     @Builder.Default
-    @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(
-            name = "message_labels",
-            joinColumns = @JoinColumn(name = "message_id"),
-            inverseJoinColumns = @JoinColumn(name = "label_id")
-    )
-    private List<Label> labels = new ArrayList<>();
+    @OneToMany(mappedBy = "message", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MessageLabel> messageLabels = new ArrayList<>();
 
     public static Message from(Thread thread, CreateValues values) {
         CreateValues normalizedValues = values.normalizeNames();
@@ -136,7 +130,7 @@ public class Message extends BaseEntity {
                 .bodyText(normalizedValues.bodyText())
                 .bodyHtml(normalizedValues.bodyHtml())
                 .attachments(new ArrayList<>())
-                .labels(Collections.emptyList())
+                .messageLabels(new ArrayList<>())
                 .build();
     }
 
@@ -259,6 +253,13 @@ public class Message extends BaseEntity {
         this.attachments.clear();
         if (attachments != null) {
             this.attachments.addAll(attachments);
+        }
+    }
+
+    public void replaceMessageLabels(List<MessageLabel> newMessageLabels) {
+        this.messageLabels.clear();
+        if (newMessageLabels != null) {
+            this.messageLabels.addAll(newMessageLabels);
         }
     }
 

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Message.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Entity
@@ -260,6 +261,13 @@ public class Message extends BaseEntity {
         this.messageLabels.clear();
         if (newMessageLabels != null) {
             this.messageLabels.addAll(newMessageLabels);
+        }
+    }
+
+    public void applyTargetLabels(Set<UUID> removeIds, List<MessageLabel> newEntries) {
+        this.messageLabels.removeIf(ml -> removeIds.contains(ml.getLabel().getId()));
+        if (newEntries != null) {
+            this.messageLabels.addAll(newEntries);
         }
     }
 

--- a/db/src/main/java/com/mailsangja/db/entity/mail/Thread.java
+++ b/db/src/main/java/com/mailsangja/db/entity/mail/Thread.java
@@ -1,7 +1,7 @@
 package com.mailsangja.db.entity.mail;
 
 import com.mailsangja.db.entity.common.BaseEntity;
-import com.mailsangja.db.entity.label.Label;
+import com.mailsangja.db.entity.label.ThreadLabel;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -70,13 +70,8 @@ public class Thread extends BaseEntity {
     private List<Message> messages = new ArrayList<>();
 
     @Builder.Default
-    @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(
-            name = "thread_labels",
-            joinColumns = @JoinColumn(name = "thread_id"),
-            inverseJoinColumns = @JoinColumn(name = "label_id")
-    )
-    private List<Label> labels = new ArrayList<>();
+    @OneToMany(mappedBy = "thread", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ThreadLabel> threadLabels = new ArrayList<>();
 
     public void updateLatestMessageInfo(
             String subject,
@@ -115,6 +110,7 @@ public class Thread extends BaseEntity {
     public void updateReadStatus(boolean read) {
         this.read = read;
     }
+
     public void updateMessageCount(int messageCount) {
         this.messageCount = Math.max(messageCount, 0);
     }

--- a/db/src/main/java/com/mailsangja/db/module/label/LabelJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/label/LabelJpaRepositoryModule.java
@@ -2,6 +2,8 @@ package com.mailsangja.db.module.label;
 
 import com.mailsangja.db.entity.label.Label;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,7 +13,38 @@ public interface LabelJpaRepositoryModule extends JpaRepository<Label, UUID> {
 
     List<Label> findAllByUserIdAndDeletedAtIsNull(UUID userId);
 
+    @Query("SELECT l FROM Label l WHERE l.user.id = :userId AND l.deletedAt IS NULL ORDER BY l.displayOrder ASC, l.createdAt ASC")
+    List<Label> findAllByUserIdAndDeletedAtIsNullOrderByDisplayOrder(@Param("userId") UUID userId);
+
     Optional<Label> findByIdAndDeletedAtIsNull(UUID id);
 
     Optional<Label> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId);
+
+    boolean existsByUserIdAndNameIgnoreCaseAndDeletedAtIsNull(UUID userId, String name);
+
+    @Query("""
+            SELECT COUNT(l) > 0
+            FROM Label l
+            WHERE l.user.id = :userId
+              AND lower(l.name) = lower(:name)
+              AND l.id <> :excludeId
+              AND l.deletedAt IS NULL
+            """)
+    boolean existsByUserIdAndNameIgnoreCaseAndIdNotAndDeletedAtIsNull(
+            @Param("userId") UUID userId,
+            @Param("name") String name,
+            @Param("excludeId") UUID excludeId
+    );
+
+    @Query("""
+            SELECT tl.label.id as labelId, COUNT(DISTINCT tl.thread.id) as unreadCount
+            FROM ThreadLabel tl
+            WHERE tl.label.user.id = :userId
+              AND tl.label.deletedAt IS NULL
+              AND tl.thread.deletedAt IS NULL
+              AND tl.thread.read = false
+              AND tl.thread.direction = com.mailsangja.db.entity.mail.Direction.INBOUND
+            GROUP BY tl.label.id
+            """)
+    List<LabelUnreadCountProjection> findUnreadThreadCountsByUserId(@Param("userId") UUID userId);
 }

--- a/db/src/main/java/com/mailsangja/db/module/label/LabelJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/label/LabelJpaRepositoryModule.java
@@ -40,6 +40,7 @@ public interface LabelJpaRepositoryModule extends JpaRepository<Label, UUID> {
             SELECT tl.label.id as labelId, COUNT(DISTINCT tl.thread.id) as unreadCount
             FROM ThreadLabel tl
             WHERE tl.label.user.id = :userId
+              AND tl.deletedAt IS NULL
               AND tl.label.deletedAt IS NULL
               AND tl.thread.deletedAt IS NULL
               AND tl.thread.read = false

--- a/db/src/main/java/com/mailsangja/db/module/label/LabelUnreadCountProjection.java
+++ b/db/src/main/java/com/mailsangja/db/module/label/LabelUnreadCountProjection.java
@@ -1,0 +1,8 @@
+package com.mailsangja.db.module.label;
+
+import java.util.UUID;
+
+public interface LabelUnreadCountProjection {
+    UUID getLabelId();
+    Long getUnreadCount();
+}

--- a/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
@@ -156,6 +156,7 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
                             tl.label.colorCode AS labelColorCode
             FROM ThreadLabel tl
             WHERE tl.thread.id IN :threadIds
+              AND tl.deletedAt IS NULL
               AND tl.label.deletedAt IS NULL
             """)
     List<ThreadLabelProjection> findLabelsByThreadIdIn(@Param("threadIds") List<UUID> threadIds);

--- a/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
@@ -130,4 +130,37 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
             @Param("mailAccountId") UUID mailAccountId,
             @Param("gmailThreadId") String gmailThreadId
     );
+
+    @EntityGraph(attributePaths = {"messageLabels", "messageLabels.label", "thread", "thread.mailAccount"})
+    @Query("""
+            SELECT DISTINCT m FROM Message m
+            WHERE m.thread.mailAccount.user.id = :userId
+              AND m.deletedAt IS NULL
+              AND m.thread.deletedAt IS NULL
+            """)
+    List<Message> findAllByUserIdAndDeletedAtIsNullWithLabels(@Param("userId") UUID userId);
+
+    @EntityGraph(attributePaths = {"attachments"})
+    @Query("""
+            SELECT DISTINCT m FROM Message m
+            WHERE m.thread.mailAccount.user.id = :userId
+              AND m.deletedAt IS NULL
+              AND m.thread.deletedAt IS NULL
+            """)
+    List<Message> findAllByUserIdAndDeletedAtIsNullWithAttachments(@Param("userId") UUID userId);
+
+    @Query("""
+            SELECT DISTINCT tl.thread.id AS threadId,
+                            tl.label.id  AS labelId,
+                            tl.label.name AS labelName,
+                            tl.label.colorCode AS labelColorCode
+            FROM ThreadLabel tl
+            WHERE tl.thread.id IN :threadIds
+              AND tl.label.deletedAt IS NULL
+            """)
+    List<ThreadLabelProjection> findLabelsByThreadIdIn(@Param("threadIds") List<UUID> threadIds);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM MessageLabel ml WHERE ml.label.id = :labelId")
+    int deleteMessageLabelsByLabelId(@Param("labelId") UUID labelId);
 }

--- a/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
@@ -102,6 +102,8 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             AND tl.label.deletedAt IS NULL
             AND (:markerId IS NULL OR t.lastMessageAt < (
                 SELECT m.lastMessageAt FROM Thread m WHERE m.id = :markerId
+                AND m.mailAccount.id IN (SELECT ma.id FROM MailAccount ma WHERE ma.user.id = :userId AND ma.deletedAt IS NULL)
+                AND m.direction = 'INBOUND'
             ))
             ORDER BY t.lastMessageAt DESC
             """)

--- a/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
@@ -96,11 +96,12 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
                 SELECT ma.id FROM MailAccount ma
                 WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
             )
-            AND t.direction = 'INBOUND'
-            AND t.deletedAt IS NULL
-            AND tl.label.id IN :labelIds
-            AND tl.label.deletedAt IS NULL
-            AND (:markerId IS NULL OR t.lastMessageAt < (
+             AND t.direction = 'INBOUND'
+             AND t.deletedAt IS NULL
+             AND tl.deletedAt IS NULL
+             AND tl.label.id IN :labelIds
+             AND tl.label.deletedAt IS NULL
+             AND (:markerId IS NULL OR t.lastMessageAt < (
                 SELECT m.lastMessageAt FROM Thread m WHERE m.id = :markerId
                 AND m.mailAccount.id IN (SELECT ma.id FROM MailAccount ma WHERE ma.user.id = :userId AND ma.deletedAt IS NULL)
                 AND m.direction = 'INBOUND'

--- a/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
@@ -87,4 +87,32 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             @Param("markerId") UUID markerId,
             Pageable pageable
     );
+
+    @EntityGraph(attributePaths = {"mailAccount"})
+    @Query("""
+            SELECT DISTINCT t FROM Thread t
+            JOIN t.threadLabels tl
+            WHERE t.mailAccount.id IN (
+                SELECT ma.id FROM MailAccount ma
+                WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+            )
+            AND t.direction = 'INBOUND'
+            AND t.deletedAt IS NULL
+            AND tl.label.id IN :labelIds
+            AND tl.label.deletedAt IS NULL
+            AND (:markerId IS NULL OR t.lastMessageAt < (
+                SELECT m.lastMessageAt FROM Thread m WHERE m.id = :markerId
+            ))
+            ORDER BY t.lastMessageAt DESC
+            """)
+    Slice<Thread> findInboxByUserIdAndLabelIdsAndDeletedAtIsNull(
+            @Param("userId") UUID userId,
+            @Param("labelIds") List<UUID> labelIds,
+            @Param("markerId") UUID markerId,
+            Pageable pageable
+    );
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM ThreadLabel tl WHERE tl.label.id = :labelId")
+    int deleteThreadLabelsByLabelId(@Param("labelId") UUID labelId);
 }

--- a/db/src/main/java/com/mailsangja/db/module/mail/ThreadLabelProjection.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/ThreadLabelProjection.java
@@ -1,0 +1,10 @@
+package com.mailsangja.db.module.mail;
+
+import java.util.UUID;
+
+public interface ThreadLabelProjection {
+    UUID getThreadId();
+    UUID getLabelId();
+    String getLabelName();
+    String getLabelColorCode();
+}

--- a/db/src/main/java/com/mailsangja/db/port/LabelRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/LabelRepositoryPort.java
@@ -3,12 +3,25 @@ package com.mailsangja.db.port;
 import com.mailsangja.db.entity.label.Label;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface LabelRepositoryPort {
+
     Label save(Label label);
+
     List<Label> findAllByUserIdAndDeletedAtIsNull(UUID userId);
+
+    List<Label> findAllByUserIdAndDeletedAtIsNullOrderByDisplayOrder(UUID userId);
+
     Optional<Label> findByIdAndDeletedAtIsNull(UUID id);
+
     Optional<Label> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId);
+
+    boolean existsByUserIdAndNameIgnoreCaseAndDeletedAtIsNull(UUID userId, String name);
+
+    boolean existsByUserIdAndNameIgnoreCaseAndIdNotAndDeletedAtIsNull(UUID userId, String name, UUID excludeId);
+
+    Map<UUID, Long> findUnreadThreadCountsByUserId(UUID userId);
 }

--- a/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
@@ -40,4 +40,14 @@ public interface MessageRepositoryPort {
     int bulkRestoreByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId);
     void hardDelete(Message message);
     boolean existsByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId);
+
+    List<Message> findAllByUserIdAndDeletedAtIsNullWithLabels(UUID userId);
+
+    List<Message> findAllByUserIdAndDeletedAtIsNullWithAttachments(UUID userId);
+
+    List<Message> saveAll(List<Message> messages);
+
+    List<ThreadLabelView> findLabelsByThreadIdIn(List<UUID> threadIds);
+
+    int deleteMessageLabelsByLabelId(UUID labelId);
 }

--- a/db/src/main/java/com/mailsangja/db/port/ThreadLabelView.java
+++ b/db/src/main/java/com/mailsangja/db/port/ThreadLabelView.java
@@ -1,0 +1,10 @@
+package com.mailsangja.db.port;
+
+import java.util.UUID;
+
+public record ThreadLabelView(
+        UUID threadId,
+        UUID labelId,
+        String labelName,
+        String colorCode
+) {}

--- a/db/src/main/java/com/mailsangja/db/port/ThreadRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/ThreadRepositoryPort.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Slice;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -26,4 +25,8 @@ public interface ThreadRepositoryPort {
     int bulkRestoreByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId);
     int bulkRestoreAndResetMessageCountByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId);
     void hardDeleteAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId);
+
+    Slice<Thread> findInboxByUserIdAndLabelIdsAndDeletedAtIsNull(UUID userId, List<UUID> labelIds, UUID markerId, Pageable pageable);
+
+    int deleteThreadLabelsByLabelId(UUID labelId);
 }

--- a/db/src/main/resources/init.sql
+++ b/db/src/main/resources/init.sql
@@ -10,3 +10,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_gmail_thread_locks_account_thread
 
 CREATE UNIQUE INDEX IF NOT EXISTS uq_messages_thread_gmail
     ON messages (thread_id, gmail_message_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_labels_user_name_active
+    ON labels (user_id, lower(name))
+    WHERE deleted_at IS NULL;

--- a/db/src/main/resources/schema.sql
+++ b/db/src/main/resources/schema.sql
@@ -141,6 +141,7 @@ CREATE TABLE IF NOT EXISTS labels (
     name                 VARCHAR(100) NOT NULL,
     color_code           VARCHAR(7)   NOT NULL,
     notification_enabled BOOLEAN      NOT NULL DEFAULT FALSE,
+    display_order        INT          NOT NULL DEFAULT 0,
     rule                 JSONB        NULL,
     created_at           TIMESTAMP    NOT NULL,
     modified_at          TIMESTAMP    NOT NULL,
@@ -149,6 +150,10 @@ CREATE TABLE IF NOT EXISTS labels (
     PRIMARY KEY (id),
     CONSTRAINT fk_labels_user FOREIGN KEY (user_id) REFERENCES users (id)
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_labels_user_name_active
+    ON labels (user_id, lower(name))
+    WHERE deleted_at IS NULL;
 
 CREATE TABLE IF NOT EXISTS thread_labels (
     thread_id CHAR(36) NOT NULL,

--- a/db/src/main/resources/schema.sql
+++ b/db/src/main/resources/schema.sql
@@ -156,8 +156,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_labels_user_name_active
     WHERE deleted_at IS NULL;
 
 CREATE TABLE IF NOT EXISTS thread_labels (
-    thread_id CHAR(36) NOT NULL,
-    label_id  CHAR(36) NOT NULL,
+    thread_id   CHAR(36)  NOT NULL,
+    label_id    CHAR(36)  NOT NULL,
+    created_at  TIMESTAMP NOT NULL,
+    modified_at TIMESTAMP NOT NULL,
+    deleted_at  TIMESTAMP NULL,
 
     PRIMARY KEY (thread_id, label_id),
     CONSTRAINT fk_thread_labels_thread FOREIGN KEY (thread_id) REFERENCES threads (id),
@@ -165,8 +168,11 @@ CREATE TABLE IF NOT EXISTS thread_labels (
 );
 
 CREATE TABLE IF NOT EXISTS message_labels (
-    message_id CHAR(36) NOT NULL,
-    label_id   CHAR(36) NOT NULL,
+    message_id  CHAR(36)  NOT NULL,
+    label_id    CHAR(36)  NOT NULL,
+    created_at  TIMESTAMP NOT NULL,
+    modified_at TIMESTAMP NOT NULL,
+    deleted_at  TIMESTAMP NULL,
 
     PRIMARY KEY (message_id, label_id),
     CONSTRAINT fk_message_labels_message FOREIGN KEY (message_id) REFERENCES messages (id),

--- a/worker/src/main/java/com/mailsangja/worker/config/properties/LabelReclassifyRabbitProperties.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/properties/LabelReclassifyRabbitProperties.java
@@ -1,28 +1,22 @@
 package com.mailsangja.worker.config.properties;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-@Getter
-@Setter
 @Component
-@ConfigurationProperties(prefix = "mailsangja.rabbitmq.label-reclassify")
 public class LabelReclassifyRabbitProperties {
 
-    private String taskName;
+    private static final String TASK_NAME = "label.reclassify";
 
     public String getTaskName() {
-        return taskName;
+        return TASK_NAME;
     }
 
     public String getQueueName() {
-        return "mailsangja." + taskName;
+        return "mailsangja." + TASK_NAME;
     }
 
     public String getRoutingKey() {
-        return "mail." + taskName;
+        return "mail." + TASK_NAME;
     }
 
     public String getDeadLetterQueueName() {

--- a/worker/src/main/java/com/mailsangja/worker/config/properties/LabelReclassifyRabbitProperties.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/properties/LabelReclassifyRabbitProperties.java
@@ -1,0 +1,35 @@
+package com.mailsangja.worker.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "mailsangja.rabbitmq.label-reclassify")
+public class LabelReclassifyRabbitProperties {
+
+    private String taskName;
+
+    public String getTaskName() {
+        return taskName;
+    }
+
+    public String getQueueName() {
+        return "mailsangja." + taskName;
+    }
+
+    public String getRoutingKey() {
+        return "mail." + taskName;
+    }
+
+    public String getDeadLetterQueueName() {
+        return getQueueName() + ".dlq";
+    }
+
+    public String getDeadLetterRoutingKey() {
+        return getRoutingKey() + ".dlq";
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/LabelReclassifyRabbitConfig.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/LabelReclassifyRabbitConfig.java
@@ -1,0 +1,108 @@
+package com.mailsangja.worker.config.rabbitmq;
+
+import com.mailsangja.worker.config.properties.LabelReclassifyRabbitProperties;
+import com.mailsangja.worker.config.properties.MailTaskRabbitProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.rabbit.config.RetryInterceptorBuilder;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.retry.MessageRecoverer;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Slf4j
+public class LabelReclassifyRabbitConfig {
+
+    @Bean
+    public Queue labelReclassifyQueue(
+            LabelReclassifyRabbitProperties properties,
+            MailTaskRabbitProperties mailTaskRabbitProperties
+    ) {
+        RabbitMqConfig.validateTaskName(properties.getTaskName(), "mailsangja.rabbitmq.label-reclassify.task-name");
+        return QueueBuilder.durable(properties.getQueueName())
+                .ttl(RabbitMqConfig.toQueueTtlMillis(mailTaskRabbitProperties.getTtl(), "mailsangja.rabbitmq.task.ttl"))
+                .deadLetterExchange(mailTaskRabbitProperties.getDeadLetterExchange())
+                .deadLetterRoutingKey(properties.getDeadLetterRoutingKey())
+                .build();
+    }
+
+    @Bean
+    public Queue labelReclassifyDeadLetterQueue(LabelReclassifyRabbitProperties properties) {
+        RabbitMqConfig.validateTaskName(properties.getTaskName(), "mailsangja.rabbitmq.label-reclassify.task-name");
+        return QueueBuilder.durable(properties.getDeadLetterQueueName()).build();
+    }
+
+    @Bean
+    public Binding labelReclassifyBinding(
+            @Qualifier("labelReclassifyQueue") Queue labelReclassifyQueue,
+            @Qualifier("mailTaskExchange") DirectExchange mailTaskExchange,
+            LabelReclassifyRabbitProperties properties
+    ) {
+        return BindingBuilder.bind(labelReclassifyQueue)
+                .to(mailTaskExchange)
+                .with(properties.getRoutingKey());
+    }
+
+    @Bean
+    public Binding labelReclassifyDeadLetterBinding(
+            @Qualifier("labelReclassifyDeadLetterQueue") Queue labelReclassifyDeadLetterQueue,
+            @Qualifier("mailTaskDeadLetterExchange") DirectExchange mailTaskDeadLetterExchange,
+            LabelReclassifyRabbitProperties properties
+    ) {
+        return BindingBuilder.bind(labelReclassifyDeadLetterQueue)
+                .to(mailTaskDeadLetterExchange)
+                .with(properties.getDeadLetterRoutingKey());
+    }
+
+    @Bean
+    public MessageRecoverer labelReclassifyMessageRecoverer(LabelReclassifyRabbitProperties properties) {
+        return (message, cause) -> {
+            log.warn(
+                    "LabelReclassify retries exhausted. Sending to DLQ routingKey={} messageId={} payloadSize={}B",
+                    properties.getDeadLetterRoutingKey(),
+                    message.getMessageProperties().getMessageId(),
+                    message.getBody().length,
+                    cause
+            );
+            throw new AmqpRejectAndDontRequeueException("LabelReclassify retries exhausted", cause);
+        };
+    }
+
+    @Bean
+    public MethodInterceptor labelReclassifyRetryInterceptor(
+            MailTaskRabbitProperties properties,
+            @Qualifier("labelReclassifyMessageRecoverer") MessageRecoverer labelReclassifyMessageRecoverer
+    ) {
+        return RetryInterceptorBuilder.stateless()
+                .maxRetries(properties.getRetryMaxAttempts())
+                .recoverer(labelReclassifyMessageRecoverer)
+                .build();
+    }
+
+    @Bean
+    public SimpleRabbitListenerContainerFactory labelReclassifyRabbitListenerContainerFactory(
+            ConnectionFactory connectionFactory,
+            MessageConverter rabbitMessageConverter,
+            @Qualifier("labelReclassifyRetryInterceptor") MethodInterceptor labelReclassifyRetryInterceptor,
+            MailTaskRabbitProperties properties
+    ) {
+        SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+        factory.setMessageConverter(rabbitMessageConverter);
+        factory.setConcurrentConsumers(properties.getConcurrency());
+        factory.setMaxConcurrentConsumers(properties.getConcurrency());
+        factory.setDefaultRequeueRejected(false);
+        factory.setAdviceChain(labelReclassifyRetryInterceptor);
+        return factory;
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/dto/label/LabelReclassifyMessage.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/label/LabelReclassifyMessage.java
@@ -1,0 +1,23 @@
+package com.mailsangja.worker.dto.label;
+
+import java.util.Set;
+import java.util.UUID;
+
+public record LabelReclassifyMessage(
+        UUID userId,
+        Set<UUID> labelIds
+) {
+
+    public LabelReclassifyMessage {
+        if (userId == null) {
+            throw new IllegalArgumentException("userId must not be null");
+        }
+        if (labelIds == null || labelIds.isEmpty()) {
+            throw new IllegalArgumentException("labelIds must not be null or empty");
+        }
+        if (labelIds.stream().anyMatch(id -> id == null)) {
+            throw new IllegalArgumentException("labelIds must not contain null");
+        }
+        labelIds = Set.copyOf(labelIds);
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/handler/label/AhoCorasickAutomaton.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/label/AhoCorasickAutomaton.java
@@ -1,0 +1,144 @@
+package com.mailsangja.worker.handler.label;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+/**
+ * 경량 Aho-Corasick automaton 구현체.
+ * 여러 패턴 키워드를 텍스트에서 한 번에 검색한다.
+ *
+ * build() 호출 전에 addPattern()으로 패턴을 등록하고,
+ * build() 이후 search()로 매칭 결과를 조회한다.
+ *
+ * 이 구현은 모든 비교를 소문자/trim 정규화된 입력에 대해 수행하는 것을 가정한다.
+ */
+class AhoCorasickAutomaton {
+
+    private static final int ROOT = 0;
+
+    private final List<Map<Character, Integer>> goto_ = new ArrayList<>();
+    private final List<Integer> fail = new ArrayList<>();
+    private final List<Set<String>> output = new ArrayList<>();
+    private final Set<String> patterns = new LinkedHashSet<>();
+
+    private boolean built = false;
+
+    AhoCorasickAutomaton() {
+        addState();
+    }
+
+    boolean hasPatterns() {
+        return !patterns.isEmpty();
+    }
+
+    /**
+     * 패턴을 추가한다. build() 호출 전에만 사용 가능.
+     */
+    void addPattern(String pattern) {
+        if (pattern == null || pattern.isBlank()) {
+            return;
+        }
+        if (!patterns.add(pattern)) {
+            return;
+        }
+        insertPattern(pattern);
+    }
+
+    /**
+     * 모든 패턴을 등록한 뒤 자동화 automaton을 빌드한다.
+     */
+    void build() {
+        buildFailureLinks();
+        built = true;
+    }
+
+    /**
+     * 텍스트에서 등록된 패턴을 검색한다.
+     * @return 발견된 패턴 문자열 집합
+     */
+    Set<String> search(String text) {
+        if (!built || text == null || text.isEmpty()) {
+            return Set.of();
+        }
+
+        Set<String> found = new HashSet<>();
+        int current = ROOT;
+
+        for (char ch : text.toCharArray()) {
+            while (current != ROOT && !goto_.get(current).containsKey(ch)) {
+                current = fail.get(current);
+            }
+            current = goto_.get(current).getOrDefault(ch, ROOT);
+            Set<String> hits = output.get(current);
+            if (!hits.isEmpty()) {
+                found.addAll(hits);
+            }
+        }
+
+        return found;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Internal
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private void insertPattern(String pattern) {
+        int current = ROOT;
+        for (char ch : pattern.toCharArray()) {
+            Map<Character, Integer> children = goto_.get(current);
+            if (!children.containsKey(ch)) {
+                int newState = addState();
+                children.put(ch, newState);
+            }
+            current = children.get(ch);
+        }
+        output.get(current).add(pattern);
+    }
+
+    private void buildFailureLinks() {
+        Queue<Integer> queue = new ArrayDeque<>();
+
+        // 깊이 1 노드의 failure link는 루트
+        for (int child : goto_.get(ROOT).values()) {
+            fail.set(child, ROOT);
+            queue.add(child);
+        }
+
+        while (!queue.isEmpty()) {
+            int state = queue.poll();
+            for (Map.Entry<Character, Integer> entry : goto_.get(state).entrySet()) {
+                char ch = entry.getKey();
+                int next = entry.getValue();
+                queue.add(next);
+
+                int failState = fail.get(state);
+                while (failState != ROOT && !goto_.get(failState).containsKey(ch)) {
+                    failState = fail.get(failState);
+                }
+                int link = goto_.get(failState).getOrDefault(ch, ROOT);
+                if (link == next) {
+                    link = ROOT;
+                }
+                fail.set(next, link);
+
+                // output 전파: failure link의 output을 현재 상태 output에 합산
+                output.get(next).addAll(output.get(link));
+            }
+        }
+    }
+
+    private int addState() {
+        int id = goto_.size();
+        goto_.add(new HashMap<>());
+        fail.add(ROOT);
+        output.add(new HashSet<>());
+        return id;
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/handler/label/AhoCorasickAutomaton.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/label/AhoCorasickAutomaton.java
@@ -42,6 +42,9 @@ class AhoCorasickAutomaton {
      * 패턴을 추가한다. build() 호출 전에만 사용 가능.
      */
     void addPattern(String pattern) {
+        if (built) {
+            throw new IllegalStateException("Cannot add patterns after build()");
+        }
         if (pattern == null || pattern.isBlank()) {
             return;
         }

--- a/worker/src/main/java/com/mailsangja/worker/handler/label/LabelRuleCompiler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/label/LabelRuleCompiler.java
@@ -1,0 +1,462 @@
+package com.mailsangja.worker.handler.label;
+
+import com.mailsangja.db.common.label.LabelRule;
+import com.mailsangja.db.entity.label.Label;
+import com.mailsangja.db.entity.mail.Message;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * 라벨 규칙을 컴파일하고 메시지 목록에 대해 라벨을 평가하는 컴포넌트.
+ *
+ * 평가 전략:
+ * 1. 활성 라벨 규칙을 ConditionRef 단위로 컴파일하여 필드별 인덱스를 생성한다.
+ * 2. EQUALS/BOOLEAN 조건은 Map 인덱스(O(1))로 후보를 추출한다.
+ * 3. CONTAINS/NOT_CONTAINS 조건은 Aho-Corasick automaton으로 후보를 추출한다.
+ * 4. 후보 라벨에 한해 전체 조건(DNF: OR of AND)을 정밀 평가한다.
+ * 5. 결과는 메시지 ID → 적용할 Label 목록으로 반환한다.
+ */
+@Slf4j
+@Component
+public class LabelRuleCompiler {
+
+    private static final int MAX_VALUE_LENGTH = 200;
+
+    /**
+     * 라벨 규칙을 컴파일하여 메시지별 적용 라벨 맵을 반환한다.
+     *
+     * @param labels                    사용자의 활성 라벨 목록
+     * @param messages                  평가 대상 메시지 목록 (messageLabels 컬렉션 초기화 필요)
+     * @param messageIdsWithAttachments 첨부파일이 있는 메시지 ID 집합 (별도 쿼리로 조회)
+     * @return 메시지 ID → 적용할 Label 목록
+     */
+    public Map<UUID, List<Label>> compile(List<Label> labels, List<Message> messages, Set<UUID> messageIdsWithAttachments) {
+        if (labels.isEmpty() || messages.isEmpty()) {
+            return Map.of();
+        }
+
+        CompiledRules compiled = buildIndex(labels);
+        Map<UUID, List<Label>> result = new HashMap<>();
+
+        for (Message message : messages) {
+            boolean hasAttachment = messageIdsWithAttachments.contains(message.getId());
+            List<Label> matchedLabels = evaluate(message, compiled, labels, hasAttachment);
+            result.put(message.getId(), matchedLabels);
+        }
+
+        return result;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Rule compilation
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private CompiledRules buildIndex(List<Label> labels) {
+        Map<String, List<ConditionRef>> equalsIndex = new HashMap<>();
+        Map<String, List<ConditionRef>> containsIndex = new HashMap<>();
+        List<ConditionRef> notContainsRefs = new ArrayList<>();
+        Map<UUID, List<ParsedGroup>> parsedGroupsByLabel = new HashMap<>();
+
+        AhoCorasickAutomaton subjectAutomaton = new AhoCorasickAutomaton();
+        AhoCorasickAutomaton bodyTextAutomaton = new AhoCorasickAutomaton();
+        AhoCorasickAutomaton fromAddressAutomaton = new AhoCorasickAutomaton();
+        AhoCorasickAutomaton fromDomainAutomaton = new AhoCorasickAutomaton();
+        AhoCorasickAutomaton toAddressAutomaton = new AhoCorasickAutomaton();
+        AhoCorasickAutomaton ccAddressAutomaton = new AhoCorasickAutomaton();
+
+        for (Label label : labels) {
+            if (label.getRule() == null) {
+                continue;
+            }
+
+            List<ParsedGroup> parsedGroups = parseGroups(label);
+            if (parsedGroups.isEmpty()) {
+                continue;
+            }
+            parsedGroupsByLabel.put(label.getId(), parsedGroups);
+
+            for (ParsedGroup group : parsedGroups) {
+                for (ParsedCondition cond : group.conditions()) {
+                    String field = cond.field();
+                    String operator = cond.operator();
+                    String value = cond.normalizedValue();
+                    ConditionRef ref = new ConditionRef(label.getId(), group.groupId(), cond.conditionId(), field, operator, value);
+
+                    switch (operator) {
+                        case "EQUALS", "BOOLEAN" -> {
+                            String indexKey = field + ":" + (value != null ? value : "true");
+                            equalsIndex.computeIfAbsent(indexKey, k -> new ArrayList<>()).add(ref);
+                        }
+                        case "CONTAINS" -> {
+                            if (value != null && !value.isBlank()) {
+                                containsIndex.computeIfAbsent(value, k -> new ArrayList<>()).add(ref);
+                                addKeywordToAutomaton(field, value, subjectAutomaton, bodyTextAutomaton,
+                                        fromAddressAutomaton, fromDomainAutomaton, toAddressAutomaton, ccAddressAutomaton);
+                            }
+                        }
+                        case "NOT_CONTAINS" -> notContainsRefs.add(ref);
+                        default -> { /* validated upstream */ }
+                    }
+                }
+            }
+        }
+
+        subjectAutomaton.build();
+        bodyTextAutomaton.build();
+        fromAddressAutomaton.build();
+        fromDomainAutomaton.build();
+        toAddressAutomaton.build();
+        ccAddressAutomaton.build();
+
+        return new CompiledRules(
+                equalsIndex,
+                containsIndex,
+                notContainsRefs,
+                parsedGroupsByLabel,
+                subjectAutomaton,
+                bodyTextAutomaton,
+                fromAddressAutomaton,
+                fromDomainAutomaton,
+                toAddressAutomaton,
+                ccAddressAutomaton
+        );
+    }
+
+    private void addKeywordToAutomaton(
+            String field,
+            String keyword,
+            AhoCorasickAutomaton subjectAutomaton,
+            AhoCorasickAutomaton bodyTextAutomaton,
+            AhoCorasickAutomaton fromAddressAutomaton,
+            AhoCorasickAutomaton fromDomainAutomaton,
+            AhoCorasickAutomaton toAddressAutomaton,
+            AhoCorasickAutomaton ccAddressAutomaton
+    ) {
+        switch (field) {
+            case "SUBJECT"       -> subjectAutomaton.addPattern(keyword);
+            case "BODY_TEXT"     -> bodyTextAutomaton.addPattern(keyword);
+            case "FROM_ADDRESS"  -> fromAddressAutomaton.addPattern(keyword);
+            case "FROM_DOMAIN"   -> fromDomainAutomaton.addPattern(keyword);
+            case "TO_ADDRESS"    -> toAddressAutomaton.addPattern(keyword);
+            case "CC_ADDRESS"    -> ccAddressAutomaton.addPattern(keyword);
+            default              -> { /* not used for automaton */ }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Message evaluation
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private List<Label> evaluate(Message message, CompiledRules compiled, List<Label> allLabels, boolean hasAttachment) {
+        MessageFeatures features = extractFeatures(message, hasAttachment);
+
+        Map<UUID, Map<String, Set<String>>> matchedCondIdsByLabelByGroup = new HashMap<>();
+
+        collectEqualsMatches(features, compiled, matchedCondIdsByLabelByGroup);
+        collectContainsMatches(features, compiled, matchedCondIdsByLabelByGroup);
+
+        if (matchedCondIdsByLabelByGroup.isEmpty()) {
+            return List.of();
+        }
+
+        Map<UUID, Label> labelById = new HashMap<>();
+        for (Label label : allLabels) {
+            labelById.put(label.getId(), label);
+        }
+
+        List<Label> matched = new ArrayList<>();
+        for (UUID candidateLabelId : matchedCondIdsByLabelByGroup.keySet()) {
+            Label label = labelById.get(candidateLabelId);
+            if (label == null) {
+                continue;
+            }
+            List<ParsedGroup> parsedGroups = compiled.parsedGroupsByLabel().get(candidateLabelId);
+            if (parsedGroups == null) {
+                continue;
+            }
+
+            if (evaluateDnf(features, parsedGroups)) {
+                matched.add(label);
+            }
+        }
+
+        return matched;
+    }
+
+    private void collectEqualsMatches(
+            MessageFeatures features,
+            CompiledRules compiled,
+            Map<UUID, Map<String, Set<String>>> result
+    ) {
+        Map<String, List<ConditionRef>> equalsIndex = compiled.equalsIndex();
+
+        checkEqualsField("MAIL_ACCOUNT", features.mailAccountId(), equalsIndex, result);
+        checkEqualsField("FROM_DOMAIN", features.fromDomain(), equalsIndex, result);
+        checkEqualsField("FROM_ADDRESS", features.fromAddress(), equalsIndex, result);
+
+        if (features.hasAttachment()) {
+            collectFromIndex("HAS_ATTACHMENT:true", equalsIndex, result);
+        } else {
+            collectFromIndex("HAS_ATTACHMENT:false", equalsIndex, result);
+        }
+
+        for (String toAddress : features.toAddresses()) {
+            checkEqualsField("TO_ADDRESS", toAddress, equalsIndex, result);
+        }
+        for (String ccAddress : features.ccAddresses()) {
+            checkEqualsField("CC_ADDRESS", ccAddress, equalsIndex, result);
+        }
+    }
+
+    private void checkEqualsField(
+            String field,
+            String value,
+            Map<String, List<ConditionRef>> equalsIndex,
+            Map<UUID, Map<String, Set<String>>> result
+    ) {
+        if (value == null || value.isBlank()) {
+            return;
+        }
+        collectFromIndex(field + ":" + value, equalsIndex, result);
+    }
+
+    private void collectFromIndex(
+            String indexKey,
+            Map<String, List<ConditionRef>> index,
+            Map<UUID, Map<String, Set<String>>> result
+    ) {
+        List<ConditionRef> refs = index.get(indexKey);
+        if (refs == null) {
+            return;
+        }
+        for (ConditionRef ref : refs) {
+            result.computeIfAbsent(ref.labelId(), k -> new HashMap<>())
+                    .computeIfAbsent(ref.groupId(), k -> new HashSet<>())
+                    .add(ref.conditionId());
+        }
+    }
+
+    private void collectContainsMatches(
+            MessageFeatures features,
+            CompiledRules compiled,
+            Map<UUID, Map<String, Set<String>>> result
+    ) {
+        Map<String, List<ConditionRef>> containsIndex = compiled.containsIndex();
+
+        scanFieldWithAutomaton("SUBJECT", features.subject(), compiled.subjectAutomaton(), containsIndex, result);
+        scanFieldWithAutomaton("BODY_TEXT", features.bodyText(), compiled.bodyTextAutomaton(), containsIndex, result);
+        scanFieldWithAutomaton("FROM_ADDRESS", features.fromAddress(), compiled.fromAddressAutomaton(), containsIndex, result);
+        scanFieldWithAutomaton("FROM_DOMAIN", features.fromDomain(), compiled.fromDomainAutomaton(), containsIndex, result);
+
+        for (String toAddress : features.toAddresses()) {
+            scanFieldWithAutomaton("TO_ADDRESS", toAddress, compiled.toAddressAutomaton(), containsIndex, result);
+        }
+        for (String ccAddress : features.ccAddresses()) {
+            scanFieldWithAutomaton("CC_ADDRESS", ccAddress, compiled.ccAddressAutomaton(), containsIndex, result);
+        }
+    }
+
+    private void scanFieldWithAutomaton(
+            String field,
+            String text,
+            AhoCorasickAutomaton automaton,
+            Map<String, List<ConditionRef>> containsIndex,
+            Map<UUID, Map<String, Set<String>>> result
+    ) {
+        if (text == null || text.isBlank() || !automaton.hasPatterns()) {
+            return;
+        }
+
+        Set<String> matchedKeywords = automaton.search(text);
+        for (String keyword : matchedKeywords) {
+            List<ConditionRef> refs = containsIndex.get(keyword);
+            if (refs == null) {
+                continue;
+            }
+            for (ConditionRef ref : refs) {
+                if (!field.equals(ref.field())) {
+                    continue;
+                }
+                result.computeIfAbsent(ref.labelId(), k -> new HashMap<>())
+                        .computeIfAbsent(ref.groupId(), k -> new HashSet<>())
+                        .add(ref.conditionId());
+            }
+        }
+    }
+
+    private boolean evaluateDnf(MessageFeatures features, List<ParsedGroup> groups) {
+        for (ParsedGroup group : groups) {
+            if (evaluateGroup(features, group)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean evaluateGroup(MessageFeatures features, ParsedGroup group) {
+        for (ParsedCondition condition : group.conditions()) {
+            if (!evaluateCondition(features, condition)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean evaluateCondition(MessageFeatures features, ParsedCondition condition) {
+        String field = condition.field();
+        String operator = condition.operator();
+        String value = condition.normalizedValue();
+
+        return switch (field) {
+            case "MAIL_ACCOUNT"   -> evaluateString(features.mailAccountId(), operator, value);
+            case "FROM_ADDRESS"   -> evaluateString(features.fromAddress(), operator, value);
+            case "FROM_DOMAIN"    -> evaluateString(features.fromDomain(), operator, value);
+            case "SUBJECT"        -> evaluateString(features.subject(), operator, value);
+            case "BODY_TEXT"      -> evaluateString(features.bodyText(), operator, value);
+            case "HAS_ATTACHMENT" -> evaluateBoolean(features.hasAttachment(), value);
+            case "TO_ADDRESS"     -> features.toAddresses().stream().anyMatch(addr -> evaluateString(addr, operator, value));
+            case "CC_ADDRESS"     -> features.ccAddresses().stream().anyMatch(addr -> evaluateString(addr, operator, value));
+            default               -> false;
+        };
+    }
+
+    private boolean evaluateString(String target, String operator, String value) {
+        if (target == null) {
+            return "NOT_CONTAINS".equals(operator);
+        }
+        String normalizedTarget = target.trim().toLowerCase();
+        return switch (operator) {
+            case "EQUALS"       -> normalizedTarget.equals(value);
+            case "CONTAINS"     -> normalizedTarget.contains(value);
+            case "NOT_CONTAINS" -> !normalizedTarget.contains(value);
+            default             -> false;
+        };
+    }
+
+    private boolean evaluateBoolean(boolean target, String value) {
+        return target == Boolean.parseBoolean(value);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Feature extraction
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private MessageFeatures extractFeatures(Message message, boolean hasAttachment) {
+        String fromAddress = normalize(message.getFromAddress());
+        String fromDomain = extractDomain(fromAddress);
+        String subject = normalize(message.getSubject());
+        String bodyText = normalize(message.getBodyText());
+        String mailAccountId = message.getThread() != null && message.getThread().getMailAccount() != null
+                ? normalize(message.getThread().getMailAccount().getEmailAddress())
+                : null;
+
+        List<String> toAddresses = normalizeList(message.getToAddresses());
+        List<String> ccAddresses = normalizeList(message.getCcAddresses());
+
+        return new MessageFeatures(mailAccountId, fromAddress, fromDomain, subject, bodyText, hasAttachment, toAddresses, ccAddresses);
+    }
+
+    private String normalize(String value) {
+        if (value == null) return null;
+        return value.trim().toLowerCase();
+    }
+
+    private String extractDomain(String email) {
+        if (email == null || !email.contains("@")) return null;
+        return email.substring(email.indexOf('@') + 1);
+    }
+
+    private List<String> normalizeList(List<String> values) {
+        if (values == null || values.isEmpty()) return List.of();
+        return values.stream()
+                .filter(v -> v != null && !v.isBlank())
+                .map(this::normalize)
+                .toList();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Rule parsing
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private List<ParsedGroup> parseGroups(Label label) {
+        LabelRule rule = label.getRule();
+        if (rule.groups() == null) {
+            return List.of();
+        }
+
+        List<ParsedGroup> result = new ArrayList<>();
+        for (LabelRule.Group group : rule.groups()) {
+            if (group == null || group.conditions() == null) {
+                continue;
+            }
+
+            String groupId = "g" + result.size();
+
+            List<ParsedCondition> conditions = new ArrayList<>();
+            int condIdx = 0;
+            for (LabelRule.Condition condition : group.conditions()) {
+                if (condition == null || condition.field() == null || condition.operator() == null) {
+                    continue;
+                }
+
+                String field = condition.field().name();
+                String operator = condition.operator().name();
+                String normalizedValue = normalize(condition.value());
+                String conditionId = groupId + "_c" + condIdx++;
+
+                if (normalizedValue != null && normalizedValue.length() > MAX_VALUE_LENGTH) {
+                    log.warn("Label condition value too long, skipping. labelId={} field={}", label.getId(), field);
+                    continue;
+                }
+
+                conditions.add(new ParsedCondition(conditionId, field, operator, normalizedValue));
+            }
+            if (!conditions.isEmpty()) {
+                result.add(new ParsedGroup(groupId, conditions));
+            }
+        }
+        return result;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Internal value types
+    // ─────────────────────────────────────────────────────────────────────────
+
+    record ConditionRef(UUID labelId, String groupId, String conditionId, String field, String operator, String normalizedValue) {}
+
+    record ParsedCondition(String conditionId, String field, String operator, String normalizedValue) {}
+
+    record ParsedGroup(String groupId, List<ParsedCondition> conditions) {}
+
+    record MessageFeatures(
+            String mailAccountId,
+            String fromAddress,
+            String fromDomain,
+            String subject,
+            String bodyText,
+            boolean hasAttachment,
+            List<String> toAddresses,
+            List<String> ccAddresses
+    ) {}
+
+    record CompiledRules(
+            Map<String, List<ConditionRef>> equalsIndex,
+            Map<String, List<ConditionRef>> containsIndex,
+            List<ConditionRef> notContainsRefs,
+            Map<UUID, List<ParsedGroup>> parsedGroupsByLabel,
+            AhoCorasickAutomaton subjectAutomaton,
+            AhoCorasickAutomaton bodyTextAutomaton,
+            AhoCorasickAutomaton fromAddressAutomaton,
+            AhoCorasickAutomaton fromDomainAutomaton,
+            AhoCorasickAutomaton toAddressAutomaton,
+            AhoCorasickAutomaton ccAddressAutomaton
+    ) {}
+}

--- a/worker/src/main/java/com/mailsangja/worker/handler/label/LabelRuleCompiler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/label/LabelRuleCompiler.java
@@ -63,6 +63,7 @@ public class LabelRuleCompiler {
         Map<String, List<ConditionRef>> equalsIndex = new HashMap<>();
         Map<String, List<ConditionRef>> containsIndex = new HashMap<>();
         List<ConditionRef> notContainsRefs = new ArrayList<>();
+        Set<UUID> notContainsLabelIds = new HashSet<>();
         Map<UUID, List<ParsedGroup>> parsedGroupsByLabel = new HashMap<>();
 
         AhoCorasickAutomaton subjectAutomaton = new AhoCorasickAutomaton();
@@ -102,7 +103,10 @@ public class LabelRuleCompiler {
                                         fromAddressAutomaton, fromDomainAutomaton, toAddressAutomaton, ccAddressAutomaton);
                             }
                         }
-                        case "NOT_CONTAINS" -> notContainsRefs.add(ref);
+                        case "NOT_CONTAINS" -> {
+                            notContainsRefs.add(ref);
+                            notContainsLabelIds.add(label.getId());
+                        }
                         default -> { /* validated upstream */ }
                     }
                 }
@@ -120,6 +124,7 @@ public class LabelRuleCompiler {
                 equalsIndex,
                 containsIndex,
                 notContainsRefs,
+                notContainsLabelIds,
                 parsedGroupsByLabel,
                 subjectAutomaton,
                 bodyTextAutomaton,
@@ -163,7 +168,9 @@ public class LabelRuleCompiler {
         collectEqualsMatches(features, compiled, matchedCondIdsByLabelByGroup);
         collectContainsMatches(features, compiled, matchedCondIdsByLabelByGroup);
 
-        if (matchedCondIdsByLabelByGroup.isEmpty()) {
+        Set<UUID> candidateLabelIds = new HashSet<>(matchedCondIdsByLabelByGroup.keySet());
+        candidateLabelIds.addAll(compiled.notContainsLabelIds());
+        if (candidateLabelIds.isEmpty()) {
             return List.of();
         }
 
@@ -173,7 +180,7 @@ public class LabelRuleCompiler {
         }
 
         List<Label> matched = new ArrayList<>();
-        for (UUID candidateLabelId : matchedCondIdsByLabelByGroup.keySet()) {
+        for (UUID candidateLabelId : candidateLabelIds) {
             Label label = labelById.get(candidateLabelId);
             if (label == null) {
                 continue;
@@ -322,8 +329,12 @@ public class LabelRuleCompiler {
             case "SUBJECT"        -> evaluateString(features.subject(), operator, value);
             case "BODY_TEXT"      -> evaluateString(features.bodyText(), operator, value);
             case "HAS_ATTACHMENT" -> evaluateBoolean(features.hasAttachment(), value);
-            case "TO_ADDRESS"     -> features.toAddresses().stream().anyMatch(addr -> evaluateString(addr, operator, value));
-            case "CC_ADDRESS"     -> features.ccAddresses().stream().anyMatch(addr -> evaluateString(addr, operator, value));
+            case "TO_ADDRESS"     -> "NOT_CONTAINS".equals(operator)
+                    ? features.toAddresses().stream().allMatch(addr -> evaluateString(addr, operator, value))
+                    : features.toAddresses().stream().anyMatch(addr -> evaluateString(addr, operator, value));
+            case "CC_ADDRESS"     -> "NOT_CONTAINS".equals(operator)
+                    ? features.ccAddresses().stream().allMatch(addr -> evaluateString(addr, operator, value))
+                    : features.ccAddresses().stream().anyMatch(addr -> evaluateString(addr, operator, value));
             default               -> false;
         };
     }
@@ -451,6 +462,7 @@ public class LabelRuleCompiler {
             Map<String, List<ConditionRef>> equalsIndex,
             Map<String, List<ConditionRef>> containsIndex,
             List<ConditionRef> notContainsRefs,
+            Set<UUID> notContainsLabelIds,
             Map<UUID, List<ParsedGroup>> parsedGroupsByLabel,
             AhoCorasickAutomaton subjectAutomaton,
             AhoCorasickAutomaton bodyTextAutomaton,

--- a/worker/src/main/java/com/mailsangja/worker/handler/label/LabelRuleCompiler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/label/LabelRuleCompiler.java
@@ -208,6 +208,8 @@ public class LabelRuleCompiler {
         checkEqualsField("MAIL_ACCOUNT", features.mailAccountId(), equalsIndex, result);
         checkEqualsField("FROM_DOMAIN", features.fromDomain(), equalsIndex, result);
         checkEqualsField("FROM_ADDRESS", features.fromAddress(), equalsIndex, result);
+        checkEqualsField("SUBJECT", features.subject(), equalsIndex, result);
+        checkEqualsField("BODY_TEXT", features.bodyText(), equalsIndex, result);
 
         if (features.hasAttachment()) {
             collectFromIndex("HAS_ATTACHMENT:true", equalsIndex, result);

--- a/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
@@ -28,7 +28,11 @@ public class MessageAddedHistoryEventHandler {
         gmailNewMessageSyncCommandService.syncNewMessage(mailAccount, event).ifPresent(context -> {
             Set<UUID> activeLabelIds = labelQueryService.findActiveLabelIdsByUserId(mailAccount.getUser().getId());
             if (!activeLabelIds.isEmpty()) {
-                labelReclassifyPublisher.publish(new LabelReclassifyMessage(mailAccount.getUser().getId(), activeLabelIds));
+                try {
+                    labelReclassifyPublisher.publish(new LabelReclassifyMessage(mailAccount.getUser().getId(), activeLabelIds));
+                } catch (Exception e) {
+                    log.warn("Label reclassify publish skipped: userId={} error={}", mailAccount.getUser().getId(), e.getMessage());
+                }
             }
 
             try {

--- a/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
@@ -2,11 +2,17 @@ package com.mailsangja.worker.handler.mail;
 
 import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.worker.dto.gmail.history.GmailHistoryEvent;
+import com.mailsangja.worker.dto.label.LabelReclassifyMessage;
+import com.mailsangja.worker.messaging.publisher.LabelReclassifyPublisher;
 import com.mailsangja.worker.service.mail.GmailNewMessageSyncCommandService;
+import com.mailsangja.worker.service.label.LabelQueryService;
 import com.mailsangja.worker.service.notification.FcmPushCommandService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+
+import java.util.Set;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -14,10 +20,17 @@ import org.springframework.stereotype.Component;
 public class MessageAddedHistoryEventHandler {
 
     private final GmailNewMessageSyncCommandService gmailNewMessageSyncCommandService;
+    private final LabelQueryService labelQueryService;
+    private final LabelReclassifyPublisher labelReclassifyPublisher;
     private final FcmPushCommandService fcmPushCommandService;
 
     public void handle(MailAccount mailAccount, GmailHistoryEvent event) {
         gmailNewMessageSyncCommandService.syncNewMessage(mailAccount, event).ifPresent(context -> {
+            Set<UUID> activeLabelIds = labelQueryService.findActiveLabelIdsByUserId(mailAccount.getUser().getId());
+            if (!activeLabelIds.isEmpty()) {
+                labelReclassifyPublisher.publish(new LabelReclassifyMessage(mailAccount.getUser().getId(), activeLabelIds));
+            }
+
             try {
                 fcmPushCommandService.sendNewMailPush(context);
             } catch (Exception e) {

--- a/worker/src/main/java/com/mailsangja/worker/messaging/listener/LabelReclassificationListener.java
+++ b/worker/src/main/java/com/mailsangja/worker/messaging/listener/LabelReclassificationListener.java
@@ -45,6 +45,11 @@ public class LabelReclassificationListener {
         UUID userId = message.userId();
         Set<UUID> targetLabelIds = message.labelIds();
 
+        if (targetLabelIds == null || targetLabelIds.isEmpty()) {
+            log.info("LabelReclassification skipped — empty target labels for userId={}", userId);
+            return;
+        }
+
         log.info("LabelReclassification started for userId={} targetLabelCount={}", userId, targetLabelIds.size());
 
         List<Label> activeLabels = labelQueryService.findAllActiveByUserId(userId);

--- a/worker/src/main/java/com/mailsangja/worker/messaging/listener/LabelReclassificationListener.java
+++ b/worker/src/main/java/com/mailsangja/worker/messaging/listener/LabelReclassificationListener.java
@@ -1,0 +1,69 @@
+package com.mailsangja.worker.messaging.listener;
+
+import com.mailsangja.db.entity.label.Label;
+import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.worker.dto.label.LabelReclassifyMessage;
+import com.mailsangja.worker.handler.label.LabelRuleCompiler;
+import com.mailsangja.worker.service.label.LabelQueryService;
+import com.mailsangja.worker.service.label.MessageLabelCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * 라벨 재분류 MQ 메시지 수신 진입점.
+ *
+ * 흐름:
+ * 1. 대상 라벨 ID 목록 기준으로 사용자 활성 라벨 로드
+ * 2. 사용자의 활성 메시지 로드 (labels EntityGraph)
+ * 3. 첨부파일 보유 메시지 ID 집합 로드 (별도 쿼리)
+ * 4. LabelRuleCompiler로 메시지별 대상 라벨 적용 여부 계산
+ * 5. MessageLabelCommandService로 대상 라벨만 idempotent 반영
+ *
+ * 재시도 / DLQ 정책은 labelReclassifyRabbitListenerContainerFactory에 위임한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LabelReclassificationListener {
+
+    private final LabelQueryService labelQueryService;
+    private final MessageLabelCommandService messageLabelCommandService;
+    private final LabelRuleCompiler labelRuleCompiler;
+
+    @RabbitListener(
+            queues = "#{@labelReclassifyQueue.name}",
+            containerFactory = "labelReclassifyRabbitListenerContainerFactory"
+    )
+    public void handle(LabelReclassifyMessage message) {
+        UUID userId = message.userId();
+        Set<UUID> targetLabelIds = message.labelIds();
+
+        log.info("LabelReclassification started for userId={} targetLabelCount={}", userId, targetLabelIds.size());
+
+        List<Label> activeLabels = labelQueryService.findAllActiveByUserId(userId);
+        List<Label> targetLabels = activeLabels.stream()
+                .filter(label -> targetLabelIds.contains(label.getId()))
+                .toList();
+        List<Message> messages = labelQueryService.findAllActiveMessagesWithLabelsByUserId(userId);
+
+        if (messages.isEmpty()) {
+            log.info("LabelReclassification skipped — no messages for userId={}", userId);
+            return;
+        }
+
+        Set<UUID> messageIdsWithAttachments = labelQueryService.findMessageIdsWithAttachmentsByUserId(userId);
+
+        Map<UUID, List<Label>> labelsByMessageId = labelRuleCompiler.compile(targetLabels, messages, messageIdsWithAttachments);
+        messageLabelCommandService.applyLabels(messages, labelsByMessageId, targetLabelIds);
+
+        log.info("LabelReclassification completed for userId={} targetLabelCount={} messagesProcessed={}",
+                userId, targetLabelIds.size(), messages.size());
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/messaging/publisher/LabelReclassifyPublisher.java
+++ b/worker/src/main/java/com/mailsangja/worker/messaging/publisher/LabelReclassifyPublisher.java
@@ -1,0 +1,45 @@
+package com.mailsangja.worker.messaging.publisher;
+
+import com.mailsangja.worker.config.properties.LabelReclassifyRabbitProperties;
+import com.mailsangja.worker.config.properties.MailTaskRabbitProperties;
+import com.mailsangja.worker.dto.label.LabelReclassifyMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LabelReclassifyPublisher {
+
+    private final RabbitTemplate rabbitTemplate;
+    private final MailTaskRabbitProperties mailTaskRabbitProperties;
+    private final LabelReclassifyRabbitProperties labelReclassifyRabbitProperties;
+
+    public void publish(LabelReclassifyMessage message) {
+        try {
+            rabbitTemplate.convertAndSend(
+                    mailTaskRabbitProperties.getExchange(),
+                    labelReclassifyRabbitProperties.getRoutingKey(),
+                    message,
+                    new CorrelationData(message.userId() + ":" + message.labelIds().size())
+            );
+            log.info(
+                    "Published label reclassify request for userId={} labelCount={}",
+                    message.userId(),
+                    message.labelIds().size()
+            );
+        } catch (AmqpException e) {
+            log.warn(
+                    "Failed to publish label reclassify request for userId={} labelCount={}",
+                    message.userId(),
+                    message.labelIds().size(),
+                    e
+            );
+            throw e;
+        }
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/service/label/LabelQueryService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/label/LabelQueryService.java
@@ -1,0 +1,55 @@
+package com.mailsangja.worker.service.label;
+
+import com.mailsangja.db.entity.label.Label;
+import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.port.LabelRepositoryPort;
+import com.mailsangja.db.port.MessageRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class LabelQueryService {
+
+    // ⚠️ Label 재분류 유스케이스에서 mail 도메인(Message) 읽기가 필요해 cross-domain Repository를 함께 참조한다.
+    private final LabelRepositoryPort labelRepositoryPort;
+    private final MessageRepositoryPort messageRepositoryPort;
+
+    public List<Label> findAllActiveByUserId(UUID userId) {
+        return labelRepositoryPort.findAllByUserIdAndDeletedAtIsNull(userId);
+    }
+
+    public Set<UUID> findActiveLabelIdsByUserId(UUID userId) {
+        return findAllActiveByUserId(userId).stream()
+                .map(Label::getId)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * 사용자의 활성 메시지를 labels 컬렉션과 함께 로드한다.
+     * hasAttachment 정보는 별도 쿼리로 조회하여 MessageFeatureContext에서 제공한다.
+     *
+     * @return labels가 초기화된 메시지 목록
+     */
+    public List<Message> findAllActiveMessagesWithLabelsByUserId(UUID userId) {
+        return messageRepositoryPort.findAllByUserIdAndDeletedAtIsNullWithLabels(userId);
+    }
+
+    /**
+     * 사용자의 메시지 중 첨부파일이 있는 메시지 ID 집합을 반환한다.
+     * labels와 attachments를 동시에 fetch join하면 MultipleBagFetchException이 발생하므로 분리한다.
+     */
+    public Set<UUID> findMessageIdsWithAttachmentsByUserId(UUID userId) {
+        List<Message> messagesWithAttachments = messageRepositoryPort.findAllByUserIdAndDeletedAtIsNullWithAttachments(userId);
+        return messagesWithAttachments.stream()
+                .filter(m -> m.getAttachments() != null && !m.getAttachments().isEmpty())
+                .map(Message::getId)
+                .collect(Collectors.toSet());
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/service/label/MessageLabelCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/label/MessageLabelCommandService.java
@@ -11,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,8 +52,10 @@ public class MessageLabelCommandService {
             Set<UUID> desiredTargetLabelIds = toIdSet(targetLabels);
 
             if (!currentTargetLabelIds.equals(desiredTargetLabelIds)) {
-                List<MessageLabel> newMessageLabels = mergeMessageLabels(message, targetLabels, targetLabelIds);
-                message.replaceMessageLabels(newMessageLabels);
+                List<MessageLabel> newTargetEntries = targetLabels.stream()
+                        .map(label -> MessageLabel.of(message, label))
+                        .toList();
+                message.applyTargetLabels(targetLabelIds, newTargetEntries);
                 changed.add(message);
             }
         }
@@ -63,24 +64,6 @@ public class MessageLabelCommandService {
             messageRepositoryPort.saveAll(changed);
             log.info("Applied label reclassification to {} messages", changed.size());
         }
-    }
-
-    private List<MessageLabel> mergeMessageLabels(Message message, List<Label> targetLabels, Set<UUID> targetLabelIds) {
-        Map<UUID, Label> mergedLabels = new LinkedHashMap<>();
-        if (message.getMessageLabels() != null) {
-            for (MessageLabel messageLabel : message.getMessageLabels()) {
-                UUID existingLabelId = messageLabel.getLabel().getId();
-                if (!targetLabelIds.contains(existingLabelId)) {
-                    mergedLabels.put(existingLabelId, messageLabel.getLabel());
-                }
-            }
-        }
-        for (Label targetLabel : targetLabels) {
-            mergedLabels.put(targetLabel.getId(), targetLabel);
-        }
-        return mergedLabels.values().stream()
-                .map(label -> MessageLabel.of(message, label))
-                .toList();
     }
 
     private Set<UUID> toLabelIdSet(List<MessageLabel> messageLabels) {

--- a/worker/src/main/java/com/mailsangja/worker/service/label/MessageLabelCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/label/MessageLabelCommandService.java
@@ -1,0 +1,107 @@
+package com.mailsangja.worker.service.label;
+
+import com.mailsangja.db.entity.label.Label;
+import com.mailsangja.db.entity.label.MessageLabel;
+import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.port.MessageRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MessageLabelCommandService {
+
+    private final MessageRepositoryPort messageRepositoryPort;
+
+    /**
+     * 각 메시지에 적용할 라벨 목록을 idempotent하게 반영한다.
+     * targetLabelIds에 포함된 라벨만 갱신하며, 그 외 라벨은 유지한다.
+     *
+     * @param messages          업데이트 대상 메시지 목록 (messageLabels 컬렉션이 초기화된 상태여야 함)
+     * @param labelsByMessageId 메시지 ID → 대상 라벨 중 적용할 Label 목록
+     * @param targetLabelIds    재분류 대상 Label ID 목록
+     */
+    @Transactional
+    public void applyLabels(
+            List<Message> messages,
+            Map<UUID, List<Label>> labelsByMessageId,
+            Set<UUID> targetLabelIds
+    ) {
+        if (targetLabelIds == null || targetLabelIds.isEmpty()) {
+            return;
+        }
+
+        List<Message> changed = new ArrayList<>();
+        for (Message message : messages) {
+            List<Label> targetLabels = labelsByMessageId.getOrDefault(message.getId(), List.of());
+
+            Set<UUID> currentLabelIds = toLabelIdSet(message.getMessageLabels());
+            Set<UUID> currentTargetLabelIds = currentLabelIds.stream()
+                    .filter(targetLabelIds::contains)
+                    .collect(HashSet::new, HashSet::add, HashSet::addAll);
+            Set<UUID> desiredTargetLabelIds = toIdSet(targetLabels);
+
+            if (!currentTargetLabelIds.equals(desiredTargetLabelIds)) {
+                List<MessageLabel> newMessageLabels = mergeMessageLabels(message, targetLabels, targetLabelIds);
+                message.replaceMessageLabels(newMessageLabels);
+                changed.add(message);
+            }
+        }
+
+        if (!changed.isEmpty()) {
+            messageRepositoryPort.saveAll(changed);
+            log.info("Applied label reclassification to {} messages", changed.size());
+        }
+    }
+
+    private List<MessageLabel> mergeMessageLabels(Message message, List<Label> targetLabels, Set<UUID> targetLabelIds) {
+        Map<UUID, Label> mergedLabels = new LinkedHashMap<>();
+        if (message.getMessageLabels() != null) {
+            for (MessageLabel messageLabel : message.getMessageLabels()) {
+                UUID existingLabelId = messageLabel.getLabel().getId();
+                if (!targetLabelIds.contains(existingLabelId)) {
+                    mergedLabels.put(existingLabelId, messageLabel.getLabel());
+                }
+            }
+        }
+        for (Label targetLabel : targetLabels) {
+            mergedLabels.put(targetLabel.getId(), targetLabel);
+        }
+        return mergedLabels.values().stream()
+                .map(label -> MessageLabel.of(message, label))
+                .toList();
+    }
+
+    private Set<UUID> toLabelIdSet(List<MessageLabel> messageLabels) {
+        if (messageLabels == null || messageLabels.isEmpty()) {
+            return Set.of();
+        }
+        Set<UUID> ids = new HashSet<>();
+        for (MessageLabel ml : messageLabels) {
+            ids.add(ml.getLabel().getId());
+        }
+        return ids;
+    }
+
+    private Set<UUID> toIdSet(List<Label> labels) {
+        if (labels == null || labels.isEmpty()) {
+            return Set.of();
+        }
+        Set<UUID> ids = new HashSet<>();
+        for (Label label : labels) {
+            ids.add(label.getId());
+        }
+        return ids;
+    }
+}

--- a/worker/src/main/resources/application-mq.yaml
+++ b/worker/src/main/resources/application-mq.yaml
@@ -15,5 +15,3 @@ mailsangja:
       retry-max-attempts: ${MAIL_TASK_RETRY_MAX_ATTEMPTS:3}
       concurrency: ${MAIL_TASK_CONCURRENCY:1}
       publisher-mandatory: ${MAIL_TASK_PUBLISHER_MANDATORY:true}
-    label-reclassify:
-      task-name: ${LABEL_RECLASSIFY_TASK_NAME:label.reclassify}

--- a/worker/src/main/resources/application-mq.yaml
+++ b/worker/src/main/resources/application-mq.yaml
@@ -15,3 +15,5 @@ mailsangja:
       retry-max-attempts: ${MAIL_TASK_RETRY_MAX_ATTEMPTS:3}
       concurrency: ${MAIL_TASK_CONCURRENCY:1}
       publisher-mandatory: ${MAIL_TASK_PUBLISHER_MANDATORY:true}
+    label-reclassify:
+      task-name: ${LABEL_RECLASSIFY_TASK_NAME:label.reclassify}


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#16
- mailsangja/docs4capstone#17

### 📌 Task

 - Closes #71
 - Closes #73
 - Closes #74
 - Closes #75
 - Closes #81

## 💡 작업 내용

 - 라벨 CRUD API(조회/생성/수정/규칙수정/삭제)와 Facade-Service-Repository 흐름을 구현했습니다.
 - 라벨 재분류 MQ payload를 labelId 단건에서 labelIds 목록으로 확장해, 대상 라벨만 부분 재분류하도록 변경했습니다.
 - 신규 메시지 유입 시에는 사용자 활성 라벨 ID 전체를 대상으로 재분류를 발행합니다.
 - 라벨 삭제는 MQ 재분류를 거치지 않고, message_labels/thread_labels를 DB에서 즉시 제거한 뒤 Label soft delete 처리하도록 변경했습니다.
 - Worker에서 규칙 컴파일(라벨 매칭) 후, targetLabelIds만 idempotent하게 반영하고 비대상 라벨은 보존하도록 적용 로직을 분리했습니다.


## 📝 추가 설명

### 1. 라벨 생성/수정/삭제 핵심 흐름

 - 생성(POST /api/v1/labels): 요청 검증 → Label 저장 → rule 존재 시 LabelReclassifyMessage(userId, {labelId}) 발행
 - 일반 수정(PATCH /api/v1/labels/{labelId}): 메타데이터(name/color/order/notification)만 갱신, 재분류 미발행
 - 규칙 수정(PATCH /api/v1/labels/{labelId}/rule): rule 갱신 후 해당 라벨 ID만 재분류 발행
 - 삭제(DELETE /api/v1/labels/{labelId}): message_labels, thread_labels 즉시 삭제 후 label soft delete (MQ 미사용)

```mermaid
 flowchart TD
     A[LabelController] --> B[LabelFacade]
     B --> C[LabelService-Query, Command]

     B --> E[LabelReclassifyPublisher]

     B -->|신규 라벨 생성 + 규칙 존재시| E
     B -->|규칙 수정| E
     B -->|라벨 삭제| D
```


### 2. 재분류 비동기 처리 흐름(라벨 신규 생성 및 규칙 수정·추가로 인한 대상 라벨 부분 갱신)

 - CorePublisher가 LabelReclassifyMessage(userId, labelIds) 발행
 - Worker Listener가 활성 라벨 중 재분류가 필요한 targetLabelIds만 필터링
 - 메시지/첨부 조회 후 규칙 컴파일
 - MessageLabelCommandService.applyLabels(..., targetLabelIds)에서 대상 라벨만 교체하고 나머지 라벨은 유지

```mermaid
 flowchart LR
     P1[CorePublisher] --> Q[(RabbitMQ)]
     Q --> L[LabelReclassificationListener]
     L --> S1[활성 라벨 조회]
     L --> S2[활성 메시지+첨부 조회]
     L --> C[LabelRuleCompiler]
     C --> M[MessageLabelCommandService]
     M --> DB[(message_labels 업데이트)]
```

### 3. 설계 이유

 - 삭제 케이스는 “규칙 재평가”가 아니라 “관계 제거”가 목적이므로 재분류 작업을 발행하지 않고, 동기 bulk delete 방식을 통해 처리합니다.
 - 재분류 시 전체 라벨 재기록이 아닌 재분류 대상 라벨만을 Set을 통해 부분 갱신으로 변경해 불필요한 write를 줄였습니다.
 - 메시지+첨부 동시 fetch join으로 인한 MultipleBagFetchException을 피하기 위해 조회를 분리했습니다.


### 4. 앞으로의 Task (후속 작업)

  1. 신규 메일 도착 라벨링 동기 처리 + 알림 연동
     - 신규 메시지 저장 직후 라벨링을 동기적으로 수행하고, 적용된 라벨 중 notificationEnabled=true 라벨 기준으로 푸시 발송
     - 목표: 라벨 적용 지연 없이 사용자 알림 일관성 확보

  2. 계정 초기 동기화(ThreadBatch) 시 동기 라벨링
     - 초기 동기화 배치에서 Thread/Message 저장 단계와 라벨링 단계를 같은 처리 단위로 묶어 동기 적용
     - 목표: 초기 동기화 완료 시점에 라벨 상태가 즉시 정합하도록 보장

  3. 라벨 매칭 엔진 org.ahocorasick:ahocorasick 기반 리팩토링
     - 현재 커스텀 Aho-Corasick 구현을 외부 검증 라이브러리 기반으로 교체
     - 목표: 유지보수성 향상, 알고리즘 안정성 확보, 성능 회귀 최소화
  
 4. Inbox, Trash 조회시 라벨링 결과를 포함 추가
   - 추가적으로, Trash 조회 양식을 Inbox 처리 와 같은 양식으로 응답하도록합니다 (라벨 포함).


## ⚡️ Test 결과

| 기능 1 | 기능 2 | 기능 3 | 기능 4 |
| -- | -- | -- | -- |
| POST | PATCH | PATCH | DELETE |
| /api/v1/labels | /api/v1/labels/{labelId} | /api/v1/labels/{labelId}/rule | /api/v1/labels/{labelId} |
| 라벨 생성 및 rule 존재 시 재분류 발행 확인 | 라벨 메타데이터 수정 확인 | 대상 라벨 ID 기반 재분류 발행/적용 확인 | message/thread 라벨 매핑 즉시 제거 + label soft delete 확인 |
| <img width="1374" height="691" alt="image" src="https://github.com/user-attachments/assets/27f7f79d-6580-48be-8a0d-874b4d35db97" /> | <img width="939" height="720" alt="image" src="https://github.com/user-attachments/assets/d6589ddc-7588-4c2d-a8ad-535f193be092" /> |  <img width="1064" height="690" alt="image" src="https://github.com/user-attachments/assets/126585a6-d3c7-4e8e-a052-efd7359537f9" /> |  <img width="1044" height="499" alt="image" src="https://github.com/user-attachments/assets/317d1686-1d46-470e-8057-c21731415217" /> |
| <img width="1132" height="161" alt="image" src="https://github.com/user-attachments/assets/833f3106-e570-4fad-9b07-1f711d749812" /> | 재분류 X | <img width="1131" height="270" alt="image" src="https://github.com/user-attachments/assets/3239a69e-f33d-472e-bc67-dd3b3b4ad3e6" /> | <img width="733" height="238" alt="image" src="https://github.com/user-attachments/assets/ad58fbb6-656a-4b97-9a8c-74b2e980e1e3" /> |



