### PR TITLE
[STORY-307] 주소록 동기화 및 CRUD API 구현

### DIFF
--- a/core/src/main/java/com/mailsangja/core/common/exception/contact/ContactErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/contact/ContactErrorCode.java
@@ -1,0 +1,18 @@
+package com.mailsangja.core.common.exception.contact;
+
+import com.mailsangja.core.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ContactErrorCode implements ErrorCode {
+
+    INVALID_CONTACT_SYNC_REQUEST(400, "MS-CONTACT-INVALID-SYNC-REQUEST", "주소록 동기화 요청 값이 올바르지 않습니다."),
+    GOOGLE_CONTACTS_FETCH_FAILED(502, "MS-CONTACT-GOOGLE-CONTACTS-FETCH-FAILED", "Google Contacts 조회에 실패했습니다."),
+    GOOGLE_CONTACTS_RESULT_INVALID(502, "MS-CONTACT-GOOGLE-CONTACTS-RESULT-INVALID", "Google Contacts 응답값이 올바르지 않습니다.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/core/src/main/java/com/mailsangja/core/common/exception/contact/ContactErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/contact/ContactErrorCode.java
@@ -8,7 +8,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ContactErrorCode implements ErrorCode {
 
+    INVALID_CONTACT_REQUEST(400, "MS-CONTACT-INVALID-REQUEST", "주소록 요청 값이 올바르지 않습니다."),
     INVALID_CONTACT_SYNC_REQUEST(400, "MS-CONTACT-INVALID-SYNC-REQUEST", "주소록 동기화 요청 값이 올바르지 않습니다."),
+    CONTACT_EMAIL_DUPLICATE(409, "MS-CONTACT-EMAIL-DUPLICATE", "이미 등록된 주소록 이메일입니다."),
     GOOGLE_CONTACTS_FETCH_FAILED(502, "MS-CONTACT-GOOGLE-CONTACTS-FETCH-FAILED", "Google Contacts 조회에 실패했습니다."),
     GOOGLE_CONTACTS_RESULT_INVALID(502, "MS-CONTACT-GOOGLE-CONTACTS-RESULT-INVALID", "Google Contacts 응답값이 올바르지 않습니다.");
 

--- a/core/src/main/java/com/mailsangja/core/common/exception/contact/ContactErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/contact/ContactErrorCode.java
@@ -10,6 +10,7 @@ public enum ContactErrorCode implements ErrorCode {
 
     INVALID_CONTACT_REQUEST(400, "MS-CONTACT-INVALID-REQUEST", "주소록 요청 값이 올바르지 않습니다."),
     INVALID_CONTACT_SYNC_REQUEST(400, "MS-CONTACT-INVALID-SYNC-REQUEST", "주소록 동기화 요청 값이 올바르지 않습니다."),
+    CONTACT_NOT_FOUND(404, "MS-CONTACT-NOT-FOUND", "주소록을 찾을 수 없습니다."),
     CONTACT_EMAIL_DUPLICATE(409, "MS-CONTACT-EMAIL-DUPLICATE", "이미 등록된 주소록 이메일입니다."),
     GOOGLE_CONTACTS_FETCH_FAILED(502, "MS-CONTACT-GOOGLE-CONTACTS-FETCH-FAILED", "Google Contacts 조회에 실패했습니다."),
     GOOGLE_CONTACTS_RESULT_INVALID(502, "MS-CONTACT-GOOGLE-CONTACTS-RESULT-INVALID", "Google Contacts 응답값이 올바르지 않습니다.");

--- a/core/src/main/java/com/mailsangja/core/common/exception/contact/ContactException.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/contact/ContactException.java
@@ -1,0 +1,10 @@
+package com.mailsangja.core.common.exception.contact;
+
+import com.mailsangja.core.common.exception.BaseException;
+
+public class ContactException extends BaseException {
+
+    public ContactException(ContactErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/config/GooglePeopleClientConfig.java
+++ b/core/src/main/java/com/mailsangja/core/config/GooglePeopleClientConfig.java
@@ -12,8 +12,8 @@ public class GooglePeopleClientConfig {
     @Bean
     public RestClient googlePeopleRestClient(GooglePeopleProperties properties) {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-        requestFactory.setConnectTimeout((int) properties.getConnectTimeout().toMillis());
-        requestFactory.setReadTimeout((int) properties.getReadTimeout().toMillis());
+        requestFactory.setConnectTimeout(Math.toIntExact(properties.getConnectTimeout().toMillis()));
+        requestFactory.setReadTimeout(Math.toIntExact(properties.getReadTimeout().toMillis()));
 
         return RestClient.builder()
                 .requestFactory(requestFactory)

--- a/core/src/main/java/com/mailsangja/core/config/GooglePeopleClientConfig.java
+++ b/core/src/main/java/com/mailsangja/core/config/GooglePeopleClientConfig.java
@@ -1,0 +1,22 @@
+package com.mailsangja.core.config;
+
+import com.mailsangja.core.config.properties.GooglePeopleProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class GooglePeopleClientConfig {
+
+    @Bean
+    public RestClient googlePeopleRestClient(GooglePeopleProperties properties) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout((int) properties.getConnectTimeout().toMillis());
+        requestFactory.setReadTimeout((int) properties.getReadTimeout().toMillis());
+
+        return RestClient.builder()
+                .requestFactory(requestFactory)
+                .build();
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/config/properties/GooglePeopleProperties.java
+++ b/core/src/main/java/com/mailsangja/core/config/properties/GooglePeopleProperties.java
@@ -17,6 +17,7 @@ public class GooglePeopleProperties {
     private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(10);
 
     private String connectionsUri;
+    private String otherContactsUri;
     private int pageSize = 1000;
     private Duration connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     private Duration readTimeout = DEFAULT_READ_TIMEOUT;

--- a/core/src/main/java/com/mailsangja/core/config/properties/GooglePeopleProperties.java
+++ b/core/src/main/java/com/mailsangja/core/config/properties/GooglePeopleProperties.java
@@ -1,0 +1,23 @@
+package com.mailsangja.core.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "mailsangja.google.people")
+public class GooglePeopleProperties {
+
+    private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(3);
+    private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(10);
+
+    private String connectionsUri;
+    private int pageSize = 1000;
+    private Duration connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+    private Duration readTimeout = DEFAULT_READ_TIMEOUT;
+}

--- a/core/src/main/java/com/mailsangja/core/controller/ContactController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/ContactController.java
@@ -1,0 +1,43 @@
+package com.mailsangja.core.controller;
+
+import com.mailsangja.core.common.auth.AuthUser;
+import com.mailsangja.core.controller.docs.ContactControllerDocs;
+import com.mailsangja.core.dto.contact.ContactCreateRequest;
+import com.mailsangja.core.dto.contact.ContactResponse;
+import com.mailsangja.core.facade.ContactFacade;
+import com.mailsangja.db.entity.user.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ContactController implements ContactControllerDocs {
+
+    private final ContactFacade contactFacade;
+
+    @Override
+    @PostMapping("/api/v1/contacts")
+    public ResponseEntity<ContactResponse> createContact(
+            @AuthUser User user,
+            @Valid @RequestBody ContactCreateRequest request
+    ) {
+        return ResponseEntity.ok(contactFacade.createContact(user, request));
+    }
+
+    @Override
+    @GetMapping("/api/v1/contacts")
+    public ResponseEntity<List<ContactResponse>> getContacts(
+            @AuthUser User user,
+            @RequestParam(required = false) String keyword
+    ) {
+        return ResponseEntity.ok(contactFacade.getContacts(user, keyword));
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/controller/ContactController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/ContactController.java
@@ -4,18 +4,23 @@ import com.mailsangja.core.common.auth.AuthUser;
 import com.mailsangja.core.controller.docs.ContactControllerDocs;
 import com.mailsangja.core.dto.contact.ContactCreateRequest;
 import com.mailsangja.core.dto.contact.ContactResponse;
+import com.mailsangja.core.dto.contact.ContactUpdateRequest;
 import com.mailsangja.core.facade.ContactFacade;
 import com.mailsangja.db.entity.user.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,5 +44,25 @@ public class ContactController implements ContactControllerDocs {
             @RequestParam(required = false) String keyword
     ) {
         return ResponseEntity.ok(contactFacade.getContacts(user, keyword));
+    }
+
+    @Override
+    @PatchMapping("/api/v1/contacts/{contactId}")
+    public ResponseEntity<ContactResponse> updateContact(
+            @AuthUser User user,
+            @PathVariable UUID contactId,
+            @Valid @RequestBody ContactUpdateRequest request
+    ) {
+        return ResponseEntity.ok(contactFacade.updateContact(user, contactId, request));
+    }
+
+    @Override
+    @DeleteMapping("/api/v1/contacts/{contactId}")
+    public ResponseEntity<Void> deleteContact(
+            @AuthUser User user,
+            @PathVariable UUID contactId
+    ) {
+        contactFacade.deleteContact(user, contactId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/core/src/main/java/com/mailsangja/core/controller/docs/ContactControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/ContactControllerDocs.java
@@ -3,6 +3,7 @@ package com.mailsangja.core.controller.docs;
 import com.mailsangja.core.common.auth.AuthUser;
 import com.mailsangja.core.dto.contact.ContactCreateRequest;
 import com.mailsangja.core.dto.contact.ContactResponse;
+import com.mailsangja.core.dto.contact.ContactUpdateRequest;
 import com.mailsangja.db.entity.user.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -13,10 +14,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
+import java.util.UUID;
 
 @Tag(name = "Contact", description = "주소록 API")
 public interface ContactControllerDocs {
@@ -45,5 +48,32 @@ public interface ContactControllerDocs {
     ResponseEntity<List<ContactResponse>> getContacts(
             @Parameter(hidden = true) @AuthUser User user,
             @Parameter(description = "이름 또는 이메일 검색어") @RequestParam(required = false) String keyword
+    );
+
+    @Operation(summary = "주소록 이름 수정", description = "로그인한 사용자의 활성 연락처 이름만 수정합니다.",
+            security = @SecurityRequirement(name = "cookieAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주소록 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 요청",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "주소록을 찾을 수 없음",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<ContactResponse> updateContact(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "주소록 ID", required = true) @PathVariable UUID contactId,
+            @RequestBody ContactUpdateRequest request
+    );
+
+    @Operation(summary = "주소록 삭제", description = "로그인한 사용자의 활성 연락처를 soft delete 처리합니다.",
+            security = @SecurityRequirement(name = "cookieAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "주소록 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "주소록을 찾을 수 없음",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<Void> deleteContact(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "주소록 ID", required = true) @PathVariable UUID contactId
     );
 }

--- a/core/src/main/java/com/mailsangja/core/controller/docs/ContactControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/ContactControllerDocs.java
@@ -1,0 +1,49 @@
+package com.mailsangja.core.controller.docs;
+
+import com.mailsangja.core.common.auth.AuthUser;
+import com.mailsangja.core.dto.contact.ContactCreateRequest;
+import com.mailsangja.core.dto.contact.ContactResponse;
+import com.mailsangja.db.entity.user.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "Contact", description = "주소록 API")
+public interface ContactControllerDocs {
+
+    @Operation(summary = "주소록 생성", description = "로그인한 사용자의 주소록에 연락처를 생성합니다.",
+            security = @SecurityRequirement(name = "cookieAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주소록 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 요청",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "409", description = "동일한 이메일의 연락처가 이미 존재함",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<ContactResponse> createContact(
+            @Parameter(hidden = true) @AuthUser User user,
+            @RequestBody ContactCreateRequest request
+    );
+
+    @Operation(summary = "주소록 목록 조회", description = "로그인한 사용자의 활성 연락처 목록을 반환합니다.",
+            security = @SecurityRequirement(name = "cookieAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주소록 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<List<ContactResponse>> getContacts(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "이름 또는 이메일 검색어") @RequestParam(required = false) String keyword
+    );
+}

--- a/core/src/main/java/com/mailsangja/core/dto/contact/ContactCreateRequest.java
+++ b/core/src/main/java/com/mailsangja/core/dto/contact/ContactCreateRequest.java
@@ -1,0 +1,18 @@
+package com.mailsangja.core.dto.contact;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "주소록 생성 요청")
+public record ContactCreateRequest(
+        @NotBlank
+        @Schema(description = "연락처 이름", example = "Alice")
+        String name,
+
+        @Email
+        @NotBlank
+        @Schema(description = "연락처 이메일", example = "alice@example.com")
+        String email
+) {
+}

--- a/core/src/main/java/com/mailsangja/core/dto/contact/ContactResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/contact/ContactResponse.java
@@ -1,0 +1,23 @@
+package com.mailsangja.core.dto.contact;
+
+import com.mailsangja.db.entity.contact.Contact;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "주소록 응답")
+public record ContactResponse(
+        @Schema(description = "주소록 ID", format = "uuid")
+        UUID id,
+
+        @Schema(description = "연락처 이름", example = "Alice")
+        String name,
+
+        @Schema(description = "연락처 이메일", example = "alice@example.com")
+        String email
+) {
+
+    public static ContactResponse from(Contact contact) {
+        return new ContactResponse(contact.getId(), contact.getName(), contact.getEmail());
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/contact/ContactUpdateRequest.java
+++ b/core/src/main/java/com/mailsangja/core/dto/contact/ContactUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.mailsangja.core.dto.contact;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "주소록 수정 요청")
+public record ContactUpdateRequest(
+        @NotBlank
+        @Schema(description = "연락처 이름", example = "Alice Updated")
+        String name
+) {
+}

--- a/core/src/main/java/com/mailsangja/core/dto/contact/GoogleContactResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/contact/GoogleContactResponse.java
@@ -1,0 +1,26 @@
+package com.mailsangja.core.dto.contact;
+
+import java.util.List;
+
+public record GoogleContactResponse(
+        List<PersonResponse> connections,
+        String nextPageToken
+) {
+    public record PersonResponse(
+            List<NameResponse> names,
+            List<EmailAddressResponse> emailAddresses
+    ) {
+    }
+
+    public record NameResponse(
+            String displayName,
+            String givenName,
+            String familyName
+    ) {
+    }
+
+    public record EmailAddressResponse(
+            String value
+    ) {
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/contact/GoogleContactResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/contact/GoogleContactResponse.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public record GoogleContactResponse(
         List<PersonResponse> connections,
+        List<PersonResponse> otherContacts,
         String nextPageToken
 ) {
     public record PersonResponse(

--- a/core/src/main/java/com/mailsangja/core/dto/contact/GoogleContactResult.java
+++ b/core/src/main/java/com/mailsangja/core/dto/contact/GoogleContactResult.java
@@ -1,0 +1,7 @@
+package com.mailsangja.core.dto.contact;
+
+public record GoogleContactResult(
+        String name,
+        String email
+) {
+}

--- a/core/src/main/java/com/mailsangja/core/facade/ContactFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/ContactFacade.java
@@ -1,0 +1,63 @@
+package com.mailsangja.core.facade;
+
+import com.mailsangja.core.common.exception.contact.ContactErrorCode;
+import com.mailsangja.core.common.exception.contact.ContactException;
+import com.mailsangja.core.dto.contact.ContactCreateRequest;
+import com.mailsangja.core.dto.contact.ContactResponse;
+import com.mailsangja.core.service.contact.ContactCommandService;
+import com.mailsangja.core.service.contact.ContactQueryService;
+import com.mailsangja.db.entity.contact.Contact;
+import com.mailsangja.db.entity.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ContactFacade {
+
+    private final ContactCommandService contactCommandService;
+    private final ContactQueryService contactQueryService;
+
+    public ContactResponse createContact(User user, ContactCreateRequest request) {
+        validateCreateRequest(user, request);
+        try {
+            Contact contact = contactCommandService.create(user, request);
+            return ContactResponse.from(contact);
+        } catch (DataIntegrityViolationException e) {
+            throw new ContactException(ContactErrorCode.CONTACT_EMAIL_DUPLICATE);
+        }
+    }
+
+    public List<ContactResponse> getContacts(User user, String keyword) {
+        validateUser(user);
+        if (keyword == null || keyword.isBlank()) {
+            return toResponses(contactQueryService.findAllContacts(user));
+        }
+        return toResponses(contactQueryService.searchContacts(user, keyword.trim()));
+    }
+
+    private List<ContactResponse> toResponses(List<Contact> contacts) {
+        List<ContactResponse> responses = new ArrayList<>();
+        for (Contact contact : contacts) {
+            responses.add(ContactResponse.from(contact));
+        }
+        return responses;
+    }
+
+    private void validateCreateRequest(User user, ContactCreateRequest request) {
+        validateUser(user);
+        if (request == null) {
+            throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
+        }
+    }
+
+    private void validateUser(User user) {
+        if (user == null || user.getId() == null) {
+            throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
+        }
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/facade/ContactFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/ContactFacade.java
@@ -4,6 +4,7 @@ import com.mailsangja.core.common.exception.contact.ContactErrorCode;
 import com.mailsangja.core.common.exception.contact.ContactException;
 import com.mailsangja.core.dto.contact.ContactCreateRequest;
 import com.mailsangja.core.dto.contact.ContactResponse;
+import com.mailsangja.core.dto.contact.ContactUpdateRequest;
 import com.mailsangja.core.service.contact.ContactCommandService;
 import com.mailsangja.core.service.contact.ContactQueryService;
 import com.mailsangja.db.entity.contact.Contact;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -40,6 +42,19 @@ public class ContactFacade {
         return toResponses(contactQueryService.searchContacts(user, keyword.trim()));
     }
 
+    public ContactResponse updateContact(User user, UUID contactId, ContactUpdateRequest request) {
+        validateUpdateRequest(user, contactId, request);
+        Contact contact = contactQueryService.findActiveContact(user, contactId);
+        Contact updated = contactCommandService.updateName(contact, request.name().trim());
+        return ContactResponse.from(updated);
+    }
+
+    public void deleteContact(User user, UUID contactId) {
+        validateContactIdRequest(user, contactId);
+        Contact contact = contactQueryService.findActiveContact(user, contactId);
+        contactCommandService.delete(contact);
+    }
+
     private List<ContactResponse> toResponses(List<Contact> contacts) {
         List<ContactResponse> responses = new ArrayList<>();
         for (Contact contact : contacts) {
@@ -51,6 +66,20 @@ public class ContactFacade {
     private void validateCreateRequest(User user, ContactCreateRequest request) {
         validateUser(user);
         if (request == null) {
+            throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
+        }
+    }
+
+    private void validateUpdateRequest(User user, UUID contactId, ContactUpdateRequest request) {
+        validateContactIdRequest(user, contactId);
+        if (request == null || request.name() == null || request.name().isBlank()) {
+            throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
+        }
+    }
+
+    private void validateContactIdRequest(User user, UUID contactId) {
+        validateUser(user);
+        if (contactId == null) {
             throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
         }
     }

--- a/core/src/main/java/com/mailsangja/core/facade/MailAccountFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/MailAccountFacade.java
@@ -2,14 +2,17 @@ package com.mailsangja.core.facade;
 
 import com.mailsangja.core.common.exception.mail.MailAccountErrorCode;
 import com.mailsangja.core.common.exception.mail.MailAccountException;
+import com.mailsangja.core.dto.contact.GoogleContactResult;
 import com.mailsangja.core.dto.mail.GoogleMailAccountResult;
 import com.mailsangja.core.dto.mail.GoogleMailWatchResult;
 import com.mailsangja.core.dto.mail.InitialMailSyncMessage;
 import com.mailsangja.core.dto.mail.MailAccountAuthorizeResponse;
 import com.mailsangja.core.dto.mail.MailAccountListResponse;
 import com.mailsangja.core.dto.mail.MailAccountResponse;
+import com.mailsangja.core.service.contact.ContactCommandService;
 import com.mailsangja.core.service.google.GoogleMailWatchQueryService;
 import com.mailsangja.core.service.google.GoogleOAuthQueryService;
+import com.mailsangja.core.service.google.GooglePeopleContactQueryService;
 import com.mailsangja.core.service.mail.InitialMailSyncMessageCommandService;
 import com.mailsangja.core.service.mail.MailAccountCommandService;
 import com.mailsangja.core.service.mail.MailAccountQueryService;
@@ -17,11 +20,13 @@ import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.MailProvider;
 import com.mailsangja.db.entity.user.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.security.SecureRandom;
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MailAccountFacade {
@@ -35,6 +40,8 @@ public class MailAccountFacade {
     private final GoogleOAuthQueryService googleOAuthQueryService;
     private final GoogleMailWatchQueryService googleMailWatchQueryService;
     private final InitialMailSyncMessageCommandService initialMailSyncMessageCommandService;
+    private final GooglePeopleContactQueryService googlePeopleContactQueryService;
+    private final ContactCommandService contactCommandService;
 
     public MailAccountAuthorizeResponse authorizeGoogle(String state) {
         String authorizationUrl = googleOAuthQueryService.buildAuthorizationUrl(state);
@@ -69,6 +76,7 @@ public class MailAccountFacade {
         if (savedMailAccount.getProvider() == MailProvider.GMAIL) {
             InitialMailSyncMessage initialMailSyncMessage = InitialMailSyncMessage.from(savedMailAccount);
             initialMailSyncMessageCommandService.publish(initialMailSyncMessage);
+            saveInitialGoogleContacts(user, result.accessToken(), savedMailAccount);
         }
 
         return MailAccountResponse.from(savedMailAccount);
@@ -126,6 +134,27 @@ public class MailAccountFacade {
 
     private boolean isBlank(String value) {
         return value == null || value.isBlank();
+    }
+
+    private void saveInitialGoogleContacts(User user, String accessToken, MailAccount mailAccount) {
+        try {
+            List<GoogleContactResult> contacts = googlePeopleContactQueryService.getContacts(accessToken);
+            int savedCount = contactCommandService.saveMissingContacts(user, contacts);
+            log.info(
+                    "Saved initial Google contacts. mailAccountId={} userId={} fetchedCount={} savedCount={}",
+                    mailAccount.getId(),
+                    user.getId(),
+                    contacts.size(),
+                    savedCount
+            );
+        } catch (Exception e) {
+            log.warn(
+                    "Failed to save initial Google contacts. mailAccountId={} userId={}",
+                    mailAccount.getId(),
+                    user.getId(),
+                    e
+            );
+        }
     }
 
     private record MailAccountAppearance(

--- a/core/src/main/java/com/mailsangja/core/facade/TrashFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/TrashFacade.java
@@ -91,7 +91,10 @@ public class TrashFacade {
                 .filter(email -> email != null && !email.isBlank())
                 .distinct()
                 .toList();
-        Map<String, String> contactNameByEmail = trashQueryService.findContactNamesByEmails(participantEmails);
+        Map<String, String> contactNameByEmail = trashQueryService.findContactNamesByEmails(
+                user.getId(),
+                participantEmails
+        );
 
         List<UUID> allMessageIds = messages.getContent().stream().map(Message::getId).toList();
         Map<UUID, List<Attachment>> attachmentsByMessageId = trashQueryService.findAttachmentsByMessageIds(allMessageIds);
@@ -119,7 +122,7 @@ public class TrashFacade {
                 thread.getMailAccount().getId(), thread.getGmailThreadId());
 
         List<String> emails = collectEmailsFromMessages(deletedMessages);
-        Map<String, String> contactNameByEmail = trashQueryService.findContactNamesByEmails(emails);
+        Map<String, String> contactNameByEmail = trashQueryService.findContactNamesByEmails(user.getId(), emails);
 
         List<UUID> messageIds = deletedMessages.stream().map(Message::getId).toList();
         Map<UUID, List<MessageLabelView>> messageLabelsByMessageId =

--- a/core/src/main/java/com/mailsangja/core/service/contact/ContactCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/contact/ContactCommandService.java
@@ -1,0 +1,45 @@
+package com.mailsangja.core.service.contact;
+
+import com.mailsangja.core.common.exception.contact.ContactErrorCode;
+import com.mailsangja.core.common.exception.contact.ContactException;
+import com.mailsangja.core.dto.contact.GoogleContactResult;
+import com.mailsangja.db.entity.contact.Contact;
+import com.mailsangja.db.entity.user.User;
+import com.mailsangja.db.port.ContactRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ContactCommandService {
+
+    private final ContactRepositoryPort contactRepositoryPort;
+
+    @Transactional
+    public int saveMissingContacts(User user, List<GoogleContactResult> results) {
+        validateSyncRequest(user, results);
+
+        if (results.isEmpty()) {
+            return 0;
+        }
+
+        List<Contact> contacts = results.stream()
+                .map(result -> Contact.builder()
+                        .user(user)
+                        .name(result.name())
+                        .email(result.email())
+                        .build())
+                .toList();
+
+        return contactRepositoryPort.saveAllIgnoreDuplicateActive(contacts);
+    }
+
+    private void validateSyncRequest(User user, List<GoogleContactResult> results) {
+        if (user == null || user.getId() == null || results == null) {
+            throw new ContactException(ContactErrorCode.INVALID_CONTACT_SYNC_REQUEST);
+        }
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/service/contact/ContactCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/contact/ContactCommandService.java
@@ -2,6 +2,7 @@ package com.mailsangja.core.service.contact;
 
 import com.mailsangja.core.common.exception.contact.ContactErrorCode;
 import com.mailsangja.core.common.exception.contact.ContactException;
+import com.mailsangja.core.dto.contact.ContactCreateRequest;
 import com.mailsangja.core.dto.contact.GoogleContactResult;
 import com.mailsangja.db.entity.contact.Contact;
 import com.mailsangja.db.entity.user.User;
@@ -10,7 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 @Service
 @RequiredArgsConstructor
@@ -19,27 +22,49 @@ public class ContactCommandService {
     private final ContactRepositoryPort contactRepositoryPort;
 
     @Transactional
+    public Contact create(User user, ContactCreateRequest request) {
+        validateCreateRequest(user, request);
+        Contact contact = Contact.create(user, request.name().trim(), normalizeEmail(request.email()));
+        return contactRepositoryPort.save(contact);
+    }
+
+    @Transactional
     public int saveMissingContacts(User user, List<GoogleContactResult> results) {
         validateSyncRequest(user, results);
-
         if (results.isEmpty()) {
             return 0;
         }
-
-        List<Contact> contacts = results.stream()
-                .map(result -> Contact.builder()
-                        .user(user)
-                        .name(result.name())
-                        .email(result.email())
-                        .build())
-                .toList();
-
-        return contactRepositoryPort.saveAllIgnoreDuplicateActive(contacts);
+        return contactRepositoryPort.saveAllIgnoreDuplicateActive(toContacts(user, results));
     }
 
     private void validateSyncRequest(User user, List<GoogleContactResult> results) {
         if (user == null || user.getId() == null || results == null) {
             throw new ContactException(ContactErrorCode.INVALID_CONTACT_SYNC_REQUEST);
         }
+    }
+
+    private void validateCreateRequest(User user, ContactCreateRequest request) {
+        if (user == null || user.getId() == null || request == null) {
+            throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
+        }
+        if (isBlank(request.name()) || isBlank(request.email())) {
+            throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
+        }
+    }
+
+    private List<Contact> toContacts(User user, List<GoogleContactResult> results) {
+        List<Contact> contacts = new ArrayList<>();
+        for (GoogleContactResult result : results) {
+            contacts.add(Contact.create(user, result.name(), result.email()));
+        }
+        return contacts;
+    }
+
+    private String normalizeEmail(String email) {
+        return email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/core/src/main/java/com/mailsangja/core/service/contact/ContactCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/contact/ContactCommandService.java
@@ -29,6 +29,20 @@ public class ContactCommandService {
     }
 
     @Transactional
+    public Contact updateName(Contact contact, String name) {
+        validateUpdateNameRequest(contact, name);
+        contact.updateName(name.trim());
+        return contactRepositoryPort.save(contact);
+    }
+
+    @Transactional
+    public void delete(Contact contact) {
+        validateContact(contact);
+        contact.delete();
+        contactRepositoryPort.save(contact);
+    }
+
+    @Transactional
     public int saveMissingContacts(User user, List<GoogleContactResult> results) {
         validateSyncRequest(user, results);
         if (results.isEmpty()) {
@@ -48,6 +62,19 @@ public class ContactCommandService {
             throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
         }
         if (isBlank(request.name()) || isBlank(request.email())) {
+            throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
+        }
+    }
+
+    private void validateUpdateNameRequest(Contact contact, String name) {
+        validateContact(contact);
+        if (isBlank(name)) {
+            throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
+        }
+    }
+
+    private void validateContact(Contact contact) {
+        if (contact == null) {
             throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
         }
     }

--- a/core/src/main/java/com/mailsangja/core/service/contact/ContactQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/contact/ContactQueryService.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +28,15 @@ public class ContactQueryService {
         return contactRepositoryPort.findAllByUserIdAndKeywordAndDeletedAtIsNull(user.getId(), keyword);
     }
 
+    public Contact findActiveContact(User user, UUID contactId) {
+        validateContactRequest(user, contactId);
+        Optional<Contact> contact = contactRepositoryPort.findByIdAndUserIdAndDeletedAtIsNull(contactId, user.getId());
+        if (contact.isEmpty()) {
+            throw new ContactException(ContactErrorCode.CONTACT_NOT_FOUND);
+        }
+        return contact.get();
+    }
+
     private void validateUser(User user) {
         if (user == null || user.getId() == null) {
             throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
@@ -35,6 +46,13 @@ public class ContactQueryService {
     private void validateSearchRequest(User user, String keyword) {
         validateUser(user);
         if (keyword == null || keyword.isBlank()) {
+            throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
+        }
+    }
+
+    private void validateContactRequest(User user, UUID contactId) {
+        validateUser(user);
+        if (contactId == null) {
             throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
         }
     }

--- a/core/src/main/java/com/mailsangja/core/service/contact/ContactQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/contact/ContactQueryService.java
@@ -1,0 +1,41 @@
+package com.mailsangja.core.service.contact;
+
+import com.mailsangja.core.common.exception.contact.ContactErrorCode;
+import com.mailsangja.core.common.exception.contact.ContactException;
+import com.mailsangja.db.entity.contact.Contact;
+import com.mailsangja.db.entity.user.User;
+import com.mailsangja.db.port.ContactRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ContactQueryService {
+
+    private final ContactRepositoryPort contactRepositoryPort;
+
+    public List<Contact> findAllContacts(User user) {
+        validateUser(user);
+        return contactRepositoryPort.findAllByUserIdAndDeletedAtIsNull(user.getId());
+    }
+
+    public List<Contact> searchContacts(User user, String keyword) {
+        validateSearchRequest(user, keyword);
+        return contactRepositoryPort.findAllByUserIdAndKeywordAndDeletedAtIsNull(user.getId(), keyword);
+    }
+
+    private void validateUser(User user) {
+        if (user == null || user.getId() == null) {
+            throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
+        }
+    }
+
+    private void validateSearchRequest(User user, String keyword) {
+        validateUser(user);
+        if (keyword == null || keyword.isBlank()) {
+            throw new ContactException(ContactErrorCode.INVALID_CONTACT_REQUEST);
+        }
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/service/google/GooglePeopleContactQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/google/GooglePeopleContactQueryService.java
@@ -5,11 +5,13 @@ import com.mailsangja.core.common.exception.contact.ContactException;
 import com.mailsangja.core.config.properties.GooglePeopleProperties;
 import com.mailsangja.core.dto.contact.GoogleContactResponse;
 import com.mailsangja.core.dto.contact.GoogleContactResult;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -18,10 +20,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Service
 public class GooglePeopleContactQueryService {
 
     private static final String PERSON_FIELDS = "names,emailAddresses";
+    private static final String READ_MASK = "names,emailAddresses";
 
     private final GooglePeopleProperties googlePeopleProperties;
     private final RestClient googlePeopleRestClient;
@@ -38,23 +42,34 @@ public class GooglePeopleContactQueryService {
         validateInput(accessToken);
 
         Map<String, GoogleContactResult> deduplicatedResults = new LinkedHashMap<>();
-        String pageToken = null;
-        do {
-            GoogleContactResponse response = fetchContactsPage(accessToken, pageToken);
-            for (GoogleContactResult result : toResults(response)) {
-                deduplicatedResults.putIfAbsent(result.email(), result);
-            }
-            pageToken = normalizeBlankToNull(response.nextPageToken());
-        } while (pageToken != null);
-
+        collectConnections(accessToken, deduplicatedResults);
+        collectOtherContacts(accessToken, deduplicatedResults);
         return List.copyOf(deduplicatedResults.values());
     }
 
-    private GoogleContactResponse fetchContactsPage(String accessToken, String pageToken) {
+    private void collectConnections(String accessToken, Map<String, GoogleContactResult> results) {
+        String pageToken = null;
+        do {
+            GoogleContactResponse response = fetchContactsPage(accessToken, buildConnectionsUri(pageToken));
+            addResults(results, toResults(response.connections()));
+            pageToken = normalizeBlankToNull(response.nextPageToken());
+        } while (pageToken != null);
+    }
+
+    private void collectOtherContacts(String accessToken, Map<String, GoogleContactResult> results) {
+        String pageToken = null;
+        do {
+            GoogleContactResponse response = fetchContactsPage(accessToken, buildOtherContactsUri(pageToken));
+            addResults(results, toResults(response.otherContacts()));
+            pageToken = normalizeBlankToNull(response.nextPageToken());
+        } while (pageToken != null);
+    }
+
+    private GoogleContactResponse fetchContactsPage(String accessToken, String uri) {
         try {
             GoogleContactResponse response = googlePeopleRestClient
                     .get()
-                    .uri(buildConnectionsUri(pageToken))
+                    .uri(uri)
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                     .accept(MediaType.APPLICATION_JSON)
                     .retrieve()
@@ -66,7 +81,15 @@ public class GooglePeopleContactQueryService {
             return response;
         } catch (ContactException e) {
             throw e;
+        } catch (RestClientResponseException e) {
+            log.warn(
+                    "Google People contacts fetch failed. status={} body={}",
+                    e.getStatusCode(),
+                    e.getResponseBodyAsString()
+            );
+            throw new ContactException(ContactErrorCode.GOOGLE_CONTACTS_FETCH_FAILED);
         } catch (RestClientException e) {
+            log.warn("Google People contacts fetch failed.", e);
             throw new ContactException(ContactErrorCode.GOOGLE_CONTACTS_FETCH_FAILED);
         }
     }
@@ -84,13 +107,31 @@ public class GooglePeopleContactQueryService {
         return builder.build(false).toUriString();
     }
 
-    private List<GoogleContactResult> toResults(GoogleContactResponse response) {
-        if (response.connections() == null || response.connections().isEmpty()) {
+    private String buildOtherContactsUri(String pageToken) {
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .fromUriString(googlePeopleProperties.getOtherContactsUri())
+                .queryParam("readMask", READ_MASK)
+                .queryParam("pageSize", googlePeopleProperties.getPageSize());
+
+        if (!isBlank(pageToken)) {
+            builder.queryParam("pageToken", pageToken);
+        }
+        return builder.build(false).toUriString();
+    }
+
+    private void addResults(Map<String, GoogleContactResult> saved, List<GoogleContactResult> fetched) {
+        for (GoogleContactResult result : fetched) {
+            saved.putIfAbsent(result.email(), result);
+        }
+    }
+
+    private List<GoogleContactResult> toResults(List<GoogleContactResponse.PersonResponse> people) {
+        if (people == null || people.isEmpty()) {
             return List.of();
         }
 
         List<GoogleContactResult> results = new ArrayList<>();
-        for (GoogleContactResponse.PersonResponse person : response.connections()) {
+        for (GoogleContactResponse.PersonResponse person : people) {
             if (person == null || person.emailAddresses() == null || person.emailAddresses().isEmpty()) {
                 continue;
             }
@@ -114,10 +155,7 @@ public class GooglePeopleContactQueryService {
             return null;
         }
 
-        GoogleContactResponse.NameResponse name = person.names().stream()
-                .filter(n -> n != null && (!isBlank(n.displayName()) || !isBlank(n.givenName()) || !isBlank(n.familyName())))
-                .findFirst()
-                .orElse(null);
+        GoogleContactResponse.NameResponse name = findFirstValidName(person.names());
         if (name == null) {
             return null;
         }
@@ -137,9 +175,23 @@ public class GooglePeopleContactQueryService {
     private void validateInput(String accessToken) {
         if (isBlank(accessToken)
                 || isBlank(googlePeopleProperties.getConnectionsUri())
+                || isBlank(googlePeopleProperties.getOtherContactsUri())
                 || googlePeopleProperties.getPageSize() <= 0) {
             throw new ContactException(ContactErrorCode.GOOGLE_CONTACTS_FETCH_FAILED);
         }
+    }
+
+    private GoogleContactResponse.NameResponse findFirstValidName(List<GoogleContactResponse.NameResponse> names) {
+        for (GoogleContactResponse.NameResponse name : names) {
+            if (name != null && hasNameValue(name)) {
+                return name;
+            }
+        }
+        return null;
+    }
+
+    private boolean hasNameValue(GoogleContactResponse.NameResponse name) {
+        return !isBlank(name.displayName()) || !isBlank(name.givenName()) || !isBlank(name.familyName());
     }
 
     private String normalizeEmail(String email) {

--- a/core/src/main/java/com/mailsangja/core/service/google/GooglePeopleContactQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/google/GooglePeopleContactQueryService.java
@@ -1,0 +1,159 @@
+package com.mailsangja.core.service.google;
+
+import com.mailsangja.core.common.exception.contact.ContactErrorCode;
+import com.mailsangja.core.common.exception.contact.ContactException;
+import com.mailsangja.core.config.properties.GooglePeopleProperties;
+import com.mailsangja.core.dto.contact.GoogleContactResponse;
+import com.mailsangja.core.dto.contact.GoogleContactResult;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class GooglePeopleContactQueryService {
+
+    private static final String PERSON_FIELDS = "names,emailAddresses";
+
+    private final GooglePeopleProperties googlePeopleProperties;
+    private final RestClient googlePeopleRestClient;
+
+    public GooglePeopleContactQueryService(
+            GooglePeopleProperties googlePeopleProperties,
+            @Qualifier("googlePeopleRestClient") RestClient googlePeopleRestClient
+    ) {
+        this.googlePeopleProperties = googlePeopleProperties;
+        this.googlePeopleRestClient = googlePeopleRestClient;
+    }
+
+    public List<GoogleContactResult> getContacts(String accessToken) {
+        validateInput(accessToken);
+
+        Map<String, GoogleContactResult> deduplicatedResults = new LinkedHashMap<>();
+        String pageToken = null;
+        do {
+            GoogleContactResponse response = fetchContactsPage(accessToken, pageToken);
+            for (GoogleContactResult result : toResults(response)) {
+                deduplicatedResults.putIfAbsent(result.email(), result);
+            }
+            pageToken = normalizeBlankToNull(response.nextPageToken());
+        } while (pageToken != null);
+
+        return List.copyOf(deduplicatedResults.values());
+    }
+
+    private GoogleContactResponse fetchContactsPage(String accessToken, String pageToken) {
+        try {
+            GoogleContactResponse response = googlePeopleRestClient
+                    .get()
+                    .uri(buildConnectionsUri(pageToken))
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .body(GoogleContactResponse.class);
+
+            if (response == null) {
+                throw new ContactException(ContactErrorCode.GOOGLE_CONTACTS_RESULT_INVALID);
+            }
+            return response;
+        } catch (ContactException e) {
+            throw e;
+        } catch (RestClientException e) {
+            throw new ContactException(ContactErrorCode.GOOGLE_CONTACTS_FETCH_FAILED);
+        }
+    }
+
+    private String buildConnectionsUri(String pageToken) {
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .fromUriString(googlePeopleProperties.getConnectionsUri())
+                .queryParam("personFields", PERSON_FIELDS)
+                .queryParam("pageSize", googlePeopleProperties.getPageSize());
+
+        if (!isBlank(pageToken)) {
+            builder.queryParam("pageToken", pageToken);
+        }
+
+        return builder.build(false).toUriString();
+    }
+
+    private List<GoogleContactResult> toResults(GoogleContactResponse response) {
+        if (response.connections() == null || response.connections().isEmpty()) {
+            return List.of();
+        }
+
+        List<GoogleContactResult> results = new ArrayList<>();
+        for (GoogleContactResponse.PersonResponse person : response.connections()) {
+            if (person == null || person.emailAddresses() == null || person.emailAddresses().isEmpty()) {
+                continue;
+            }
+
+            String name = resolveName(person);
+            for (GoogleContactResponse.EmailAddressResponse emailAddress : person.emailAddresses()) {
+                if (emailAddress == null || isBlank(emailAddress.value())) {
+                    continue;
+                }
+
+                String normalizedEmail = normalizeEmail(emailAddress.value());
+                String normalizedName = isBlank(name) ? normalizedEmail : name;
+                results.add(new GoogleContactResult(normalizedName, normalizedEmail));
+            }
+        }
+        return results;
+    }
+
+    private String resolveName(GoogleContactResponse.PersonResponse person) {
+        if (person.names() == null || person.names().isEmpty()) {
+            return null;
+        }
+
+        GoogleContactResponse.NameResponse name = person.names().stream()
+                .filter(n -> n != null && (!isBlank(n.displayName()) || !isBlank(n.givenName()) || !isBlank(n.familyName())))
+                .findFirst()
+                .orElse(null);
+        if (name == null) {
+            return null;
+        }
+
+        if (!isBlank(name.displayName())) {
+            return name.displayName().trim();
+        }
+
+        String givenName = normalizeBlankToNull(name.givenName());
+        String familyName = normalizeBlankToNull(name.familyName());
+        if (givenName != null && familyName != null) {
+            return givenName + " " + familyName;
+        }
+        return givenName != null ? givenName : familyName;
+    }
+
+    private void validateInput(String accessToken) {
+        if (isBlank(accessToken)
+                || isBlank(googlePeopleProperties.getConnectionsUri())
+                || googlePeopleProperties.getPageSize() <= 0) {
+            throw new ContactException(ContactErrorCode.GOOGLE_CONTACTS_FETCH_FAILED);
+        }
+    }
+
+    private String normalizeEmail(String email) {
+        return email.trim().toLowerCase();
+    }
+
+    private String normalizeBlankToNull(String value) {
+        if (isBlank(value)) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
@@ -61,7 +61,7 @@ public class InboxQueryService {
                 markerId,
                 pageable
         );
-        return buildThreadListResult(threads);
+        return buildThreadListResult(userId, threads);
     }
 
     public ThreadListResult findSentThreadsResult(
@@ -78,13 +78,16 @@ public class InboxQueryService {
                 markerId,
                 pageable
         );
-        return buildThreadListResult(threads);
+        return buildThreadListResult(userId, threads);
     }
 
     public ThreadDetailResult findThreadDetailResult(Thread thread) {
         List<Message> messages = messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
                 thread.getMailAccount().getId(), thread.getGmailThreadId());
-        Map<String, String> contactNameByEmail = findContactNamesByEmails(collectEmailsFromMessages(messages));
+        Map<String, String> contactNameByEmail = findContactNamesByEmails(
+                thread.getMailAccount().getUser().getId(),
+                collectEmailsFromMessages(messages)
+        );
         List<UUID> messageIds = messages.stream().map(Message::getId).toList();
         Map<UUID, List<MessageLabelView>> messageLabelsByMessageId = messageRepositoryPort
                 .findMessageLabelsByMessageIds(messageIds)
@@ -123,7 +126,7 @@ public class InboxQueryService {
                 .toList();
     }
 
-    private ThreadListResult buildThreadListResult(Slice<Thread> threads) {
+    private ThreadListResult buildThreadListResult(UUID userId, Slice<Thread> threads) {
         List<UUID> threadIds = threads.getContent().stream().map(Thread::getId).toList();
         Map<UUID, List<Attachment>> attachmentsByThreadId = findAttachmentsByThreadIds(threadIds);
         Map<UUID, List<ThreadMessageLabelView>> labelsByThreadId = findLabelsByThreadIds(threadIds);
@@ -133,7 +136,7 @@ public class InboxQueryService {
                 .filter(email -> email != null && !email.isBlank())
                 .distinct()
                 .toList();
-        Map<String, String> contactNameByEmail = findContactNamesByEmails(participantEmails);
+        Map<String, String> contactNameByEmail = findContactNamesByEmails(userId, participantEmails);
 
         return new ThreadListResult(threads, attachmentsByThreadId, contactNameByEmail, labelsByThreadId);
     }
@@ -176,11 +179,11 @@ public class InboxQueryService {
                 .toList();
     }
 
-    private Map<String, String> findContactNamesByEmails(List<String> emails) {
+    private Map<String, String> findContactNamesByEmails(UUID userId, List<String> emails) {
         if (emails.isEmpty()) {
             return Map.of();
         }
-        return contactRepositoryPort.findAllByEmailInAndDeletedAtIsNull(emails)
+        return contactRepositoryPort.findAllByUserIdAndEmailInAndDeletedAtIsNull(userId, emails)
                 .stream()
                 .collect(Collectors.toMap(Contact::getEmail, Contact::getName));
     }

--- a/core/src/main/java/com/mailsangja/core/service/trash/TrashQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/trash/TrashQueryService.java
@@ -114,11 +114,11 @@ public class TrashQueryService {
                 .collect(Collectors.groupingBy(MessageLabelView::messageId));
     }
 
-    public Map<String, String> findContactNamesByEmails(List<String> emails) {
+    public Map<String, String> findContactNamesByEmails(UUID userId, List<String> emails) {
         if (emails.isEmpty()) {
             return Map.of();
         }
-        return contactRepositoryPort.findAllByEmailInAndDeletedAtIsNull(emails)
+        return contactRepositoryPort.findAllByUserIdAndEmailInAndDeletedAtIsNull(userId, emails)
                 .stream()
                 .collect(Collectors.toMap(Contact::getEmail, Contact::getName));
     }

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -88,9 +88,11 @@ mailsangja:
         - email
         - https://mail.google.com/
         - https://www.googleapis.com/auth/contacts.readonly
+        - https://www.googleapis.com/auth/contacts.other.readonly
   google:
     people:
       connections-uri: ${GOOGLE_PEOPLE_CONNECTIONS_URI:https://people.googleapis.com/v1/people/me/connections}
+      other-contacts-uri: ${GOOGLE_PEOPLE_OTHER_CONTACTS_URI:https://people.googleapis.com/v1/otherContacts}
       page-size: ${GOOGLE_PEOPLE_CONTACTS_PAGE_SIZE:1000}
       connect-timeout: ${GOOGLE_PEOPLE_CONNECT_TIMEOUT:3s}
       read-timeout: ${GOOGLE_PEOPLE_READ_TIMEOUT:10s}

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -87,6 +87,13 @@ mailsangja:
         - openid
         - email
         - https://mail.google.com/
+        - https://www.googleapis.com/auth/contacts.readonly
+  google:
+    people:
+      connections-uri: ${GOOGLE_PEOPLE_CONNECTIONS_URI:https://people.googleapis.com/v1/people/me/connections}
+      page-size: ${GOOGLE_PEOPLE_CONTACTS_PAGE_SIZE:1000}
+      connect-timeout: ${GOOGLE_PEOPLE_CONNECT_TIMEOUT:3s}
+      read-timeout: ${GOOGLE_PEOPLE_READ_TIMEOUT:10s}
   gmail:
     google-watch:
       topic-name: ${GOOGLE_GMAIL_WATCH_TOPIC_NAME:projects/local/topics/mailbox-gmail-watch}

--- a/core/src/test/java/com/mailsangja/core/controller/ContactControllerTest.java
+++ b/core/src/test/java/com/mailsangja/core/controller/ContactControllerTest.java
@@ -1,0 +1,72 @@
+package com.mailsangja.core.controller;
+
+import com.mailsangja.core.dto.contact.ContactCreateRequest;
+import com.mailsangja.core.dto.contact.ContactResponse;
+import com.mailsangja.core.facade.ContactFacade;
+import com.mailsangja.db.entity.user.Plan;
+import com.mailsangja.db.entity.user.Role;
+import com.mailsangja.db.entity.user.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ContactControllerTest {
+
+    @Test
+    void createContact_POST_api_v1_contacts는Facade를호출하고응답을반환한다() {
+        // given
+        ContactFacade contactFacade = mock(ContactFacade.class);
+        ContactController controller = new ContactController(contactFacade);
+        User user = createUser();
+        ContactCreateRequest request = new ContactCreateRequest("Alice", "alice@example.com");
+        ContactResponse expected = new ContactResponse(UUID.randomUUID(), "Alice", "alice@example.com");
+        when(contactFacade.createContact(user, request)).thenReturn(expected);
+
+        // when
+        ResponseEntity<ContactResponse> response = controller.createContact(user, request);
+
+        // then
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(expected, response.getBody());
+        verify(contactFacade).createContact(user, request);
+    }
+
+    @Test
+    void getContacts_GET_api_v1_contacts는Facade를호출하고List응답을반환한다() {
+        // given
+        ContactFacade contactFacade = mock(ContactFacade.class);
+        ContactController controller = new ContactController(contactFacade);
+        User user = createUser();
+        List<ContactResponse> expected = List.of(
+                new ContactResponse(UUID.randomUUID(), "Alice", "alice@example.com"),
+                new ContactResponse(UUID.randomUUID(), "Bob", "bob@example.com")
+        );
+        when(contactFacade.getContacts(user, "ali")).thenReturn(expected);
+
+        // when
+        ResponseEntity<List<ContactResponse>> response = controller.getContacts(user, "ali");
+
+        // then
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(expected, response.getBody());
+        verify(contactFacade).getContacts(user, "ali");
+    }
+
+    private User createUser() {
+        return User.builder()
+                .id(UUID.randomUUID())
+                .name("사용자")
+                .username("user@example.com")
+                .password("password")
+                .plan(Plan.FREE)
+                .role(Role.USER)
+                .build();
+    }
+}

--- a/core/src/test/java/com/mailsangja/core/controller/ContactControllerTest.java
+++ b/core/src/test/java/com/mailsangja/core/controller/ContactControllerTest.java
@@ -2,6 +2,7 @@ package com.mailsangja.core.controller;
 
 import com.mailsangja.core.dto.contact.ContactCreateRequest;
 import com.mailsangja.core.dto.contact.ContactResponse;
+import com.mailsangja.core.dto.contact.ContactUpdateRequest;
 import com.mailsangja.core.facade.ContactFacade;
 import com.mailsangja.db.entity.user.Plan;
 import com.mailsangja.db.entity.user.Role;
@@ -57,6 +58,42 @@ class ContactControllerTest {
         assertEquals(200, response.getStatusCode().value());
         assertEquals(expected, response.getBody());
         verify(contactFacade).getContacts(user, "ali");
+    }
+
+    @Test
+    void updateContact_PATCH_api_v1_contacts_contactId는Facade를호출하고응답을반환한다() {
+        // given
+        ContactFacade contactFacade = mock(ContactFacade.class);
+        ContactController controller = new ContactController(contactFacade);
+        User user = createUser();
+        UUID contactId = UUID.randomUUID();
+        ContactUpdateRequest request = new ContactUpdateRequest("Alice Updated");
+        ContactResponse expected = new ContactResponse(contactId, "Alice Updated", "alice@example.com");
+        when(contactFacade.updateContact(user, contactId, request)).thenReturn(expected);
+
+        // when
+        ResponseEntity<ContactResponse> response = controller.updateContact(user, contactId, request);
+
+        // then
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(expected, response.getBody());
+        verify(contactFacade).updateContact(user, contactId, request);
+    }
+
+    @Test
+    void deleteContact_DELETE_api_v1_contacts_contactId는Facade를호출하고204를반환한다() {
+        // given
+        ContactFacade contactFacade = mock(ContactFacade.class);
+        ContactController controller = new ContactController(contactFacade);
+        User user = createUser();
+        UUID contactId = UUID.randomUUID();
+
+        // when
+        ResponseEntity<Void> response = controller.deleteContact(user, contactId);
+
+        // then
+        assertEquals(204, response.getStatusCode().value());
+        verify(contactFacade).deleteContact(user, contactId);
     }
 
     private User createUser() {

--- a/core/src/test/java/com/mailsangja/core/facade/ContactFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/ContactFacadeTest.java
@@ -4,6 +4,7 @@ import com.mailsangja.core.common.exception.contact.ContactErrorCode;
 import com.mailsangja.core.common.exception.contact.ContactException;
 import com.mailsangja.core.dto.contact.ContactCreateRequest;
 import com.mailsangja.core.dto.contact.ContactResponse;
+import com.mailsangja.core.dto.contact.ContactUpdateRequest;
 import com.mailsangja.core.service.contact.ContactCommandService;
 import com.mailsangja.core.service.contact.ContactQueryService;
 import com.mailsangja.db.entity.contact.Contact;
@@ -207,6 +208,184 @@ class ContactFacadeTest {
                 org.mockito.ArgumentMatchers.any(),
                 org.mockito.ArgumentMatchers.anyString()
         );
+    }
+
+    @Test
+    void updateContact_정상요청이면활성연락처를조회하고이름수정응답을반환한다() {
+        // given
+        User user = createUser();
+        UUID contactId = UUID.randomUUID();
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+        ContactUpdateRequest request = new ContactUpdateRequest(" Alice Updated ");
+        Contact contact = createContact(user, "Alice", "alice@example.com");
+        Contact updated = createContact(user, "Alice Updated", "alice@example.com");
+        when(contactQueryService.findActiveContact(user, contactId)).thenReturn(contact);
+        when(contactCommandService.updateName(contact, "Alice Updated")).thenReturn(updated);
+
+        // when
+        ContactResponse response = facade.updateContact(user, contactId, request);
+
+        // then
+        assertEquals(updated.getId(), response.id());
+        assertEquals("Alice Updated", response.name());
+        assertEquals("alice@example.com", response.email());
+        verify(contactQueryService).findActiveContact(user, contactId);
+        verify(contactCommandService).updateName(contact, "Alice Updated");
+    }
+
+    @Test
+    void updateContact_request가null이면실패한다() {
+        // given
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+
+        // when
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> facade.updateContact(createUser(), UUID.randomUUID(), null)
+        );
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
+        verify(contactQueryService, never()).findActiveContact(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    void updateContact_contactId가null이면실패한다() {
+        // given
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+        ContactUpdateRequest request = new ContactUpdateRequest("Alice");
+
+        // when
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> facade.updateContact(createUser(), null, request)
+        );
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
+        verify(contactQueryService, never()).findActiveContact(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    void updateContact_name이blank이면실패한다() {
+        // given
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+        ContactUpdateRequest request = new ContactUpdateRequest("   ");
+
+        // when
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> facade.updateContact(createUser(), UUID.randomUUID(), request)
+        );
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
+        verify(contactQueryService, never()).findActiveContact(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    void updateContact_대상이없으면ContactNotFound를전파한다() {
+        // given
+        User user = createUser();
+        UUID contactId = UUID.randomUUID();
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+        ContactUpdateRequest request = new ContactUpdateRequest("Alice");
+        when(contactQueryService.findActiveContact(user, contactId))
+                .thenThrow(new ContactException(ContactErrorCode.CONTACT_NOT_FOUND));
+
+        // when
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> facade.updateContact(user, contactId, request)
+        );
+
+        // then
+        assertEquals(ContactErrorCode.CONTACT_NOT_FOUND, exception.getErrorCode());
+        verify(contactCommandService, never()).updateName(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyString()
+        );
+    }
+
+    @Test
+    void deleteContact_정상요청이면활성연락처를조회하고삭제한다() {
+        // given
+        User user = createUser();
+        UUID contactId = UUID.randomUUID();
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+        Contact contact = createContact(user, "Alice", "alice@example.com");
+        when(contactQueryService.findActiveContact(user, contactId)).thenReturn(contact);
+
+        // when
+        facade.deleteContact(user, contactId);
+
+        // then
+        verify(contactQueryService).findActiveContact(user, contactId);
+        verify(contactCommandService).delete(contact);
+    }
+
+    @Test
+    void deleteContact_contactId가null이면실패한다() {
+        // given
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+
+        // when
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> facade.deleteContact(createUser(), null)
+        );
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
+        verify(contactQueryService, never()).findActiveContact(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    void deleteContact_대상이없으면ContactNotFound를전파한다() {
+        // given
+        User user = createUser();
+        UUID contactId = UUID.randomUUID();
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+        when(contactQueryService.findActiveContact(user, contactId))
+                .thenThrow(new ContactException(ContactErrorCode.CONTACT_NOT_FOUND));
+
+        // when
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> facade.deleteContact(user, contactId)
+        );
+
+        // then
+        assertEquals(ContactErrorCode.CONTACT_NOT_FOUND, exception.getErrorCode());
+        verify(contactCommandService, never()).delete(org.mockito.ArgumentMatchers.any());
     }
 
     private User createUser() {

--- a/core/src/test/java/com/mailsangja/core/facade/ContactFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/ContactFacadeTest.java
@@ -257,6 +257,25 @@ class ContactFacadeTest {
     }
 
     @Test
+    void updateContact_user가null이면실패한다() {
+        // given
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+        ContactUpdateRequest request = new ContactUpdateRequest("Alice");
+
+        // when
+        ContactException exception = assertThrows(ContactException.class, () -> facade.updateContact(null,UUID.randomUUID(), request));
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
+        verify(contactCommandService, never()).create(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
     void updateContact_contactId가null이면실패한다() {
         // given
         ContactCommandService contactCommandService = mock(ContactCommandService.class);
@@ -343,6 +362,25 @@ class ContactFacadeTest {
         // then
         verify(contactQueryService).findActiveContact(user, contactId);
         verify(contactCommandService).delete(contact);
+    }
+
+
+    @Test
+    void deleteContact_user가null이면실패한다() {
+        // given
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+
+        // when
+        ContactException exception = assertThrows(ContactException.class, () -> facade.deleteContact(null,UUID.randomUUID()));
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
+        verify(contactCommandService, never()).create(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
     }
 
     @Test

--- a/core/src/test/java/com/mailsangja/core/facade/ContactFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/ContactFacadeTest.java
@@ -1,0 +1,231 @@
+package com.mailsangja.core.facade;
+
+import com.mailsangja.core.common.exception.contact.ContactErrorCode;
+import com.mailsangja.core.common.exception.contact.ContactException;
+import com.mailsangja.core.dto.contact.ContactCreateRequest;
+import com.mailsangja.core.dto.contact.ContactResponse;
+import com.mailsangja.core.service.contact.ContactCommandService;
+import com.mailsangja.core.service.contact.ContactQueryService;
+import com.mailsangja.db.entity.contact.Contact;
+import com.mailsangja.db.entity.user.Plan;
+import com.mailsangja.db.entity.user.Role;
+import com.mailsangja.db.entity.user.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ContactFacadeTest {
+
+    @Test
+    void createContact_정상요청이면생성된연락처응답을반환한다() {
+        // given
+        User user = createUser();
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+        ContactCreateRequest request = new ContactCreateRequest("Alice", "alice@example.com");
+        Contact contact = createContact(user, "Alice", "alice@example.com");
+        when(contactCommandService.create(user, request)).thenReturn(contact);
+
+        // when
+        ContactResponse response = facade.createContact(user, request);
+
+        // then
+        assertEquals(contact.getId(), response.id());
+        assertEquals("Alice", response.name());
+        assertEquals("alice@example.com", response.email());
+        verify(contactCommandService).create(user, request);
+        verify(contactQueryService, never()).findAllContacts(
+                org.mockito.ArgumentMatchers.any()
+        );
+        verify(contactQueryService, never()).searchContacts(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyString()
+        );
+    }
+
+    @Test
+    void createContact_user가null이면실패한다() {
+        // given
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+        ContactCreateRequest request = new ContactCreateRequest("Alice", "alice@example.com");
+
+        // when
+        ContactException exception = assertThrows(ContactException.class, () -> facade.createContact(null, request));
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
+        verify(contactCommandService, never()).create(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    void createContact_request가null이면실패한다() {
+        // given
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+
+        // when
+        ContactException exception = assertThrows(ContactException.class, () -> facade.createContact(createUser(), null));
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
+        verify(contactCommandService, never()).create(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    void createContact_중복email제약위반이면ContactException으로변환한다() {
+        // given
+        User user = createUser();
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+        ContactCreateRequest request = new ContactCreateRequest("Alice", "ALICE@example.com");
+        when(contactCommandService.create(user, request)).thenThrow(new DataIntegrityViolationException("duplicate"));
+
+        // when
+        ContactException exception = assertThrows(ContactException.class, () -> facade.createContact(user, request));
+
+        // then
+        assertEquals(ContactErrorCode.CONTACT_EMAIL_DUPLICATE, exception.getErrorCode());
+        verify(contactCommandService).create(user, request);
+    }
+
+    @Test
+    void getContacts_keyword없이조회하면연락처응답목록을반환한다() {
+        // given
+        User user = createUser();
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+        Contact alice = createContact(user, "Alice", "alice@example.com");
+        Contact bob = createContact(user, "Bob", "bob@example.com");
+        when(contactQueryService.findAllContacts(user)).thenReturn(List.of(alice, bob));
+
+        // when
+        List<ContactResponse> responses = facade.getContacts(user, null);
+
+        // then
+        assertEquals(2, responses.size());
+        assertEquals(alice.getId(), responses.get(0).id());
+        assertEquals("Alice", responses.get(0).name());
+        assertEquals("alice@example.com", responses.get(0).email());
+        assertEquals(bob.getId(), responses.get(1).id());
+        assertEquals("Bob", responses.get(1).name());
+        assertEquals("bob@example.com", responses.get(1).email());
+        verify(contactQueryService).findAllContacts(user);
+        verify(contactQueryService, never()).searchContacts(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyString()
+        );
+        verify(contactCommandService, never()).create(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    void getContacts_keyword가blank이면전체연락처응답목록을반환한다() {
+        // given
+        User user = createUser();
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+        Contact alice = createContact(user, "Alice", "alice@example.com");
+        when(contactQueryService.findAllContacts(user)).thenReturn(List.of(alice));
+
+        // when
+        List<ContactResponse> responses = facade.getContacts(user, "   ");
+
+        // then
+        assertEquals(1, responses.size());
+        assertEquals(alice.getId(), responses.getFirst().id());
+        verify(contactQueryService).findAllContacts(user);
+        verify(contactQueryService, never()).searchContacts(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyString()
+        );
+    }
+
+    @Test
+    void getContacts_keyword로조회하면검색된연락처응답목록을반환한다() {
+        // given
+        User user = createUser();
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+        Contact alice = createContact(user, "Alice", "alice@example.com");
+        when(contactQueryService.searchContacts(user, "ali")).thenReturn(List.of(alice));
+
+        // when
+        List<ContactResponse> responses = facade.getContacts(user, "  ali  ");
+
+        // then
+        assertEquals(1, responses.size());
+        assertEquals(alice.getId(), responses.getFirst().id());
+        assertEquals("Alice", responses.getFirst().name());
+        assertEquals("alice@example.com", responses.getFirst().email());
+        verify(contactQueryService).searchContacts(user, "ali");
+        verify(contactQueryService, never()).findAllContacts(
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    void getContacts_user가null이면실패한다() {
+        // given
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        ContactQueryService contactQueryService = mock(ContactQueryService.class);
+        ContactFacade facade = new ContactFacade(contactCommandService, contactQueryService);
+
+        // when
+        ContactException exception = assertThrows(ContactException.class, () -> facade.getContacts(null, null));
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
+        verify(contactQueryService, never()).findAllContacts(
+                org.mockito.ArgumentMatchers.any()
+        );
+        verify(contactQueryService, never()).searchContacts(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyString()
+        );
+    }
+
+    private User createUser() {
+        return User.builder()
+                .id(UUID.randomUUID())
+                .name("사용자")
+                .username("user@example.com")
+                .password("password")
+                .plan(Plan.FREE)
+                .role(Role.USER)
+                .build();
+    }
+
+    private Contact createContact(User user, String name, String email) {
+        return Contact.builder()
+                .id(UUID.randomUUID())
+                .user(user)
+                .name(name)
+                .email(email)
+                .build();
+    }
+}

--- a/core/src/test/java/com/mailsangja/core/facade/MailAccountFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/MailAccountFacadeTest.java
@@ -1,0 +1,218 @@
+package com.mailsangja.core.facade;
+
+import com.mailsangja.core.dto.contact.GoogleContactResult;
+import com.mailsangja.core.dto.mail.GoogleMailAccountResult;
+import com.mailsangja.core.dto.mail.GoogleMailWatchResult;
+import com.mailsangja.core.dto.mail.InitialMailSyncMessage;
+import com.mailsangja.core.dto.mail.MailAccountResponse;
+import com.mailsangja.core.service.contact.ContactCommandService;
+import com.mailsangja.core.service.google.GoogleMailWatchQueryService;
+import com.mailsangja.core.service.google.GoogleOAuthQueryService;
+import com.mailsangja.core.service.google.GooglePeopleContactQueryService;
+import com.mailsangja.core.service.mail.InitialMailSyncMessageCommandService;
+import com.mailsangja.core.service.mail.MailAccountCommandService;
+import com.mailsangja.core.service.mail.MailAccountQueryService;
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.MailProvider;
+import com.mailsangja.db.entity.user.Plan;
+import com.mailsangja.db.entity.user.Role;
+import com.mailsangja.db.entity.user.User;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MailAccountFacadeTest {
+
+    @Test
+    void handleGoogleCallback_메일계정저장후MQ를먼저발행하고그다음주소록을가져와저장한다() {
+        User user = createUser();
+        GoogleMailAccountResult accountResult = createAccountResult();
+        GoogleMailWatchResult watchResult = createWatchResult();
+        MailAccount savedMailAccount = createMailAccount(user);
+        List<GoogleContactResult> contacts = List.of(new GoogleContactResult("Alice", "alice@example.com"));
+
+        MailAccountCommandService mailAccountCommandService = mock(MailAccountCommandService.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        GoogleOAuthQueryService googleOAuthQueryService = mock(GoogleOAuthQueryService.class);
+        GoogleMailWatchQueryService googleMailWatchQueryService = mock(GoogleMailWatchQueryService.class);
+        InitialMailSyncMessageCommandService initialMailSyncMessageCommandService = mock(InitialMailSyncMessageCommandService.class);
+        GooglePeopleContactQueryService googlePeopleContactQueryService = mock(GooglePeopleContactQueryService.class);
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        MailAccountFacade facade = new MailAccountFacade(
+                mailAccountCommandService,
+                mailAccountQueryService,
+                googleOAuthQueryService,
+                googleMailWatchQueryService,
+                initialMailSyncMessageCommandService,
+                googlePeopleContactQueryService,
+                contactCommandService
+        );
+        when(googleOAuthQueryService.getGoogleMailAccountResult("code")).thenReturn(accountResult);
+        when(googleMailWatchQueryService.watch("access-token")).thenReturn(watchResult);
+        when(mailAccountCommandService.createGoogleMailAccount(
+                eq(user),
+                eq(accountResult),
+                eq("alias"),
+                eq("good"),
+                any(),
+                eq(watchResult)
+        )).thenReturn(savedMailAccount);
+        when(googlePeopleContactQueryService.getContacts("access-token")).thenReturn(contacts);
+
+        MailAccountResponse response = facade.handleGoogleCallback(user, "code", "alias", null, null);
+
+        assertEquals(savedMailAccount.getId(), response.id());
+        InOrder inOrder = inOrder(
+                initialMailSyncMessageCommandService,
+                googlePeopleContactQueryService,
+                contactCommandService
+        );
+        inOrder.verify(initialMailSyncMessageCommandService).publish(InitialMailSyncMessage.from(savedMailAccount));
+        inOrder.verify(googlePeopleContactQueryService).getContacts("access-token");
+        inOrder.verify(contactCommandService).saveMissingContacts(user, contacts);
+    }
+
+    @Test
+    void handleGoogleCallback_주소록조회가실패해도메일계정연동과초기메일동기화발행은유지한다() {
+        User user = createUser();
+        GoogleMailAccountResult accountResult = createAccountResult();
+        GoogleMailWatchResult watchResult = createWatchResult();
+        MailAccount savedMailAccount = createMailAccount(user);
+
+        MailAccountCommandService mailAccountCommandService = mock(MailAccountCommandService.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        GoogleOAuthQueryService googleOAuthQueryService = mock(GoogleOAuthQueryService.class);
+        GoogleMailWatchQueryService googleMailWatchQueryService = mock(GoogleMailWatchQueryService.class);
+        InitialMailSyncMessageCommandService initialMailSyncMessageCommandService = mock(InitialMailSyncMessageCommandService.class);
+        GooglePeopleContactQueryService googlePeopleContactQueryService = mock(GooglePeopleContactQueryService.class);
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        MailAccountFacade facade = new MailAccountFacade(
+                mailAccountCommandService,
+                mailAccountQueryService,
+                googleOAuthQueryService,
+                googleMailWatchQueryService,
+                initialMailSyncMessageCommandService,
+                googlePeopleContactQueryService,
+                contactCommandService
+        );
+        when(googleOAuthQueryService.getGoogleMailAccountResult("code")).thenReturn(accountResult);
+        when(googleMailWatchQueryService.watch("access-token")).thenReturn(watchResult);
+        when(mailAccountCommandService.createGoogleMailAccount(
+                eq(user),
+                eq(accountResult),
+                eq("alias"),
+                eq("good"),
+                any(),
+                eq(watchResult)
+        )).thenReturn(savedMailAccount);
+        doThrow(new RuntimeException("People API failed"))
+                .when(googlePeopleContactQueryService)
+                .getContacts("access-token");
+
+        MailAccountResponse response = facade.handleGoogleCallback(user, "code", "alias", null, null);
+
+        assertEquals(savedMailAccount.getId(), response.id());
+        verify(initialMailSyncMessageCommandService).publish(InitialMailSyncMessage.from(savedMailAccount));
+        verify(googlePeopleContactQueryService).getContacts("access-token");
+    }
+
+    @Test
+    void handleGoogleCallback_주소록저장이실패해도메일계정연동과초기메일동기화발행은유지한다() {
+        User user = createUser();
+        GoogleMailAccountResult accountResult = createAccountResult();
+        GoogleMailWatchResult watchResult = createWatchResult();
+        MailAccount savedMailAccount = createMailAccount(user);
+        List<GoogleContactResult> contacts = List.of(new GoogleContactResult("Alice", "alice@example.com"));
+
+        MailAccountCommandService mailAccountCommandService = mock(MailAccountCommandService.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        GoogleOAuthQueryService googleOAuthQueryService = mock(GoogleOAuthQueryService.class);
+        GoogleMailWatchQueryService googleMailWatchQueryService = mock(GoogleMailWatchQueryService.class);
+        InitialMailSyncMessageCommandService initialMailSyncMessageCommandService = mock(InitialMailSyncMessageCommandService.class);
+        GooglePeopleContactQueryService googlePeopleContactQueryService = mock(GooglePeopleContactQueryService.class);
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        MailAccountFacade facade = new MailAccountFacade(
+                mailAccountCommandService,
+                mailAccountQueryService,
+                googleOAuthQueryService,
+                googleMailWatchQueryService,
+                initialMailSyncMessageCommandService,
+                googlePeopleContactQueryService,
+                contactCommandService
+        );
+        when(googleOAuthQueryService.getGoogleMailAccountResult("code")).thenReturn(accountResult);
+        when(googleMailWatchQueryService.watch("access-token")).thenReturn(watchResult);
+        when(mailAccountCommandService.createGoogleMailAccount(
+                eq(user),
+                eq(accountResult),
+                eq("alias"),
+                eq("good"),
+                any(),
+                eq(watchResult)
+        )).thenReturn(savedMailAccount);
+        when(googlePeopleContactQueryService.getContacts("access-token")).thenReturn(contacts);
+        doThrow(new RuntimeException("contact save failed"))
+                .when(contactCommandService)
+                .saveMissingContacts(user, contacts);
+
+        MailAccountResponse response = facade.handleGoogleCallback(user, "code", "alias", null, null);
+
+        assertEquals(savedMailAccount.getId(), response.id());
+        verify(initialMailSyncMessageCommandService).publish(InitialMailSyncMessage.from(savedMailAccount));
+        verify(contactCommandService).saveMissingContacts(user, contacts);
+    }
+
+    private User createUser() {
+        return User.builder()
+                .id(UUID.randomUUID())
+                .name("사용자")
+                .username("user@example.com")
+                .password("password")
+                .plan(Plan.FREE)
+                .role(Role.USER)
+                .build();
+    }
+
+    private GoogleMailAccountResult createAccountResult() {
+        return new GoogleMailAccountResult(
+                "gmail@example.com",
+                "access-token",
+                LocalDateTime.now().plusHours(1),
+                "refresh-token"
+        );
+    }
+
+    private GoogleMailWatchResult createWatchResult() {
+        return new GoogleMailWatchResult("history-id", LocalDateTime.now().plusDays(1));
+    }
+
+    private MailAccount createMailAccount(User user) {
+        return MailAccount.builder()
+                .id(UUID.randomUUID())
+                .user(user)
+                .provider(MailProvider.GMAIL)
+                .emailAddress("gmail@example.com")
+                .alias("alias")
+                .icon("good")
+                .color("#123456")
+                .accessToken("access-token")
+                .accessTokenExpiresAt(LocalDateTime.now().plusHours(1))
+                .refreshToken("refresh-token")
+                .active(true)
+                .syncHistoryId("history-id")
+                .watchExpiresAt(LocalDateTime.now().plusDays(1))
+                .build();
+    }
+}

--- a/core/src/test/java/com/mailsangja/core/service/contact/ContactCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/contact/ContactCommandServiceTest.java
@@ -1,0 +1,165 @@
+package com.mailsangja.core.service.contact;
+
+import com.mailsangja.core.common.exception.contact.ContactErrorCode;
+import com.mailsangja.core.common.exception.contact.ContactException;
+import com.mailsangja.core.dto.contact.GoogleContactResult;
+import com.mailsangja.db.entity.contact.Contact;
+import com.mailsangja.db.entity.user.Plan;
+import com.mailsangja.db.entity.user.Role;
+import com.mailsangja.db.entity.user.User;
+import com.mailsangja.db.port.ContactRepositoryPort;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ContactCommandServiceTest {
+
+    @Test
+    void saveMissingContacts_기존활성연락처는덮어쓰지않고신규연락처만저장한다() {
+        User user = createUser();
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactCommandService service = new ContactCommandService(contactRepositoryPort);
+        List<GoogleContactResult> results = List.of(
+                new GoogleContactResult("기존 구글 이름", "exists@example.com"),
+                new GoogleContactResult("새 연락처", "new@example.com"),
+                new GoogleContactResult("중복 새 연락처", "new@example.com")
+        );
+        Contact existingContact = Contact.builder()
+                .id(UUID.randomUUID())
+                .user(user)
+                .name("사용자가 저장한 이름")
+                .email("exists@example.com")
+                .build();
+        when(contactRepositoryPort.findAllByUserIdAndEmailInAndDeletedAtIsNull(
+                eq(user.getId()),
+                eq(List.of("exists@example.com", "new@example.com"))
+        )).thenReturn(List.of(existingContact));
+        when(contactRepositoryPort.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        int savedCount = service.saveMissingContacts(user, results);
+
+        assertEquals(1, savedCount);
+        ArgumentCaptor<List<Contact>> contactsCaptor = contactListCaptor();
+        verify(contactRepositoryPort).saveAll(contactsCaptor.capture());
+        List<Contact> savedContacts = contactsCaptor.getValue();
+        assertEquals(1, savedContacts.size());
+        assertEquals(user, savedContacts.get(0).getUser());
+        assertEquals("새 연락처", savedContacts.get(0).getName());
+        assertEquals("new@example.com", savedContacts.get(0).getEmail());
+    }
+
+    @Test
+    void saveMissingContacts_빈결과면저장하지않고0을반환한다() {
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactCommandService service = new ContactCommandService(contactRepositoryPort);
+
+        int savedCount = service.saveMissingContacts(createUser(), List.of());
+
+        assertEquals(0, savedCount);
+        verify(contactRepositoryPort, never()).saveAll(anyList());
+    }
+
+    @Test
+    void saveMissingContacts_user가null이면실패한다() {
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactCommandService service = new ContactCommandService(contactRepositoryPort);
+
+        ContactException exception = assertThrows(ContactException.class, () -> service.saveMissingContacts(
+                null,
+                List.of(new GoogleContactResult("Alice", "alice@example.com"))
+        ));
+        assertEquals(ContactErrorCode.INVALID_CONTACT_SYNC_REQUEST, exception.getErrorCode());
+        verify(contactRepositoryPort, never()).saveAll(anyList());
+    }
+
+    @Test
+    void saveMissingContacts_results가null이면실패한다() {
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactCommandService service = new ContactCommandService(contactRepositoryPort);
+
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> service.saveMissingContacts(createUser(), null)
+        );
+        assertEquals(ContactErrorCode.INVALID_CONTACT_SYNC_REQUEST, exception.getErrorCode());
+        verify(contactRepositoryPort, never()).saveAll(anyList());
+    }
+
+    @Test
+    void saveMissingContacts_blankEmail결과는저장대상에서제외한다() {
+        User user = createUser();
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactCommandService service = new ContactCommandService(contactRepositoryPort);
+        when(contactRepositoryPort.findAllByUserIdAndEmailInAndDeletedAtIsNull(
+                eq(user.getId()),
+                eq(List.of("valid@example.com"))
+        )).thenReturn(List.of());
+        when(contactRepositoryPort.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        int savedCount = service.saveMissingContacts(user, List.of(
+                new GoogleContactResult("Blank", " "),
+                new GoogleContactResult("Valid", "valid@example.com")
+        ));
+
+        assertEquals(1, savedCount);
+        ArgumentCaptor<List<Contact>> contactsCaptor = contactListCaptor();
+        verify(contactRepositoryPort).saveAll(contactsCaptor.capture());
+        List<Contact> savedContacts = contactsCaptor.getValue();
+        assertEquals(1, savedContacts.size());
+        assertEquals(user, savedContacts.get(0).getUser());
+        assertEquals("Valid", savedContacts.get(0).getName());
+        assertEquals("valid@example.com", savedContacts.get(0).getEmail());
+    }
+
+    @Test
+    void saveMissingContacts_기존활성연락처는이름을업데이트하지않는다() {
+        User user = createUser();
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactCommandService service = new ContactCommandService(contactRepositoryPort);
+        Contact existingContact = Contact.builder()
+                .id(UUID.randomUUID())
+                .user(user)
+                .name("사용자가 저장한 이름")
+                .email("exists@example.com")
+                .build();
+        when(contactRepositoryPort.findAllByUserIdAndEmailInAndDeletedAtIsNull(
+                eq(user.getId()),
+                eq(List.of("exists@example.com"))
+        )).thenReturn(List.of(existingContact));
+
+        int savedCount = service.saveMissingContacts(user, List.of(
+                new GoogleContactResult("구글 주소록 이름", "exists@example.com")
+        ));
+
+        assertEquals(0, savedCount);
+        assertEquals("사용자가 저장한 이름", existingContact.getName());
+        verify(contactRepositoryPort, never()).saveAll(anyList());
+    }
+
+    private User createUser() {
+        return User.builder()
+                .id(UUID.randomUUID())
+                .name("사용자")
+                .username("user@example.com")
+                .password("password")
+                .plan(Plan.FREE)
+                .role(Role.USER)
+                .build();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private ArgumentCaptor<List<Contact>> contactListCaptor() {
+        return ArgumentCaptor.forClass((Class) List.class);
+    }
+}

--- a/core/src/test/java/com/mailsangja/core/service/contact/ContactCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/contact/ContactCommandServiceTest.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -76,6 +77,55 @@ class ContactCommandServiceTest {
         // then
         assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
         verify(contactRepositoryPort, never()).save(org.mockito.ArgumentMatchers.any(Contact.class));
+    }
+
+    @Test
+    void updateName_이름만trim해서수정하고email은유지한다() {
+        // given
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactCommandService service = new ContactCommandService(contactRepositoryPort);
+        Contact contact = Contact.create(createUser(), "Alice", "alice@example.com");
+        when(contactRepositoryPort.save(contact)).thenReturn(contact);
+
+        // when
+        Contact updated = service.updateName(contact, " Alice Updated ");
+
+        // then
+        assertEquals(contact, updated);
+        assertEquals("Alice Updated", contact.getName());
+        assertEquals("alice@example.com", contact.getEmail());
+        verify(contactRepositoryPort).save(contact);
+    }
+
+    @Test
+    void updateName_name이blank이면실패한다() {
+        // given
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactCommandService service = new ContactCommandService(contactRepositoryPort);
+
+        // when
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> service.updateName(Contact.create(createUser(), "Alice", "alice@example.com"), "   ")
+        );
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
+    }
+
+    @Test
+    void delete_contact를softDelete처리한다() {
+        // given
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactCommandService service = new ContactCommandService(contactRepositoryPort);
+        Contact contact = Contact.create(createUser(), "Alice", "alice@example.com");
+
+        // when
+        service.delete(contact);
+
+        // then
+        assertTrue(contact.isDeleted());
+        verify(contactRepositoryPort).save(contact);
     }
 
     @Test

--- a/core/src/test/java/com/mailsangja/core/service/contact/ContactCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/contact/ContactCommandServiceTest.java
@@ -2,6 +2,7 @@ package com.mailsangja.core.service.contact;
 
 import com.mailsangja.core.common.exception.contact.ContactErrorCode;
 import com.mailsangja.core.common.exception.contact.ContactException;
+import com.mailsangja.core.dto.contact.ContactCreateRequest;
 import com.mailsangja.core.dto.contact.GoogleContactResult;
 import com.mailsangja.db.entity.contact.Contact;
 import com.mailsangja.db.entity.user.Plan;
@@ -23,6 +24,59 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ContactCommandServiceTest {
+
+    @Test
+    void create_요청값으로연락처를저장하고Contact를반환한다() {
+        // given
+        User user = createUser();
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactCommandService service = new ContactCommandService(contactRepositoryPort);
+        ContactCreateRequest request = new ContactCreateRequest(" Alice ", " Alice@Example.COM ");
+
+        when(contactRepositoryPort.save(org.mockito.ArgumentMatchers.any(Contact.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        Contact saved = service.create(user, request);
+
+        // then
+        ArgumentCaptor<Contact> contactCaptor = ArgumentCaptor.forClass(Contact.class);
+        verify(contactRepositoryPort).save(contactCaptor.capture());
+        Contact persisted = contactCaptor.getValue();
+        assertEquals(user, persisted.getUser());
+        assertEquals("Alice", persisted.getName());
+        assertEquals("alice@example.com", persisted.getEmail());
+        assertEquals(persisted, saved);
+    }
+
+    @Test
+    void create_user가null이면실패한다() {
+        // given
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactCommandService service = new ContactCommandService(contactRepositoryPort);
+        ContactCreateRequest request = new ContactCreateRequest("Alice", "alice@example.com");
+
+        // when
+        ContactException exception = assertThrows(ContactException.class, () -> service.create(null, request));
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
+        verify(contactRepositoryPort, never()).save(org.mockito.ArgumentMatchers.any(Contact.class));
+    }
+
+    @Test
+    void create_request가null이면실패한다() {
+        // given
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactCommandService service = new ContactCommandService(contactRepositoryPort);
+
+        // when
+        ContactException exception = assertThrows(ContactException.class, () -> service.create(createUser(), null));
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
+        verify(contactRepositoryPort, never()).save(org.mockito.ArgumentMatchers.any(Contact.class));
+    }
 
     @Test
     void saveMissingContacts_정제된결과를중복무시저장포트로위임한다() {

--- a/core/src/test/java/com/mailsangja/core/service/contact/ContactCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/contact/ContactCommandServiceTest.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -26,37 +25,29 @@ import static org.mockito.Mockito.when;
 class ContactCommandServiceTest {
 
     @Test
-    void saveMissingContacts_기존활성연락처는덮어쓰지않고신규연락처만저장한다() {
+    void saveMissingContacts_정제된결과를중복무시저장포트로위임한다() {
         User user = createUser();
         ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
         ContactCommandService service = new ContactCommandService(contactRepositoryPort);
         List<GoogleContactResult> results = List.of(
                 new GoogleContactResult("기존 구글 이름", "exists@example.com"),
-                new GoogleContactResult("새 연락처", "new@example.com"),
-                new GoogleContactResult("중복 새 연락처", "new@example.com")
+                new GoogleContactResult("새 연락처", "new@example.com")
         );
-        Contact existingContact = Contact.builder()
-                .id(UUID.randomUUID())
-                .user(user)
-                .name("사용자가 저장한 이름")
-                .email("exists@example.com")
-                .build();
-        when(contactRepositoryPort.findAllByUserIdAndEmailInAndDeletedAtIsNull(
-                eq(user.getId()),
-                eq(List.of("exists@example.com", "new@example.com"))
-        )).thenReturn(List.of(existingContact));
-        when(contactRepositoryPort.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(contactRepositoryPort.saveAllIgnoreDuplicateActive(anyList())).thenReturn(1);
 
         int savedCount = service.saveMissingContacts(user, results);
 
         assertEquals(1, savedCount);
         ArgumentCaptor<List<Contact>> contactsCaptor = contactListCaptor();
-        verify(contactRepositoryPort).saveAll(contactsCaptor.capture());
+        verify(contactRepositoryPort).saveAllIgnoreDuplicateActive(contactsCaptor.capture());
         List<Contact> savedContacts = contactsCaptor.getValue();
-        assertEquals(1, savedContacts.size());
+        assertEquals(2, savedContacts.size());
         assertEquals(user, savedContacts.get(0).getUser());
-        assertEquals("새 연락처", savedContacts.get(0).getName());
-        assertEquals("new@example.com", savedContacts.get(0).getEmail());
+        assertEquals("기존 구글 이름", savedContacts.get(0).getName());
+        assertEquals("exists@example.com", savedContacts.get(0).getEmail());
+        assertEquals(user, savedContacts.get(1).getUser());
+        assertEquals("새 연락처", savedContacts.get(1).getName());
+        assertEquals("new@example.com", savedContacts.get(1).getEmail());
     }
 
     @Test
@@ -67,7 +58,7 @@ class ContactCommandServiceTest {
         int savedCount = service.saveMissingContacts(createUser(), List.of());
 
         assertEquals(0, savedCount);
-        verify(contactRepositoryPort, never()).saveAll(anyList());
+        verify(contactRepositoryPort, never()).saveAllIgnoreDuplicateActive(anyList());
     }
 
     @Test
@@ -80,7 +71,7 @@ class ContactCommandServiceTest {
                 List.of(new GoogleContactResult("Alice", "alice@example.com"))
         ));
         assertEquals(ContactErrorCode.INVALID_CONTACT_SYNC_REQUEST, exception.getErrorCode());
-        verify(contactRepositoryPort, never()).saveAll(anyList());
+        verify(contactRepositoryPort, never()).saveAllIgnoreDuplicateActive(anyList());
     }
 
     @Test
@@ -93,58 +84,22 @@ class ContactCommandServiceTest {
                 () -> service.saveMissingContacts(createUser(), null)
         );
         assertEquals(ContactErrorCode.INVALID_CONTACT_SYNC_REQUEST, exception.getErrorCode());
-        verify(contactRepositoryPort, never()).saveAll(anyList());
+        verify(contactRepositoryPort, never()).saveAllIgnoreDuplicateActive(anyList());
     }
 
     @Test
-    void saveMissingContacts_blankEmail결과는저장대상에서제외한다() {
+    void saveMissingContacts_이미존재하는연락처는DB고유제약으로무시된저장개수를반환한다() {
         User user = createUser();
         ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
         ContactCommandService service = new ContactCommandService(contactRepositoryPort);
-        when(contactRepositoryPort.findAllByUserIdAndEmailInAndDeletedAtIsNull(
-                eq(user.getId()),
-                eq(List.of("valid@example.com"))
-        )).thenReturn(List.of());
-        when(contactRepositoryPort.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
-
-        int savedCount = service.saveMissingContacts(user, List.of(
-                new GoogleContactResult("Blank", " "),
-                new GoogleContactResult("Valid", "valid@example.com")
-        ));
-
-        assertEquals(1, savedCount);
-        ArgumentCaptor<List<Contact>> contactsCaptor = contactListCaptor();
-        verify(contactRepositoryPort).saveAll(contactsCaptor.capture());
-        List<Contact> savedContacts = contactsCaptor.getValue();
-        assertEquals(1, savedContacts.size());
-        assertEquals(user, savedContacts.get(0).getUser());
-        assertEquals("Valid", savedContacts.get(0).getName());
-        assertEquals("valid@example.com", savedContacts.get(0).getEmail());
-    }
-
-    @Test
-    void saveMissingContacts_기존활성연락처는이름을업데이트하지않는다() {
-        User user = createUser();
-        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
-        ContactCommandService service = new ContactCommandService(contactRepositoryPort);
-        Contact existingContact = Contact.builder()
-                .id(UUID.randomUUID())
-                .user(user)
-                .name("사용자가 저장한 이름")
-                .email("exists@example.com")
-                .build();
-        when(contactRepositoryPort.findAllByUserIdAndEmailInAndDeletedAtIsNull(
-                eq(user.getId()),
-                eq(List.of("exists@example.com"))
-        )).thenReturn(List.of(existingContact));
+        when(contactRepositoryPort.saveAllIgnoreDuplicateActive(anyList())).thenReturn(0);
 
         int savedCount = service.saveMissingContacts(user, List.of(
                 new GoogleContactResult("구글 주소록 이름", "exists@example.com")
         ));
 
         assertEquals(0, savedCount);
-        assertEquals("사용자가 저장한 이름", existingContact.getName());
-        verify(contactRepositoryPort, never()).saveAll(anyList());
+        verify(contactRepositoryPort).saveAllIgnoreDuplicateActive(anyList());
     }
 
     private User createUser() {

--- a/core/src/test/java/com/mailsangja/core/service/contact/ContactQueryServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/contact/ContactQueryServiceTest.java
@@ -10,6 +10,7 @@ import com.mailsangja.db.port.ContactRepositoryPort;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -111,6 +112,61 @@ class ContactQueryServiceTest {
                 org.mockito.ArgumentMatchers.any(),
                 org.mockito.ArgumentMatchers.anyString()
         );
+    }
+
+    @Test
+    void findActiveContact_contactId와userId로activeContact를조회한다() {
+        // given
+        User user = createUser();
+        UUID contactId = UUID.randomUUID();
+        Contact contact = createContact(user, "Alice", "alice@example.com");
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactQueryService service = new ContactQueryService(contactRepositoryPort);
+        when(contactRepositoryPort.findByIdAndUserIdAndDeletedAtIsNull(contactId, user.getId()))
+                .thenReturn(Optional.of(contact));
+
+        // when
+        Contact result = service.findActiveContact(user, contactId);
+
+        // then
+        assertEquals(contact, result);
+        verify(contactRepositoryPort).findByIdAndUserIdAndDeletedAtIsNull(contactId, user.getId());
+    }
+
+    @Test
+    void findActiveContact_조회결과가없으면실패한다() {
+        // given
+        User user = createUser();
+        UUID contactId = UUID.randomUUID();
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactQueryService service = new ContactQueryService(contactRepositoryPort);
+        when(contactRepositoryPort.findByIdAndUserIdAndDeletedAtIsNull(contactId, user.getId()))
+                .thenReturn(Optional.empty());
+
+        // when
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> service.findActiveContact(user, contactId)
+        );
+
+        // then
+        assertEquals(ContactErrorCode.CONTACT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void findActiveContact_contactId가null이면실패한다() {
+        // given
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactQueryService service = new ContactQueryService(contactRepositoryPort);
+
+        // when
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> service.findActiveContact(createUser(), null)
+        );
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
     }
 
     private User createUser() {

--- a/core/src/test/java/com/mailsangja/core/service/contact/ContactQueryServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/contact/ContactQueryServiceTest.java
@@ -1,0 +1,135 @@
+package com.mailsangja.core.service.contact;
+
+import com.mailsangja.core.common.exception.contact.ContactErrorCode;
+import com.mailsangja.core.common.exception.contact.ContactException;
+import com.mailsangja.db.entity.contact.Contact;
+import com.mailsangja.db.entity.user.Plan;
+import com.mailsangja.db.entity.user.Role;
+import com.mailsangja.db.entity.user.User;
+import com.mailsangja.db.port.ContactRepositoryPort;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ContactQueryServiceTest {
+
+    @Test
+    void findAllContacts_사용자의activeContact전체조회포트를호출한다() {
+        // given
+        User user = createUser();
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactQueryService service = new ContactQueryService(contactRepositoryPort);
+        List<Contact> contacts = List.of(createContact(user, "Alice", "alice@example.com"));
+        when(contactRepositoryPort.findAllByUserIdAndDeletedAtIsNull(user.getId())).thenReturn(contacts);
+
+        // when
+        List<Contact> result = service.findAllContacts(user);
+
+        // then
+        assertEquals(contacts, result);
+        verify(contactRepositoryPort).findAllByUserIdAndDeletedAtIsNull(user.getId());
+        verify(contactRepositoryPort, never()).findAllByUserIdAndKeywordAndDeletedAtIsNull(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyString()
+        );
+    }
+
+    @Test
+    void searchContacts_keyword가있으면검색어로nameEmail검색포트를호출한다() {
+        // given
+        User user = createUser();
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactQueryService service = new ContactQueryService(contactRepositoryPort);
+        List<Contact> contacts = List.of(createContact(user, "Alice", "alice@example.com"));
+        when(contactRepositoryPort.findAllByUserIdAndKeywordAndDeletedAtIsNull(user.getId(), "alice"))
+                .thenReturn(contacts);
+
+        // when
+        List<Contact> result = service.searchContacts(user, "alice");
+
+        // then
+        assertEquals(contacts, result);
+        verify(contactRepositoryPort).findAllByUserIdAndKeywordAndDeletedAtIsNull(user.getId(), "alice");
+        verify(contactRepositoryPort, never()).findAllByUserIdAndDeletedAtIsNull(
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    void findAllContacts_user가null이면실패한다() {
+        // given
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactQueryService service = new ContactQueryService(contactRepositoryPort);
+
+        // when
+        ContactException exception = assertThrows(ContactException.class, () -> service.findAllContacts(null));
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
+        verify(contactRepositoryPort, never()).findAllByUserIdAndDeletedAtIsNull(
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    void searchContacts_user가null이면실패한다() {
+        // given
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactQueryService service = new ContactQueryService(contactRepositoryPort);
+
+        // when
+        ContactException exception = assertThrows(ContactException.class, () -> service.searchContacts(null, "alice"));
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
+        verify(contactRepositoryPort, never()).findAllByUserIdAndKeywordAndDeletedAtIsNull(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyString()
+        );
+    }
+
+    @Test
+    void searchContacts_keyword가blank이면실패한다() {
+        // given
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        ContactQueryService service = new ContactQueryService(contactRepositoryPort);
+
+        // when
+        ContactException exception = assertThrows(ContactException.class, () -> service.searchContacts(createUser(), "   "));
+
+        // then
+        assertEquals(ContactErrorCode.INVALID_CONTACT_REQUEST, exception.getErrorCode());
+        verify(contactRepositoryPort, never()).findAllByUserIdAndKeywordAndDeletedAtIsNull(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyString()
+        );
+    }
+
+    private User createUser() {
+        return User.builder()
+                .id(UUID.randomUUID())
+                .name("사용자")
+                .username("user@example.com")
+                .password("password")
+                .plan(Plan.FREE)
+                .role(Role.USER)
+                .build();
+    }
+
+    private Contact createContact(User user, String name, String email) {
+        return Contact.builder()
+                .id(UUID.randomUUID())
+                .user(user)
+                .name(name)
+                .email(email)
+                .build();
+    }
+}

--- a/core/src/test/java/com/mailsangja/core/service/google/GooglePeopleContactQueryServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/google/GooglePeopleContactQueryServiceTest.java
@@ -105,7 +105,7 @@ class GooglePeopleContactQueryServiceTest {
     }
 
     @Test
-    void getContacts_응답호출이실패하면MailAccountException을던진다() {
+    void getContacts_응답호출이실패하면ContactException을던진다() {
         GooglePeopleProperties properties = createProperties();
         GooglePeopleContactQueryService service = new GooglePeopleContactQueryService(
                 properties,

--- a/core/src/test/java/com/mailsangja/core/service/google/GooglePeopleContactQueryServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/google/GooglePeopleContactQueryServiceTest.java
@@ -1,0 +1,269 @@
+package com.mailsangja.core.service.google;
+
+import com.mailsangja.core.common.exception.contact.ContactErrorCode;
+import com.mailsangja.core.common.exception.contact.ContactException;
+import com.mailsangja.core.config.properties.GooglePeopleProperties;
+import com.mailsangja.core.dto.contact.GoogleContactResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+import org.springframework.web.client.RestClient;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GooglePeopleContactQueryServiceTest {
+
+    @Test
+    void getContacts_페이지네이션을따라가며이메일을정규화하고중복을제거한다() {
+        GooglePeopleProperties properties = createProperties();
+        CapturingPagedRequestFactory requestFactory = new CapturingPagedRequestFactory(
+                """
+                        {
+                          "connections": [
+                            {
+                              "names": [{"displayName": " Alice "}],
+                              "emailAddresses": [{"value": " Alice@Example.com "}]
+                            },
+                            {
+                              "names": [{"displayName": "Duplicate"}],
+                              "emailAddresses": [{"value": "alice@example.com"}]
+                            },
+                            {
+                              "names": [{"givenName": "Bob", "familyName": "Kim"}],
+                              "emailAddresses": [{"value": "bob@example.com"}]
+                            },
+                            {
+                              "names": [{"displayName": "No Email"}],
+                              "emailAddresses": []
+                            }
+                          ],
+                          "nextPageToken": "next-token"
+                        }
+                        """,
+                """
+                        {
+                          "connections": [
+                            {
+                              "names": [],
+                              "emailAddresses": [{"value": "carol@example.com"}]
+                            }
+                          ]
+                        }
+                        """
+        );
+        GooglePeopleContactQueryService service = new GooglePeopleContactQueryService(
+                properties,
+                RestClient.builder().requestFactory(requestFactory).build()
+        );
+
+        List<GoogleContactResult> results = service.getContacts("access-token");
+
+        assertEquals(3, results.size());
+        assertEquals(new GoogleContactResult("Alice", "alice@example.com"), results.get(0));
+        assertEquals(new GoogleContactResult("Bob Kim", "bob@example.com"), results.get(1));
+        assertEquals(new GoogleContactResult("carol@example.com", "carol@example.com"), results.get(2));
+
+        assertEquals(2, requestFactory.requestUris().size());
+        assertTrue(requestFactory.requestUris().get(0).contains("personFields=names,emailAddresses"));
+        assertTrue(requestFactory.requestUris().get(0).contains("pageSize=1000"));
+        assertTrue(requestFactory.requestUris().get(1).contains("pageToken=next-token"));
+        assertEquals(List.of("Bearer access-token", "Bearer access-token"), requestFactory.authorizationHeaders());
+    }
+
+    @Test
+    void getContacts_응답호출이실패하면MailAccountException을던진다() {
+        GooglePeopleProperties properties = createProperties();
+        GooglePeopleContactQueryService service = new GooglePeopleContactQueryService(
+                properties,
+                RestClient.builder().requestFactory(new FailingRequestFactory()).build()
+        );
+
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> service.getContacts("access-token")
+        );
+
+        assertEquals(ContactErrorCode.GOOGLE_CONTACTS_FETCH_FAILED, exception.getErrorCode());
+    }
+
+    @Test
+    void getContacts_accessToken이공백이면API를호출하지않고실패한다() {
+        CapturingPagedRequestFactory requestFactory = new CapturingPagedRequestFactory("{}");
+        GooglePeopleContactQueryService service = new GooglePeopleContactQueryService(
+                createProperties(),
+                RestClient.builder().requestFactory(requestFactory).build()
+        );
+
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> service.getContacts(" ")
+        );
+
+        assertEquals(ContactErrorCode.GOOGLE_CONTACTS_FETCH_FAILED, exception.getErrorCode());
+        assertEquals(0, requestFactory.requestUris().size());
+    }
+
+    @Test
+    void getContacts_connectionsUri가공백이면API를호출하지않고실패한다() {
+        GooglePeopleProperties properties = createProperties();
+        properties.setConnectionsUri(" ");
+        CapturingPagedRequestFactory requestFactory = new CapturingPagedRequestFactory("{}");
+        GooglePeopleContactQueryService service = new GooglePeopleContactQueryService(
+                properties,
+                RestClient.builder().requestFactory(requestFactory).build()
+        );
+
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> service.getContacts("access-token")
+        );
+
+        assertEquals(ContactErrorCode.GOOGLE_CONTACTS_FETCH_FAILED, exception.getErrorCode());
+        assertEquals(0, requestFactory.requestUris().size());
+    }
+
+    @Test
+    void getContacts_pageSize가0이하면API를호출하지않고실패한다() {
+        GooglePeopleProperties properties = createProperties();
+        properties.setPageSize(0);
+        CapturingPagedRequestFactory requestFactory = new CapturingPagedRequestFactory("{}");
+        GooglePeopleContactQueryService service = new GooglePeopleContactQueryService(
+                properties,
+                RestClient.builder().requestFactory(requestFactory).build()
+        );
+
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> service.getContacts("access-token")
+        );
+
+        assertEquals(ContactErrorCode.GOOGLE_CONTACTS_FETCH_FAILED, exception.getErrorCode());
+        assertEquals(0, requestFactory.requestUris().size());
+    }
+
+    @Test
+    void getContacts_응답이비어있으면결과오류로실패한다() {
+        GooglePeopleContactQueryService service = new GooglePeopleContactQueryService(
+                createProperties(),
+                RestClient.builder().requestFactory(new EmptyBodyRequestFactory()).build()
+        );
+
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> service.getContacts("access-token")
+        );
+
+        assertEquals(ContactErrorCode.GOOGLE_CONTACTS_RESULT_INVALID, exception.getErrorCode());
+    }
+
+    @Test
+    void getContacts_한연락처에이메일이여러개면각이메일을별도결과로반환한다() {
+        GooglePeopleContactQueryService service = new GooglePeopleContactQueryService(
+                createProperties(),
+                RestClient.builder().requestFactory(new CapturingPagedRequestFactory("""
+                        {
+                          "connections": [
+                            {
+                              "names": [{"displayName": "Multi Email"}],
+                              "emailAddresses": [
+                                {"value": "first@example.com"},
+                                {"value": "second@example.com"}
+                              ]
+                            }
+                          ]
+                        }
+                        """)).build()
+        );
+
+        List<GoogleContactResult> results = service.getContacts("access-token");
+
+        assertEquals(List.of(
+                new GoogleContactResult("Multi Email", "first@example.com"),
+                new GoogleContactResult("Multi Email", "second@example.com")
+        ), results);
+    }
+
+    private GooglePeopleProperties createProperties() {
+        GooglePeopleProperties properties = new GooglePeopleProperties();
+        properties.setConnectionsUri("https://people.googleapis.com/v1/people/me/connections");
+        properties.setPageSize(1000);
+        return properties;
+    }
+
+    private static final class CapturingPagedRequestFactory extends SimpleClientHttpRequestFactory {
+        private final List<String> responses;
+        private final List<String> requestUris = new ArrayList<>();
+        private final List<String> authorizationHeaders = new ArrayList<>();
+        private int requestIndex;
+
+        private CapturingPagedRequestFactory(String... responses) {
+            this.responses = List.of(responses);
+        }
+
+        @Override
+        public ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod) {
+            return new MockClientHttpRequest(httpMethod, uri) {
+                @Override
+                protected ClientHttpResponse executeInternal() {
+                    requestUris.add(uri.toString());
+                    authorizationHeaders.add(getHeaders().getFirst(HttpHeaders.AUTHORIZATION));
+
+                    MockClientHttpResponse response = new MockClientHttpResponse(
+                            responses.get(requestIndex++).getBytes(StandardCharsets.UTF_8),
+                            HttpStatus.OK
+                    );
+                    response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+                    return response;
+                }
+            };
+        }
+
+        private List<String> requestUris() {
+            return requestUris;
+        }
+
+        private List<String> authorizationHeaders() {
+            return authorizationHeaders;
+        }
+    }
+
+    private static final class FailingRequestFactory extends SimpleClientHttpRequestFactory {
+        @Override
+        public ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod) {
+            return new MockClientHttpRequest(httpMethod, uri) {
+                @Override
+                protected ClientHttpResponse executeInternal() {
+                    return new MockClientHttpResponse(new byte[0], HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            };
+        }
+    }
+
+    private static final class EmptyBodyRequestFactory extends SimpleClientHttpRequestFactory {
+        @Override
+        public ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod) {
+            return new MockClientHttpRequest(httpMethod, uri) {
+                @Override
+                protected ClientHttpResponse executeInternal() {
+                    MockClientHttpResponse response = new MockClientHttpResponse(new byte[0], HttpStatus.OK);
+                    response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+                    return response;
+                }
+            };
+        }
+    }
+}

--- a/core/src/test/java/com/mailsangja/core/service/google/GooglePeopleContactQueryServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/google/GooglePeopleContactQueryServiceTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class GooglePeopleContactQueryServiceTest {
 
     @Test
-    void getContacts_페이지네이션을따라가며이메일을정규화하고중복을제거한다() {
+    void getContacts_연락처와기타연락처페이지네이션을따라가며이메일을정규화하고중복을제거한다() {
         GooglePeopleProperties properties = createProperties();
         CapturingPagedRequestFactory requestFactory = new CapturingPagedRequestFactory(
                 """
@@ -63,6 +63,20 @@ class GooglePeopleContactQueryServiceTest {
                             }
                           ]
                         }
+                        """,
+                """
+                        {
+                          "otherContacts": [
+                            {
+                              "names": [{"displayName": "Other Duplicate"}],
+                              "emailAddresses": [{"value": "ALICE@example.com"}]
+                            },
+                            {
+                              "names": [{"displayName": "Other Contact"}],
+                              "emailAddresses": [{"value": "other@example.com"}]
+                            }
+                          ]
+                        }
                         """
         );
         GooglePeopleContactQueryService service = new GooglePeopleContactQueryService(
@@ -72,16 +86,22 @@ class GooglePeopleContactQueryServiceTest {
 
         List<GoogleContactResult> results = service.getContacts("access-token");
 
-        assertEquals(3, results.size());
+        assertEquals(4, results.size());
         assertEquals(new GoogleContactResult("Alice", "alice@example.com"), results.get(0));
         assertEquals(new GoogleContactResult("Bob Kim", "bob@example.com"), results.get(1));
         assertEquals(new GoogleContactResult("carol@example.com", "carol@example.com"), results.get(2));
+        assertEquals(new GoogleContactResult("Other Contact", "other@example.com"), results.get(3));
 
-        assertEquals(2, requestFactory.requestUris().size());
+        assertEquals(3, requestFactory.requestUris().size());
         assertTrue(requestFactory.requestUris().get(0).contains("personFields=names,emailAddresses"));
         assertTrue(requestFactory.requestUris().get(0).contains("pageSize=1000"));
         assertTrue(requestFactory.requestUris().get(1).contains("pageToken=next-token"));
-        assertEquals(List.of("Bearer access-token", "Bearer access-token"), requestFactory.authorizationHeaders());
+        assertTrue(requestFactory.requestUris().get(2).contains("/v1/otherContacts"));
+        assertTrue(requestFactory.requestUris().get(2).contains("readMask=names,emailAddresses"));
+        assertEquals(
+                List.of("Bearer access-token", "Bearer access-token", "Bearer access-token"),
+                requestFactory.authorizationHeaders()
+        );
     }
 
     @Test
@@ -121,6 +141,25 @@ class GooglePeopleContactQueryServiceTest {
     void getContacts_connectionsUri가공백이면API를호출하지않고실패한다() {
         GooglePeopleProperties properties = createProperties();
         properties.setConnectionsUri(" ");
+        CapturingPagedRequestFactory requestFactory = new CapturingPagedRequestFactory("{}");
+        GooglePeopleContactQueryService service = new GooglePeopleContactQueryService(
+                properties,
+                RestClient.builder().requestFactory(requestFactory).build()
+        );
+
+        ContactException exception = assertThrows(
+                ContactException.class,
+                () -> service.getContacts("access-token")
+        );
+
+        assertEquals(ContactErrorCode.GOOGLE_CONTACTS_FETCH_FAILED, exception.getErrorCode());
+        assertEquals(0, requestFactory.requestUris().size());
+    }
+
+    @Test
+    void getContacts_otherContactsUri가공백이면API를호출하지않고실패한다() {
+        GooglePeopleProperties properties = createProperties();
+        properties.setOtherContactsUri(" ");
         CapturingPagedRequestFactory requestFactory = new CapturingPagedRequestFactory("{}");
         GooglePeopleContactQueryService service = new GooglePeopleContactQueryService(
                 properties,
@@ -186,6 +225,11 @@ class GooglePeopleContactQueryServiceTest {
                             }
                           ]
                         }
+                        """,
+                        """
+                        {
+                          "otherContacts": []
+                        }
                         """)).build()
         );
 
@@ -200,6 +244,7 @@ class GooglePeopleContactQueryServiceTest {
     private GooglePeopleProperties createProperties() {
         GooglePeopleProperties properties = new GooglePeopleProperties();
         properties.setConnectionsUri("https://people.googleapis.com/v1/people/me/connections");
+        properties.setOtherContactsUri("https://people.googleapis.com/v1/otherContacts");
         properties.setPageSize(1000);
         return properties;
     }

--- a/db/src/main/java/com/mailsangja/db/adapter/contact/ContactRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/contact/ContactRepositoryAdapter.java
@@ -56,8 +56,18 @@ public class ContactRepositoryAdapter implements ContactRepositoryPort {
     }
 
     @Override
+    public List<Contact> findAllByUserIdAndDeletedAtIsNull(UUID userId) {
+        return contactJpaRepositoryModule.findAllByUserIdAndDeletedAtIsNull(userId);
+    }
+
+    @Override
     public Page<Contact> findAllByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable) {
         return contactJpaRepositoryModule.findAllByUserIdAndDeletedAtIsNull(userId, pageable);
+    }
+
+    @Override
+    public List<Contact> findAllByUserIdAndKeywordAndDeletedAtIsNull(UUID userId, String keyword) {
+        return contactJpaRepositoryModule.findAllByUserIdAndKeywordAndDeletedAtIsNull(userId, keyword);
     }
 
     @Override

--- a/db/src/main/java/com/mailsangja/db/adapter/contact/ContactRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/contact/ContactRepositoryAdapter.java
@@ -33,7 +33,7 @@ public class ContactRepositoryAdapter implements ContactRepositoryPort {
         if (contacts.isEmpty()) {
             return 0;
         }
-feat: 
+
         String[] ids = new String[contacts.size()];
         String[] userIds = new String[contacts.size()];
         String[] names = new String[contacts.size()];

--- a/db/src/main/java/com/mailsangja/db/adapter/contact/ContactRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/contact/ContactRepositoryAdapter.java
@@ -66,9 +66,4 @@ public class ContactRepositoryAdapter implements ContactRepositoryPort {
         );
     }
 
-    @Deprecated
-    @Override
-    public List<Contact> findAllByEmailInAndDeletedAtIsNull(List<String> emails) {
-        return contactJpaRepositoryModule.findAllByEmailInAndDeletedAtIsNull(emails);
-    }
 }

--- a/db/src/main/java/com/mailsangja/db/adapter/contact/ContactRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/contact/ContactRepositoryAdapter.java
@@ -4,9 +4,13 @@ import com.mailsangja.db.entity.contact.Contact;
 import com.mailsangja.db.module.contact.ContactJpaRepositoryModule;
 import com.mailsangja.db.port.ContactRepositoryPort;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 @RequiredArgsConstructor
@@ -20,8 +24,51 @@ public class ContactRepositoryAdapter implements ContactRepositoryPort {
     }
 
     @Override
+    public List<Contact> saveAll(List<Contact> contacts) {
+        return contactJpaRepositoryModule.saveAll(contacts);
+    }
+
+    @Override
+    public Optional<Contact> findByIdAndUserIdAndDeletedAtIsNull(UUID contactId, UUID userId) {
+        return contactJpaRepositoryModule.findByIdAndUserIdAndDeletedAtIsNull(contactId, userId);
+    }
+
+    @Override
+    public Page<Contact> findAllByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable) {
+        return contactJpaRepositoryModule.findAllByUserIdAndDeletedAtIsNull(userId, pageable);
+    }
+
+    @Override
+    public Page<Contact> findAllByUserIdAndKeywordAndDeletedAtIsNull(UUID userId, String keyword, Pageable pageable) {
+        return contactJpaRepositoryModule.findAllByUserIdAndKeywordAndDeletedAtIsNull(userId, keyword, pageable);
+    }
+
+    @Override
+    public List<Contact> findAllByUserIdAndEmailInAndDeletedAtIsNull(UUID userId, List<String> emails) {
+        return contactJpaRepositoryModule.findAllByUserIdAndEmailInAndDeletedAtIsNull(userId, emails);
+    }
+
+    @Override
+    public boolean existsByUserIdAndEmailIgnoreCaseAndDeletedAtIsNull(UUID userId, String email) {
+        return contactJpaRepositoryModule.existsByUserIdAndEmailIgnoreCaseAndDeletedAtIsNull(userId, email);
+    }
+
+    @Override
+    public boolean existsByUserIdAndEmailIgnoreCaseAndIdNotAndDeletedAtIsNull(
+            UUID userId,
+            String email,
+            UUID excludeId
+    ) {
+        return contactJpaRepositoryModule.existsByUserIdAndEmailIgnoreCaseAndIdNotAndDeletedAtIsNull(
+                userId,
+                email,
+                excludeId
+        );
+    }
+
+    @Deprecated
+    @Override
     public List<Contact> findAllByEmailInAndDeletedAtIsNull(List<String> emails) {
         return contactJpaRepositoryModule.findAllByEmailInAndDeletedAtIsNull(emails);
     }
 }
-

--- a/db/src/main/java/com/mailsangja/db/adapter/contact/ContactRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/contact/ContactRepositoryAdapter.java
@@ -29,6 +29,28 @@ public class ContactRepositoryAdapter implements ContactRepositoryPort {
     }
 
     @Override
+    public int saveAllIgnoreDuplicateActive(List<Contact> contacts) {
+        if (contacts.isEmpty()) {
+            return 0;
+        }
+feat: 
+        String[] ids = new String[contacts.size()];
+        String[] userIds = new String[contacts.size()];
+        String[] names = new String[contacts.size()];
+        String[] emails = new String[contacts.size()];
+
+        for (int index = 0; index < contacts.size(); index++) {
+            Contact contact = contacts.get(index);
+            ids[index] = UUID.randomUUID().toString();
+            userIds[index] = contact.getUser().getId().toString();
+            names[index] = contact.getName();
+            emails[index] = contact.getEmail();
+        }
+
+        return contactJpaRepositoryModule.insertAllIgnoreDuplicateActive(ids, userIds, names, emails);
+    }
+
+    @Override
     public Optional<Contact> findByIdAndUserIdAndDeletedAtIsNull(UUID contactId, UUID userId) {
         return contactJpaRepositoryModule.findByIdAndUserIdAndDeletedAtIsNull(contactId, userId);
     }

--- a/db/src/main/java/com/mailsangja/db/adapter/contact/ContactRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/contact/ContactRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package com.mailsangja.db.adapter.contact;
 
 import com.mailsangja.db.entity.contact.Contact;
+import com.mailsangja.db.module.contact.ContactBulkInsertModule;
 import com.mailsangja.db.module.contact.ContactJpaRepositoryModule;
 import com.mailsangja.db.port.ContactRepositoryPort;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import java.util.UUID;
 public class ContactRepositoryAdapter implements ContactRepositoryPort {
 
     private final ContactJpaRepositoryModule contactJpaRepositoryModule;
+    private final ContactBulkInsertModule contactBulkInsertModule;
 
     @Override
     public Contact save(Contact contact) {
@@ -47,7 +49,7 @@ public class ContactRepositoryAdapter implements ContactRepositoryPort {
             emails[index] = contact.getEmail();
         }
 
-        return contactJpaRepositoryModule.insertAllIgnoreDuplicateActive(ids, userIds, names, emails);
+        return contactBulkInsertModule.insertAllIgnoreDuplicateActive(ids, userIds, names, emails);
     }
 
     @Override

--- a/db/src/main/java/com/mailsangja/db/entity/contact/Contact.java
+++ b/db/src/main/java/com/mailsangja/db/entity/contact/Contact.java
@@ -45,6 +45,14 @@ public class Contact extends BaseEntity {
     @Column(name = "email", nullable = false, length = 255)
     private String email;
 
+    public static Contact create(User user, String name, String email) {
+        return Contact.builder()
+                .user(user)
+                .name(name)
+                .email(email)
+                .build();
+    }
+
     public void updateName(String name) {
         this.name = name;
     }

--- a/db/src/main/java/com/mailsangja/db/entity/contact/Contact.java
+++ b/db/src/main/java/com/mailsangja/db/entity/contact/Contact.java
@@ -41,7 +41,7 @@ public class Contact extends BaseEntity {
 
     @Column(name = "name", nullable = false, length = 255)
     private String name;
-fix: 
+
     @Column(name = "email", nullable = false, length = 255)
     private String email;
 

--- a/db/src/main/java/com/mailsangja/db/entity/contact/Contact.java
+++ b/db/src/main/java/com/mailsangja/db/entity/contact/Contact.java
@@ -1,11 +1,15 @@
 package com.mailsangja.db.entity.contact;
 
 import com.mailsangja.db.entity.common.BaseEntity;
+import com.mailsangja.db.entity.user.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -31,14 +35,21 @@ public class Contact extends BaseEntity {
     @JdbcTypeCode(SqlTypes.CHAR)
     private UUID id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
     @Column(name = "name", nullable = false, length = 255)
     private String name;
-
-    @Column(name = "email", nullable = false, unique = true, length = 255)
+fix: 
+    @Column(name = "email", nullable = false, length = 255)
     private String email;
 
     public void updateName(String name) {
         this.name = name;
     }
-}
 
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+}

--- a/db/src/main/java/com/mailsangja/db/entity/contact/Contact.java
+++ b/db/src/main/java/com/mailsangja/db/entity/contact/Contact.java
@@ -56,8 +56,4 @@ public class Contact extends BaseEntity {
     public void updateName(String name) {
         this.name = name;
     }
-
-    public void updateEmail(String email) {
-        this.email = email;
-    }
 }

--- a/db/src/main/java/com/mailsangja/db/module/contact/ContactBulkInsertModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/contact/ContactBulkInsertModule.java
@@ -1,0 +1,56 @@
+package com.mailsangja.db.module.contact;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementCallback;
+import org.springframework.jdbc.core.PreparedStatementCreator;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Array;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@Repository
+@RequiredArgsConstructor
+public class ContactBulkInsertModule {
+
+    private static final String TEXT_ARRAY_TYPE = "text";
+    private static final String INSERT_ALL_IGNORE_DUPLICATE_ACTIVE_SQL = """
+            INSERT INTO contacts (id, user_id, name, email, created_at, modified_at)
+            SELECT id, user_id, name, email, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+            FROM unnest(
+                CAST(? AS text[]),
+                CAST(? AS text[]),
+                CAST(? AS text[]),
+                CAST(? AS text[])
+            ) AS contact_data(id, user_id, name, email)
+            ON CONFLICT (user_id, (lower(email))) WHERE deleted_at IS NULL DO NOTHING
+            """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public int insertAllIgnoreDuplicateActive(String[] ids, String[] userIds, String[] names, String[] emails) {
+        PreparedStatementCreator creator = connection -> connection.prepareStatement(INSERT_ALL_IGNORE_DUPLICATE_ACTIVE_SQL);
+        PreparedStatementCallback<Integer> callback =
+                statement -> executeInsertAllIgnoreDuplicateActive(statement, ids, userIds, names, emails);
+        return jdbcTemplate.execute(creator, callback);
+    }
+
+    private int executeInsertAllIgnoreDuplicateActive(
+            PreparedStatement statement,
+            String[] ids,
+            String[] userIds,
+            String[] names,
+            String[] emails
+    ) throws SQLException {
+        statement.setArray(1, createTextArray(statement, ids));
+        statement.setArray(2, createTextArray(statement, userIds));
+        statement.setArray(3, createTextArray(statement, names));
+        statement.setArray(4, createTextArray(statement, emails));
+        return statement.executeUpdate();
+    }
+
+    private Array createTextArray(PreparedStatement statement, String[] values) throws SQLException {
+        return statement.getConnection().createArrayOf(TEXT_ARRAY_TYPE, values);
+    }
+}

--- a/db/src/main/java/com/mailsangja/db/module/contact/ContactJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/contact/ContactJpaRepositoryModule.java
@@ -4,6 +4,7 @@ import com.mailsangja.db.entity.contact.Contact;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -31,6 +32,25 @@ public interface ContactJpaRepositoryModule extends JpaRepository<Contact, UUID>
             @Param("userId") UUID userId,
             @Param("keyword") String keyword,
             Pageable pageable
+    );
+
+    @Modifying
+    @Query(value = """
+            INSERT INTO contacts (id, user_id, name, email, created_at, modified_at)
+            SELECT id, user_id, name, email, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+            FROM unnest(
+                CAST(:ids AS text[]),
+                CAST(:userIds AS text[]),
+                CAST(:names AS text[]),
+                CAST(:emails AS text[])
+            ) AS contact_data(id, user_id, name, email)
+            ON CONFLICT (user_id, lower(email)) WHERE deleted_at IS NULL DO NOTHING
+            """, nativeQuery = true)
+    int insertAllIgnoreDuplicateActive(
+            @Param("ids") String[] ids,
+            @Param("userIds") String[] userIds,
+            @Param("names") String[] names,
+            @Param("emails") String[] emails
     );
 
     List<Contact> findAllByUserIdAndEmailInAndDeletedAtIsNull(UUID userId, Collection<String> emails);

--- a/db/src/main/java/com/mailsangja/db/module/contact/ContactJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/contact/ContactJpaRepositoryModule.java
@@ -51,6 +51,4 @@ public interface ContactJpaRepositoryModule extends JpaRepository<Contact, UUID>
             @Param("excludeId") UUID excludeId
     );
 
-    @Deprecated
-    List<Contact> findAllByEmailInAndDeletedAtIsNull(Collection<String> emails);
 }

--- a/db/src/main/java/com/mailsangja/db/module/contact/ContactJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/contact/ContactJpaRepositoryModule.java
@@ -1,13 +1,56 @@
 package com.mailsangja.db.module.contact;
 
 import com.mailsangja.db.entity.contact.Contact;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ContactJpaRepositoryModule extends JpaRepository<Contact, UUID> {
+    Optional<Contact> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId);
+
+    Page<Contact> findAllByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
+
+    @Query("""
+            SELECT c
+            FROM Contact c
+            WHERE c.user.id = :userId
+              AND c.deletedAt IS NULL
+              AND (
+                    lower(c.name) LIKE lower(concat('%', :keyword, '%'))
+                    OR lower(c.email) LIKE lower(concat('%', :keyword, '%'))
+              )
+            """)
+    Page<Contact> findAllByUserIdAndKeywordAndDeletedAtIsNull(
+            @Param("userId") UUID userId,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    List<Contact> findAllByUserIdAndEmailInAndDeletedAtIsNull(UUID userId, Collection<String> emails);
+
+    boolean existsByUserIdAndEmailIgnoreCaseAndDeletedAtIsNull(UUID userId, String email);
+
+    @Query("""
+            SELECT COUNT(c) > 0
+            FROM Contact c
+            WHERE c.user.id = :userId
+              AND lower(c.email) = lower(:email)
+              AND c.id <> :excludeId
+              AND c.deletedAt IS NULL
+            """)
+    boolean existsByUserIdAndEmailIgnoreCaseAndIdNotAndDeletedAtIsNull(
+            @Param("userId") UUID userId,
+            @Param("email") String email,
+            @Param("excludeId") UUID excludeId
+    );
+
+    @Deprecated
     List<Contact> findAllByEmailInAndDeletedAtIsNull(Collection<String> emails);
 }
-

--- a/db/src/main/java/com/mailsangja/db/module/contact/ContactJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/contact/ContactJpaRepositoryModule.java
@@ -4,7 +4,6 @@ import com.mailsangja.db.entity.contact.Contact;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -49,25 +48,6 @@ public interface ContactJpaRepositoryModule extends JpaRepository<Contact, UUID>
             @Param("userId") UUID userId,
             @Param("keyword") String keyword,
             Pageable pageable
-    );
-
-    @Modifying
-    @Query(value = """
-            INSERT INTO contacts (id, user_id, name, email, created_at, modified_at)
-            SELECT id, user_id, name, email, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
-            FROM unnest(
-                CAST(:ids AS text[]),
-                CAST(:userIds AS text[]),
-                CAST(:names AS text[]),
-                CAST(:emails AS text[])
-            ) AS contact_data(id, user_id, name, email)
-            ON CONFLICT (user_id, (lower(email))) WHERE deleted_at IS NULL DO NOTHING
-            """, nativeQuery = true)
-    int insertAllIgnoreDuplicateActive(
-            @Param("ids") String[] ids,
-            @Param("userIds") String[] userIds,
-            @Param("names") String[] names,
-            @Param("emails") String[] emails
     );
 
     List<Contact> findAllByUserIdAndEmailInAndDeletedAtIsNull(UUID userId, Collection<String> emails);

--- a/db/src/main/java/com/mailsangja/db/module/contact/ContactJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/contact/ContactJpaRepositoryModule.java
@@ -61,7 +61,7 @@ public interface ContactJpaRepositoryModule extends JpaRepository<Contact, UUID>
                 CAST(:names AS text[]),
                 CAST(:emails AS text[])
             ) AS contact_data(id, user_id, name, email)
-            ON CONFLICT (user_id, lower(email)) WHERE deleted_at IS NULL DO NOTHING
+            ON CONFLICT (user_id, (lower(email))) WHERE deleted_at IS NULL DO NOTHING
             """, nativeQuery = true)
     int insertAllIgnoreDuplicateActive(
             @Param("ids") String[] ids,

--- a/db/src/main/java/com/mailsangja/db/module/contact/ContactJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/contact/ContactJpaRepositoryModule.java
@@ -16,7 +16,24 @@ import java.util.UUID;
 public interface ContactJpaRepositoryModule extends JpaRepository<Contact, UUID> {
     Optional<Contact> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId);
 
+    List<Contact> findAllByUserIdAndDeletedAtIsNull(UUID userId);
+
     Page<Contact> findAllByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
+
+    @Query("""
+            SELECT c
+            FROM Contact c
+            WHERE c.user.id = :userId
+              AND c.deletedAt IS NULL
+              AND (
+                    lower(c.name) LIKE lower(concat('%', :keyword, '%'))
+                    OR lower(c.email) LIKE lower(concat('%', :keyword, '%'))
+              )
+            """)
+    List<Contact> findAllByUserIdAndKeywordAndDeletedAtIsNull(
+            @Param("userId") UUID userId,
+            @Param("keyword") String keyword
+    );
 
     @Query("""
             SELECT c

--- a/db/src/main/java/com/mailsangja/db/port/ContactRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/ContactRepositoryPort.java
@@ -24,7 +24,4 @@ public interface ContactRepositoryPort {
     boolean existsByUserIdAndEmailIgnoreCaseAndDeletedAtIsNull(UUID userId, String email);
 
     boolean existsByUserIdAndEmailIgnoreCaseAndIdNotAndDeletedAtIsNull(UUID userId, String email, UUID excludeId);
-
-    @Deprecated
-    List<Contact> findAllByEmailInAndDeletedAtIsNull(List<String> emails);
 }

--- a/db/src/main/java/com/mailsangja/db/port/ContactRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/ContactRepositoryPort.java
@@ -13,6 +13,8 @@ public interface ContactRepositoryPort {
 
     List<Contact> saveAll(List<Contact> contacts);
 
+    int saveAllIgnoreDuplicateActive(List<Contact> contacts);
+
     Optional<Contact> findByIdAndUserIdAndDeletedAtIsNull(UUID contactId, UUID userId);
 
     Page<Contact> findAllByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);

--- a/db/src/main/java/com/mailsangja/db/port/ContactRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/ContactRepositoryPort.java
@@ -17,7 +17,11 @@ public interface ContactRepositoryPort {
 
     Optional<Contact> findByIdAndUserIdAndDeletedAtIsNull(UUID contactId, UUID userId);
 
+    List<Contact> findAllByUserIdAndDeletedAtIsNull(UUID userId);
+
     Page<Contact> findAllByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
+
+    List<Contact> findAllByUserIdAndKeywordAndDeletedAtIsNull(UUID userId, String keyword);
 
     Page<Contact> findAllByUserIdAndKeywordAndDeletedAtIsNull(UUID userId, String keyword, Pageable pageable);
 

--- a/db/src/main/java/com/mailsangja/db/port/ContactRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/ContactRepositoryPort.java
@@ -1,10 +1,30 @@
 package com.mailsangja.db.port;
 
 import com.mailsangja.db.entity.contact.Contact;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface ContactRepositoryPort {
     Contact save(Contact contact);
+
+    List<Contact> saveAll(List<Contact> contacts);
+
+    Optional<Contact> findByIdAndUserIdAndDeletedAtIsNull(UUID contactId, UUID userId);
+
+    Page<Contact> findAllByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
+
+    Page<Contact> findAllByUserIdAndKeywordAndDeletedAtIsNull(UUID userId, String keyword, Pageable pageable);
+
+    List<Contact> findAllByUserIdAndEmailInAndDeletedAtIsNull(UUID userId, List<String> emails);
+
+    boolean existsByUserIdAndEmailIgnoreCaseAndDeletedAtIsNull(UUID userId, String email);
+
+    boolean existsByUserIdAndEmailIgnoreCaseAndIdNotAndDeletedAtIsNull(UUID userId, String email, UUID excludeId);
+
+    @Deprecated
     List<Contact> findAllByEmailInAndDeletedAtIsNull(List<String> emails);
 }

--- a/db/src/main/resources/init.sql
+++ b/db/src/main/resources/init.sql
@@ -11,6 +11,10 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_gmail_thread_locks_account_thread
 CREATE UNIQUE INDEX IF NOT EXISTS uq_messages_thread_gmail
     ON messages (thread_id, gmail_message_id);
 
+CREATE UNIQUE INDEX IF NOT EXISTS uq_contacts_user_email_active
+    ON contacts (user_id, lower(email))
+    WHERE deleted_at IS NULL;
+
 CREATE UNIQUE INDEX IF NOT EXISTS uq_labels_user_name_active
     ON labels (user_id, lower(name))
     WHERE deleted_at IS NULL;

--- a/db/src/main/resources/schema.sql
+++ b/db/src/main/resources/schema.sql
@@ -137,6 +137,23 @@ CREATE TABLE IF NOT EXISTS attachments (
     CONSTRAINT fk_attachments_message FOREIGN KEY (message_id) REFERENCES messages (id)
 );
 
+CREATE TABLE IF NOT EXISTS contacts (
+    id          CHAR(36)     NOT NULL,
+    user_id     CHAR(36)     NOT NULL,
+    name        VARCHAR(255) NOT NULL,
+    email       VARCHAR(255) NOT NULL,
+    created_at  TIMESTAMP    NOT NULL,
+    modified_at TIMESTAMP    NOT NULL,
+    deleted_at  TIMESTAMP    NULL,
+
+    PRIMARY KEY (id),
+    CONSTRAINT fk_contacts_user FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_contacts_user_email_active
+    ON contacts (user_id, lower(email))
+    WHERE deleted_at IS NULL;
+
 CREATE TABLE IF NOT EXISTS labels (
     id                   CHAR(36)     NOT NULL,
     user_id              CHAR(36)     NOT NULL,


### PR DESCRIPTION
  ## 🔗 관련 작업

  ### 👤 User Story
  - mailsangja/docs4capstone#30

  ### 📌 Task
  - Closes #104


  ## 💡 작업 내용

  - **Gmail 주소록 초기 동기화 구현**
    - Gmail 계정 최초 연동 callback 흐름에서 메일 계정 저장 후 초기 메일 동기화 MQ를 발행하고, Google People API로 주소록을 조회해 저장합니다.
    - Google Contacts(`people/me/connections`)와 Gmail 자동완성 기반 Other contacts(`otherContacts`)를 함께 조회합니다.
    - email 기준으로 중복을 제거하고, DB의 `(user_id, lower(email)) WHERE deleted_at IS NULL` unique index를 통해 active 연락처 중복 저장을 방지합니다.

  - **주소록 API 구현**
    - `POST /api/v1/contacts`: 사용자가 직접 연락처 생성
    - `GET /api/v1/contacts`: 로그인 사용자의 active 연락처 목록 조회
    - `PATCH /api/v1/contacts/{contactId}`: 연락처 이름 수정
    - `DELETE /api/v1/contacts/{contactId}`: 연락처 soft delete

  - **주소록 도메인/예외 처리 보강**
    - 연락처는 사용자별 주소록으로 관리합니다.
    - 수정/삭제는 현재 로그인 사용자의 active contact에 대해서만 수행합니다.
    - 수정 API는 email 변경을 허용하지 않고 name만 변경합니다.
    - 삭제 API는 물리 삭제가 아니라 `deletedAt` 기반 soft delete로 처리합니다.


  ## 📝 추가 설명

  ### 1. Gmail 최초 연동 시 주소록 동기화 흐름

  ```mermaid
  sequenceDiagram
      participant Client
      participant Core as Core API
      participant Google as Google OAuth / People API
      participant DB
      participant MQ

      Client->>Core: GET /api/v1/mail-accounts/google/callback
      Core->>Google: Authorization code로 token/account 정보 조회
      Core->>Google: Gmail watch 등록
      Core->>DB: Gmail MailAccount 저장
      Core->>MQ: 초기 메일 동기화 메시지 발행
      Core->>Google: people/me/connections 조회
      Core->>Google: otherContacts 조회
      Core->>DB: active email 중복은 DB unique index로 무시하며 주소록 저장
      Core-->>Client: MailAccountResponse
```

  - 주소록 동기화 실패는 Gmail 계정 연동 자체를 실패시키지 않고 warn 로그로 남깁니다.
  - Google People API 실패 시 HTTP status/body를 로그에 남겨 scope/API 비활성화 문제를 확인할 수 있도록 했습니다.
  - Other contacts 조회를 위해 OAuth scope에 https://www.googleapis.com/auth/contacts.other.readonly를 추가했습니다.
  - 새 scope 적용을 위해 기존 Gmail 계정은 재연동이 필요합니다.

  ### 2. 주소록 CRUD 흐름

 ```mermaid
  sequenceDiagram
      participant Client
      participant Controller
      participant Facade
      participant QueryService
      participant CommandService
      participant DB

      Client->>Controller: PATCH/DELETE /api/v1/contacts/{contactId}
      Controller->>Facade: @AuthUser + contactId + request
      Facade->>QueryService: findActiveContact(user, contactId)
      QueryService->>DB: contactId + userId + deletedAt IS NULL 조회
      DB-->>QueryService: Contact or empty
      QueryService-->>Facade: Contact
      Facade->>CommandService: updateName(contact) or delete(contact)
      CommandService->>DB: save(contact)
      Facade-->>Controller: ContactResponse or 204
```

  - 다른 사용자의 연락처, 이미 삭제된 연락처, 존재하지 않는 연락처는 모두 MS-CONTACT-NOT-FOUND로 처리합니다.
  - 생성/수정 요청 값이 올바르지 않으면 MS-CONTACT-INVALID-REQUEST를 반환합니다.
  - 같은 사용자의 active 연락처 중 email 중복은 MS-CONTACT-EMAIL-DUPLICATE로 처리합니다.

  ### 3. 조회 및 검색 기준

  - GET /api/v1/contacts
      - 로그인 사용자의 active 연락처만 반환합니다.
      - deleted contact는 조회되지 않습니다.
  - GET /api/v1/contacts?keyword={keyword}
      - name, email 기준으로 검색합니다.
      - keyword가 없거나 blank이면 전체 active 연락처를 반환합니다.

  ## ⚡️ Test 결과

  | 주소록 목록 조회 | 주소록 생성 | 주소록 이름 수정 | 주소록 삭제 |
  | -- | -- | -- | -- |
  | GET | POST | PATCH | DELETE |
  | /api/v1/contacts | /api/v1/contacts | /api/v1/contacts/{contactId} | /api/v1/contacts/{contactId} |
  | <img width="1377" height="764" alt="스크린샷 2026-05-08 150714" src="https://github.com/user-attachments/assets/9ccb79d7-1ad8-4ece-9377-7e041ce3e102" /> | <img width="1412" height="807" alt="스크린샷 2026-05-08 150730" src="https://github.com/user-attachments/assets/4f9b6cd9-fd24-47cf-9715-062805626da0" />  | <img width="1394" height="757" alt="스크린샷 2026-05-08 150842" src="https://github.com/user-attachments/assets/cc3d75d6-bc6e-4f1a-a08d-c55df87f4231" /> | <img width="1382" height="783" alt="스크린샷 2026-05-08 150909" src="https://github.com/user-attachments/assets/57a5901e-699d-46a3-9590-a6d2027077ed" /> |