### PR TITLE
[STORY-501] AI 초안 SSE 스트리밍 및 메일 컨텍스트 기반 작성 안정화

### DIFF
--- a/core/src/main/java/com/mailsangja/core/service/ai/draft/MailDraftQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/ai/draft/MailDraftQueryService.java
@@ -70,7 +70,14 @@ public class MailDraftQueryService {
             Use thread emails only to understand reply context and prior commitments.
             Prefer concise, specific, and business-appropriate wording.
             Choose the draft language from the situation, not from a Korean default.
-            Infer the best language from the user's query, recipient address/domain, thread language, recipient_history, and reference emails.
+            Before drafting, decide the output language by priority:
+            1. If the user explicitly requests a language, use that language.
+            2. If the user uses contrastive wording such as "한글 말고 영어", "not Korean but English", "instead", or "대신", use the language after the contrast.
+            3. Otherwise, if recipient_history or thread emails have a dominant language, use that dominant language.
+            4. Otherwise, use the user's query language.
+            5. Otherwise, use Korean.
+            The user's query language is only an instruction language. It is not automatically the email output language.
+            If recipient_history is mostly English and the query is Korean, write the email in English.
             For replies, primarily use the language of the thread unless the user explicitly asks for a different language.
             For new outbound drafts, use the requested language if stated; otherwise match the recipient and most relevant prior emails.
             If the situation is mixed or unclear, use the user's query language.
@@ -99,6 +106,9 @@ public class MailDraftQueryService {
             For GENERAL drafts, infer a new outbound email from the user's query and references.
             Prioritize the user's query, then relevant_received and entity_hint emails for context.
             Use relevant_sent and recent_sent emails for prior response patterns and style.
+            If recipient_history exists, choose the draft language from the dominant language used with the target recipient.
+            If prior emails with the recipient are mostly English, write the draft in English even if the user's query is written in Korean.
+            Use the user's query language only when recipient_history is missing, mixed, or insufficient.
             """;
     private static final String REPLY_SYSTEM_PROMPT = SYSTEM_PROMPT + """
             Draft type: REPLY.
@@ -145,11 +155,11 @@ public class MailDraftQueryService {
     }
 
     public MailDraftPromptResult generalPrompt(MailDraftCommand command, MailDraftRagContextResult context) {
-        return new MailDraftPromptResult(GENERAL_SYSTEM_PROMPT, buildUserPrompt(command, context));
+        return new MailDraftPromptResult(GENERAL_SYSTEM_PROMPT, buildUserPrompt(command, context, DraftPromptType.GENERAL));
     }
 
     public MailDraftPromptResult replyPrompt(MailDraftCommand command, MailDraftRagContextResult context) {
-        return new MailDraftPromptResult(REPLY_SYSTEM_PROMPT, buildUserPrompt(command, context));
+        return new MailDraftPromptResult(REPLY_SYSTEM_PROMPT, buildUserPrompt(command, context, DraftPromptType.REPLY));
     }
 
     public MailDraftRagContextResult generalRagContext(MailDraftCommand command) {
@@ -219,11 +229,27 @@ public class MailDraftQueryService {
         return values;
     }
 
-    private String buildUserPrompt(MailDraftCommand command, MailDraftRagContextResult context) {
+    private String buildUserPrompt(MailDraftCommand command, MailDraftRagContextResult context, DraftPromptType promptType) {
         StringBuilder builder = new StringBuilder();
+        appendLanguageSelectionPolicy(builder, promptType);
         appendRequest(builder, command);
         appendReferenceEmails(builder, context);
         return builder.toString();
+    }
+
+    private void appendLanguageSelectionPolicy(StringBuilder builder, DraftPromptType promptType) {
+        builder.append("<language_selection_policy>\n");
+        if (promptType == DraftPromptType.REPLY) {
+            builder.append("Choose the reply output language before writing. Apply this priority exactly: explicit language request in query, contrastive language after words like '말고' or 'instead', dominant thread_emails language, recipient_history language, query language, Korean default.\n");
+            builder.append("For replies, the query language is an instruction language only. Do not choose Korean only because the query is Korean.\n");
+            builder.append("If thread_emails are mostly English and the query is Korean, write the reply in English.\n");
+        } else {
+            builder.append("Choose the email output language before writing. Apply this priority exactly: explicit language request in query, contrastive language after words like '말고' or 'instead', dominant recipient_history or thread language, query language, Korean default.\n");
+            builder.append("The query language is an instruction language only. Do not choose Korean only because the query is Korean.\n");
+            builder.append("If recipient_history is mostly English and the query is Korean, write the email in English.\n");
+        }
+        builder.append("Do not explain the selected language in the output.\n");
+        builder.append("</language_selection_policy>\n");
     }
 
     private void appendRequest(StringBuilder builder, MailDraftCommand command) {
@@ -257,7 +283,7 @@ public class MailDraftQueryService {
 
     private void appendRecipientHistoryEmails(StringBuilder builder, List<MailDraftSearchContextResult> messages) {
         builder.append("<recipient_history_emails purpose=\"recipient_specific_context\">\n");
-        builder.append("<instruction>Use these emails to adapt salutation, tone, relationship context, and prior conversation with the target recipient. Do not copy unrelated facts.</instruction>\n");
+        builder.append("<instruction>Use these emails as the strongest context for recipient-specific output language, salutation, tone, relationship context, and prior conversation with the target recipient. Do not copy unrelated facts.</instruction>\n");
         appendReferenceEmailItems(builder, messages);
         builder.append("</recipient_history_emails>\n");
     }
@@ -287,9 +313,36 @@ public class MailDraftQueryService {
         if (referenceQueryPort == null || hints.isEmpty()) {
             return List.of();
         }
-        return toMaskedContexts(referenceQueryPort.findRecipientHistoryMessages(
+        List<MailDraftReferenceMessageResult> messages = referenceQueryPort.findRecipientHistoryMessages(
                 command.userId(), command.mailAccountId(), hints, RECIPIENT_HISTORY_LIMIT
-        ), SOURCE_RECIPIENT_HISTORY);
+        );
+        logRecipientHistoryMessages(command, hints, messages);
+        return toMaskedContexts(messages, SOURCE_RECIPIENT_HISTORY);
+    }
+
+    private void logRecipientHistoryMessages(MailDraftCommand command, List<String> hints,
+                                             List<MailDraftReferenceMessageResult> messages) {
+        if (messages.isEmpty()) {
+            log.info("Mail draft recipient history empty. userId={} mailAccountId={} hintCount={}",
+                    command.userId(), command.mailAccountId(), hints.size());
+            return;
+        }
+        for (MailDraftReferenceMessageResult message : messages) {
+            log.info("Mail draft recipient history selected. userId={} mailAccountId={} hintCount={} messageId={} direction={} subject={}",
+                    command.userId(), command.mailAccountId(), hints.size(), message.messageId(), message.direction(),
+                    logPreview(message.subject()));
+        }
+    }
+
+    private String logPreview(String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+        String normalized = value.replaceAll("\\s+", " ").trim();
+        if (normalized.length() <= 80) {
+            return normalized;
+        }
+        return normalized.substring(0, 80);
     }
 
     private List<String> recipientHints(MailDraftCommand command) {
@@ -640,4 +693,10 @@ public class MailDraftQueryService {
         }
         return toMaskedContexts(referenceQueryPort.findThreadContextMessages(replyMessageId), SOURCE_THREAD);
     }
+
+    private enum DraftPromptType {
+        GENERAL,
+        REPLY
+    }
+
 }

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -33,6 +33,7 @@ spring:
       chat:
         options:
           model: ${OPENAI_CHAT_MODEL:gpt-4o-mini}
+          temperature: ${OPENAI_CHAT_TEMPERATURE:0.3}
       embedding:
         options:
           model: ${OPENAI_EMBEDDING_MODEL:text-embedding-3-small}

--- a/core/src/test/java/com/mailsangja/core/service/ai/draft/MailDraftQueryServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/ai/draft/MailDraftQueryServiceTest.java
@@ -100,6 +100,8 @@ class MailDraftQueryServiceTest {
         assertTrue(result.userPrompt().contains("<thread_emails purpose=\"reply_context\">"));
         assertTrue(result.userPrompt().contains("<recipient_history_emails purpose=\"recipient_specific_context\">"));
         assertTrue(result.userPrompt().contains("<relevant_emails purpose=\"facts_and_prior_responses\">"));
+        assertTrue(result.userPrompt().contains("<language_selection_policy>"));
+        assertTrue(result.userPrompt().indexOf("<language_selection_policy>") < result.userPrompt().indexOf("<draft_request>"));
         assertFalse(result.userPrompt().contains("alice@example.com"));
     }
 
@@ -156,6 +158,10 @@ class MailDraftQueryServiceTest {
 
         // then
         assertTrue(result.systemPrompt().contains("Choose the draft language from the situation"));
+        assertTrue(result.systemPrompt().contains("Before drafting, decide the output language by priority"));
+        assertTrue(result.systemPrompt().contains("If the user explicitly requests a language, use that language"));
+        assertTrue(result.systemPrompt().contains("If the user uses contrastive wording"));
+        assertTrue(result.systemPrompt().contains("The user's query language is only an instruction language"));
         assertTrue(result.systemPrompt().contains("For replies, primarily use the language of the thread"));
         assertTrue(result.systemPrompt().contains("If the situation is mixed or unclear, use the user's query language"));
         assertFalse(result.systemPrompt().contains("Write naturally in Korean unless"));
@@ -173,6 +179,49 @@ class MailDraftQueryServiceTest {
         assertTrue(result.systemPrompt().contains("Select the reply language from the current conversation context"));
         assertTrue(result.systemPrompt().contains("Match the dominant language of thread emails and the latest inbound message"));
         assertTrue(result.systemPrompt().contains("If thread and query languages differ, preserve the thread language"));
+    }
+
+    @Test
+    void 답장사용자프롬프트는스레드언어를Query보다우선한다() {
+        // given
+        MailDraftQueryService service = createService();
+
+        // when
+        MailDraftPromptResult result = service.replyPrompt(createCommand(UUID.randomUUID()), MailDraftRagContextResult.empty());
+
+        // then
+        assertTrue(result.userPrompt().contains("dominant thread_emails language"));
+        assertTrue(result.userPrompt().contains("For replies, the query language is an instruction language only"));
+        assertTrue(result.userPrompt().contains("If thread_emails are mostly English and the query is Korean"));
+    }
+
+    @Test
+    void 일반초안시스템프롬프트는수신자히스토리언어를우선한다() {
+        // given
+        MailDraftQueryService service = createService();
+
+        // when
+        MailDraftPromptResult result = service.generalPrompt(createCommand(null), MailDraftRagContextResult.empty());
+
+        // then
+        assertTrue(result.systemPrompt().contains("choose the draft language from the dominant language used with the target recipient"));
+        assertTrue(result.systemPrompt().contains("mostly English"));
+        assertTrue(result.systemPrompt().contains("even if the user's query is written in Korean"));
+        assertTrue(result.systemPrompt().contains("recipient_history is missing, mixed, or insufficient"));
+    }
+
+    @Test
+    void 사용자프롬프트는수신자히스토리언어우선규칙을요청앞에제공한다() {
+        // given
+        MailDraftQueryService service = createService();
+
+        // when
+        MailDraftPromptResult result = service.generalPrompt(createCommand(null), MailDraftRagContextResult.empty());
+
+        // then
+        assertTrue(result.userPrompt().contains("Do not choose Korean only because the query is Korean"));
+        assertTrue(result.userPrompt().contains("If recipient_history is mostly English and the query is Korean"));
+        assertTrue(result.userPrompt().contains("strongest context for recipient-specific output language"));
     }
 
     @Test


### PR DESCRIPTION
  PR 본문:

  ## 🔗 관련 작업

  ### 👤 User Story
  - mailsangja/docs4capstone#24

  ### 📌 Task
  - Closes #86


  ## 💡 작업 내용

  - AI 초안 제목/본문을 단일 LLM 스트림에서 파싱해 SSE로 전달하도록 개선
  - 답장 초안은 제목 없이 본문만 스트리밍하도록 분기
  - 수신자 히스토리, 스레드, 최근 작성 메일을 기반으로 초안 언어/톤/맥락 반영 강화
  - 메일 마스킹 기본 대상에서 이름/이메일 제외
  - AI 초안 요청의 `to`, `cc`를 선택값으로 허용
  - OpenAI 호환 채팅 모델 temperature 기본값을 `0.3`으로 설정


  ## 📝 추가 설명

  ### 1. AI 초안 스트리밍 안정화
  - 제목과 본문을 별도 호출하지 않고 단일 스트림 응답에서 `<SUBJECT>`, `<BODY>` 구간을 파싱합니다.
  - SSE delta 전송 로그를 추가해 실제 전송 여부를 확인할 수 있도록 했습니다.
  - 답장 초안은 기존 메일 제목을 유지하는 흐름에 맞춰 본문만 생성하도록 처리했습니다.

  ### 2. 메일 컨텍스트 기반 초안 품질 개선
  - `recipient_history`를 추가해 수신자와 과거에 주고받은 메일을 초안 컨텍스트로 제공합니다.
  - 답장 초안은 기존 thread 문맥을 우선해 언어를 선택하도록 프롬프트를 강화했습니다.
  - 일반 초안은 수신자 히스토리의 지배 언어와 말투를 우선 반영하도록 프롬프트를 강화했습니다.
  - `recipient_history`에 선정된 메일은 `messageId`, `direction`, `subject` preview 로그로 확인할 수 있습니다.

  ### 3. 마스킹 및 요청 형식 완화
  - 이름과 이메일은 초안 품질과 수신자 히스토리 검색에 필요하므로 기본 마스킹 대상에서 제외했습니다.
  - `to`, `cc`가 없어도 초안 요청이 가능하도록 DTO 검증을 완화했습니다.
  - 수신자 정보가 있는 경우에만 해당 값을 히스토리 검색과 수신자 컨텍스트에 활용합니다.


  ## ⚡️ Test 결과

  | AI 초안 스트리밍 | 답장 초안 | 수신자 히스토리 | 요청 검증 |
  | -- | -- | -- | -- |
  | Unit Test | Unit Test | Unit Test | Unit Test |
  | `MailDraftCommandServiceTest` | `MailDraftAsyncServiceTest` | `MailDraftQueryServiceTest`,
  `MailDraftReferenceQueryAdapterTest` | `MailDraftStreamRequestTest` |