### PR TITLE
[STORY-403] 라벨 제안 상세 조회 API 구현

### DIFF
--- a/core/src/main/java/com/mailsangja/core/controller/LabelController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/LabelController.java
@@ -100,6 +100,15 @@ public class LabelController implements LabelControllerDocs {
     }
 
     @Override
+    @GetMapping("/api/v1/labels/suggestions/{suggestionId}")
+    public ResponseEntity<LabelDetailResponse> getSuggestionDetail(
+            @AuthUser User user,
+            @PathVariable UUID suggestionId
+    ) {
+        return ResponseEntity.ok(labelFacade.getSuggestionDetail(user, suggestionId));
+    }
+
+    @Override
     @PostMapping("/api/v1/labels/suggestions/{suggestionId}/approve")
     public ResponseEntity<LabelDetailResponse> approveSuggestion(
             @AuthUser User user,

--- a/core/src/main/java/com/mailsangja/core/controller/docs/LabelControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/LabelControllerDocs.java
@@ -166,6 +166,23 @@ public interface LabelControllerDocs {
     );
 
     @Operation(
+            summary = "라벨 제안 단건 조회",
+            description = "특정 라벨 제안의 상세 정보를 반환합니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "라벨 제안 단건 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "라벨 제안을 찾을 수 없음",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<LabelDetailResponse> getSuggestionDetail(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "라벨 제안 ID", required = true) @PathVariable UUID suggestionId
+    );
+
+    @Operation(
             summary = "라벨 제안 단건 승인",
             description = "라벨 제안을 수정하여 confirmed=true로 전환합니다. 요청 바디로 이름·색상·순서·알림정책·규칙을 원하는 값으로 변경한 뒤 승인할 수 있습니다. rule이 있는 라벨은 승인 후 과거 메일 재분류 작업이 비동기로 발행됩니다.",
             security = @SecurityRequirement(name = "cookieAuth")

--- a/core/src/main/java/com/mailsangja/core/facade/LabelFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/LabelFacade.java
@@ -102,6 +102,11 @@ public class LabelFacade {
                 .toList();
     }
 
+    public LabelDetailResponse getSuggestionDetail(User user, UUID suggestionId) {
+        Label suggestion = labelQueryService.findSuggestionByIdAndUserId(suggestionId, user.getId());
+        return LabelDetailResponse.of(suggestion, suggestion.getRule());
+    }
+
     public List<LabelListResponse> getSuggestions(User user) {
         return labelQueryService.findAllSuggestionsByUserId(user.getId()).stream()
                 .map(label -> LabelListResponse.of(label, 0L))

--- a/core/src/test/java/com/mailsangja/core/facade/LabelFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/LabelFacadeTest.java
@@ -210,6 +210,31 @@ class LabelFacadeTest {
     }
 
     @Test
+    void 라벨제안단건조회_제안의규칙반환() {
+        User user = user();
+        LabelRule rule = rule("invoice");
+        Label suggestion = label("업무", 1, rule);
+        when(labelQueryService.findSuggestionByIdAndUserId(suggestion.getId(), user.getId())).thenReturn(suggestion);
+
+        LabelDetailResponse response = labelFacade.getSuggestionDetail(user, suggestion.getId());
+
+        assertEquals(suggestion.getId(), response.id());
+        assertSame(rule, response.rule());
+    }
+
+    @Test
+    void 라벨제안단건조회_규칙없는제안_null규칙반환() {
+        User user = user();
+        Label suggestion = label("업무", 1, null);
+        when(labelQueryService.findSuggestionByIdAndUserId(suggestion.getId(), user.getId())).thenReturn(suggestion);
+
+        LabelDetailResponse response = labelFacade.getSuggestionDetail(user, suggestion.getId());
+
+        assertEquals(suggestion.getId(), response.id());
+        assertEquals(null, response.rule());
+    }
+
+    @Test
     void 라벨삭제_CommandService에위임() {
         User user = user();
         Label label = label("삭제", 1);


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#18

### 📌 Task
- #78 


## 💡 작업 내용

- 라벨 제안 단건 조회 API 구현
- `GET /api/v1/labels/suggestions/{suggestionId}`
- Facade 테스트 코드 작성
  - 규칙이 있는 제안 조회 시 id와 rule이 그대로 반환됨을 검증
  - rule이 없는 제안도 null rule로 정상 반환됨을 검증


## ⚡️ Test 결과


<img width="1474" height="726" alt="image" src="https://github.com/user-attachments/assets/b3fbd6f6-3e67-4c8c-8211-4bbaf6342be8" />