### PR TITLE
[STORY-102] MailAccount 외관 변경 및 비활성화  API 구현

### DIFF
--- a/core/src/main/java/com/mailsangja/core/common/exception/mail/MailAccountErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/mail/MailAccountErrorCode.java
@@ -31,7 +31,9 @@ public enum MailAccountErrorCode implements ErrorCode {
     GOOGLE_REFRESH_TOKEN_MISSING(400, "MS-MAIL-GOOGLE-REFRESH-TOKEN-MISSING", "Google 계정 재연동이 필요합니다. 다시 동의하고 계정을 연결해주세요."),
     MAIL_ACCOUNT_ALREADY_CONNECTED(409, "MS-MAIL-ACCOUNT-ALREADY-CONNECTED", "이미 연결된 메일 계정입니다."),
     MAIL_ACCOUNT_ALREADY_CONNECTED_BY_ANOTHER_USER(409, "MS-MAIL-ACCOUNT-ALREADY-CONNECTED-BY-ANOTHER-USER", "다른 사용자가 이미 연결한 메일 계정입니다."),
-    MAIL_ACCOUNT_NOT_FOUND(404, "MS-MAIL-ACCOUNT-NOT-FOUND", "메일 계정을 찾을 수 없습니다.");
+    MAIL_ACCOUNT_NOT_FOUND(404, "MS-MAIL-ACCOUNT-NOT-FOUND", "메일 계정을 찾을 수 없습니다."),
+    MAIL_ACCOUNT_ACCESS_DENIED(403, "MS-MAIL-ACCOUNT-ACCESS-DENIED", "해당 메일 계정에 접근 권한이 없습니다."),
+    MAIL_ACCOUNT_NO_FIELD_TO_UPDATE(400, "MS-MAIL-ACCOUNT-NO-FIELD-TO-UPDATE", "변경할 항목을 하나 이상 입력해주세요.");
 
     private final int status;
     private final String code;

--- a/core/src/main/java/com/mailsangja/core/config/AppConfig.java
+++ b/core/src/main/java/com/mailsangja/core/config/AppConfig.java
@@ -1,0 +1,16 @@
+package com.mailsangja.core.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/controller/MailAccountController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/MailAccountController.java
@@ -62,12 +62,32 @@ public class MailAccountController implements MailAccountControllerDocs {
     }
 
     @Override
-    @DeleteMapping("/api/v1/mail-accounts/{mailAccountId}")
+    @PatchMapping("/api/v1/mail-accounts/{mailAccountId}/activate")
+    public ResponseEntity<Void> activateMailAccount(
+            @AuthUser User user,
+            @PathVariable UUID mailAccountId
+    ) {
+        mailAccountFacade.activateMailAccount(user, mailAccountId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    @PatchMapping("/api/v1/mail-accounts/{mailAccountId}/deactivate")
     public ResponseEntity<Void> deactivateMailAccount(
             @AuthUser User user,
             @PathVariable UUID mailAccountId
     ) {
         mailAccountFacade.deactivateMailAccount(user, mailAccountId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    @DeleteMapping("/api/v1/mail-accounts/{mailAccountId}")
+    public ResponseEntity<Void> deleteMailAccount(
+            @AuthUser User user,
+            @PathVariable UUID mailAccountId
+    ) {
+        mailAccountFacade.deleteMailAccount(user, mailAccountId);
         return ResponseEntity.ok().build();
     }
 

--- a/core/src/main/java/com/mailsangja/core/controller/MailAccountController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/MailAccountController.java
@@ -7,6 +7,7 @@ import com.mailsangja.core.common.exception.mail.MailAccountErrorCode;
 import com.mailsangja.core.common.exception.mail.MailAccountException;
 import com.mailsangja.core.config.properties.GoogleOAuthProperties;
 import com.mailsangja.core.controller.docs.MailAccountControllerDocs;
+import com.mailsangja.core.dto.mail.MailAccountAppearanceUpdateRequest;
 import com.mailsangja.core.dto.mail.MailAccountAuthorizeRequest;
 import com.mailsangja.core.dto.mail.MailAccountAuthorizeResponse;
 import com.mailsangja.core.dto.mail.MailAccountListResponse;
@@ -15,8 +16,12 @@ import com.mailsangja.db.entity.user.User;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -43,6 +48,27 @@ public class MailAccountController implements MailAccountControllerDocs {
     @GetMapping("/api/v1/mail-accounts")
     public ResponseEntity<List<MailAccountListResponse>> getMyMailAccounts(@AuthUser User user) {
         return ResponseEntity.ok(mailAccountFacade.getMyMailAccounts(user));
+    }
+
+    @Override
+    @PatchMapping("/api/v1/mail-accounts/{mailAccountId}")
+    public ResponseEntity<Void> updateMailAccountAppearance(
+            @AuthUser User user,
+            @PathVariable UUID mailAccountId,
+            @RequestBody MailAccountAppearanceUpdateRequest request
+    ) {
+        mailAccountFacade.updateMailAccountAppearance(user, mailAccountId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    @DeleteMapping("/api/v1/mail-accounts/{mailAccountId}")
+    public ResponseEntity<Void> deactivateMailAccount(
+            @AuthUser User user,
+            @PathVariable UUID mailAccountId
+    ) {
+        mailAccountFacade.deactivateMailAccount(user, mailAccountId);
+        return ResponseEntity.ok().build();
     }
 
     @Override

--- a/core/src/main/java/com/mailsangja/core/controller/docs/MailAccountControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/MailAccountControllerDocs.java
@@ -1,6 +1,7 @@
 package com.mailsangja.core.controller.docs;
 
 import com.mailsangja.core.common.auth.AuthUser;
+import com.mailsangja.core.dto.mail.MailAccountAppearanceUpdateRequest;
 import com.mailsangja.core.dto.mail.MailAccountAuthorizeRequest;
 import com.mailsangja.core.dto.mail.MailAccountAuthorizeResponse;
 import com.mailsangja.core.dto.mail.MailAccountListResponse;
@@ -17,8 +18,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
+import java.util.UUID;
 
 @Tag(name = "Mail Account", description = "메일 계정 연동 API")
 public interface MailAccountControllerDocs {
@@ -42,6 +46,40 @@ public interface MailAccountControllerDocs {
     })
     ResponseEntity<List<MailAccountListResponse>> getMyMailAccounts(
             @Parameter(hidden = true) @AuthUser User user
+    );
+
+    @Operation(
+            summary = "메일 계정 외관 변경",
+            description = "메일 계정의 별칭(alias), 아이콘(icon), 색상(color) 중 하나 이상을 변경합니다. 제공한 필드만 변경됩니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "외관 변경 성공", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "400", description = "변경할 필드 없음 또는 형식 오류", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "메일 계정 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<Void> updateMailAccountAppearance(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "메일 계정 ID", required = true) @PathVariable UUID mailAccountId,
+            @RequestBody MailAccountAppearanceUpdateRequest request
+    );
+
+    @Operation(
+            summary = "메일 계정 비활성화",
+            description = "메일 계정을 비활성화합니다. 비활성화된 계정은 메일 수신 및 동기화가 중단됩니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비활성화 성공", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "메일 계정 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<Void> deactivateMailAccount(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "메일 계정 ID", required = true) @PathVariable UUID mailAccountId
     );
 
     @Operation(

--- a/core/src/main/java/com/mailsangja/core/controller/docs/MailAccountControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/MailAccountControllerDocs.java
@@ -67,8 +67,24 @@ public interface MailAccountControllerDocs {
     );
 
     @Operation(
+            summary = "메일 계정 활성화",
+            description = "비활성화된 메일 계정을 활성화합니다. 백그라운드 동기화는 활성/비활성 상태와 무관하게 유지됩니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "활성화 성공", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "메일 계정 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<Void> activateMailAccount(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "메일 계정 ID", required = true) @PathVariable UUID mailAccountId
+    );
+
+    @Operation(
             summary = "메일 계정 비활성화",
-            description = "메일 계정을 비활성화합니다. 비활성화된 계정은 메일 수신 및 동기화가 중단됩니다.",
+            description = "메일 계정을 비활성화합니다. 비활성화된 계정은 inbox/라벨 조회에서 제외되지만 백그라운드 동기화는 계속됩니다.",
             security = @SecurityRequirement(name = "cookieAuth")
     )
     @ApiResponses({
@@ -78,6 +94,22 @@ public interface MailAccountControllerDocs {
             @ApiResponse(responseCode = "404", description = "메일 계정 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     ResponseEntity<Void> deactivateMailAccount(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "메일 계정 ID", required = true) @PathVariable UUID mailAccountId
+    );
+
+    @Operation(
+            summary = "메일 계정 삭제",
+            description = "메일 계정을 영구 삭제합니다. 삭제된 계정은 모든 조회와 동기화, watch 갱신에서 완전히 제외됩니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "메일 계정 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<Void> deleteMailAccount(
             @Parameter(hidden = true) @AuthUser User user,
             @Parameter(description = "메일 계정 ID", required = true) @PathVariable UUID mailAccountId
     );

--- a/core/src/main/java/com/mailsangja/core/dto/mail/MailAccountAppearanceUpdateRequest.java
+++ b/core/src/main/java/com/mailsangja/core/dto/mail/MailAccountAppearanceUpdateRequest.java
@@ -1,0 +1,36 @@
+package com.mailsangja.core.dto.mail;
+
+import com.mailsangja.core.common.exception.mail.MailAccountErrorCode;
+import com.mailsangja.core.common.exception.mail.MailAccountException;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "메일 계정 외관 변경 요청")
+public record MailAccountAppearanceUpdateRequest(
+        @Schema(description = "변경할 별칭", example = "업무 메일")
+        String alias,
+        @Schema(description = "변경할 아이콘", example = "mail")
+        String icon,
+        @Schema(description = "변경할 색상 HEX 값", example = "#4F46E5")
+        String color
+) {
+    private static final String HEX_COLOR_REGEX = "^#[0-9A-Fa-f]{6}$";
+
+    public void validate() {
+        if (isBlank(alias) && isBlank(icon) && isBlank(color)) {
+            throw new MailAccountException(MailAccountErrorCode.MAIL_ACCOUNT_NO_FIELD_TO_UPDATE);
+        }
+        if (!isBlank(alias) && alias.length() > 255) {
+            throw new MailAccountException(MailAccountErrorCode.INVALID_MAIL_ACCOUNT_ALIAS);
+        }
+        if (!isBlank(icon) && icon.length() > 255) {
+            throw new MailAccountException(MailAccountErrorCode.INVALID_MAIL_ACCOUNT_ICON);
+        }
+        if (!isBlank(color) && !color.matches(HEX_COLOR_REGEX)) {
+            throw new MailAccountException(MailAccountErrorCode.INVALID_MAIL_ACCOUNT_COLOR);
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/facade/MailAccountFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/MailAccountFacade.java
@@ -96,8 +96,16 @@ public class MailAccountFacade {
         mailAccountCommandService.updateMailAccountAppearance(user, mailAccountId, request.alias(), request.icon(), request.color());
     }
 
+    public void activateMailAccount(User user, UUID mailAccountId) {
+        mailAccountCommandService.activateMailAccount(user, mailAccountId);
+    }
+
     public void deactivateMailAccount(User user, UUID mailAccountId) {
         mailAccountCommandService.deactivateMailAccount(user, mailAccountId);
+    }
+
+    public void deleteMailAccount(User user, UUID mailAccountId) {
+        mailAccountCommandService.deleteMailAccount(user, mailAccountId);
     }
 
     private void validateAuthorizationCode(String code) {

--- a/core/src/main/java/com/mailsangja/core/facade/MailAccountFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/MailAccountFacade.java
@@ -6,6 +6,7 @@ import com.mailsangja.core.dto.contact.GoogleContactResult;
 import com.mailsangja.core.dto.mail.GoogleMailAccountResult;
 import com.mailsangja.core.dto.mail.GoogleMailWatchResult;
 import com.mailsangja.core.dto.mail.InitialMailSyncMessage;
+import com.mailsangja.core.dto.mail.MailAccountAppearanceUpdateRequest;
 import com.mailsangja.core.dto.mail.MailAccountAuthorizeResponse;
 import com.mailsangja.core.dto.mail.MailAccountListResponse;
 import com.mailsangja.core.dto.mail.MailAccountResponse;
@@ -25,6 +26,7 @@ import org.springframework.stereotype.Component;
 
 import java.security.SecureRandom;
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -87,6 +89,15 @@ public class MailAccountFacade {
         return mailAccounts.stream()
                 .map(MailAccountListResponse::from)
                 .toList();
+    }
+
+    public void updateMailAccountAppearance(User user, UUID mailAccountId, MailAccountAppearanceUpdateRequest request) {
+        request.validate();
+        mailAccountCommandService.updateMailAccountAppearance(user, mailAccountId, request.alias(), request.icon(), request.color());
+    }
+
+    public void deactivateMailAccount(User user, UUID mailAccountId) {
+        mailAccountCommandService.deactivateMailAccount(user, mailAccountId);
     }
 
     private void validateAuthorizationCode(String code) {

--- a/core/src/main/java/com/mailsangja/core/service/mail/MailAccountCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/mail/MailAccountCommandService.java
@@ -161,10 +161,25 @@ public class MailAccountCommandService {
     }
 
     @Transactional
+    public void activateMailAccount(User user, UUID mailAccountId) {
+        MailAccount mailAccount = mailAccountQueryService.findById(mailAccountId);
+        validateOwnership(mailAccount, user);
+        mailAccount.activate();
+    }
+
+    @Transactional
     public void deactivateMailAccount(User user, UUID mailAccountId) {
         MailAccount mailAccount = mailAccountQueryService.findById(mailAccountId);
         validateOwnership(mailAccount, user);
         mailAccount.deactivate();
+    }
+
+    @Transactional
+    public void deleteMailAccount(User user, UUID mailAccountId) {
+        MailAccount mailAccount = mailAccountQueryService.findById(mailAccountId);
+        validateOwnership(mailAccount, user);
+        mailAccount.deactivate();
+        mailAccount.delete();
     }
 
     private void validateOwnership(MailAccount mailAccount, User user) {

--- a/core/src/main/java/com/mailsangja/core/service/mail/MailAccountCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/mail/MailAccountCommandService.java
@@ -34,11 +34,6 @@ public class MailAccountCommandService {
                         result.emailAddress()
                 )
         );
-
-        validateAnotherOwnerDuplicate(
-                mailAccountQueryService.findByProviderAndEmailAddress(MailProvider.GMAIL, result.emailAddress()),
-                user
-        );
     }
 
     @Transactional
@@ -155,18 +150,33 @@ public class MailAccountCommandService {
         }
     }
 
+    @Transactional
+    public void updateMailAccountAppearance(User user, UUID mailAccountId, String alias, String icon, String color) {
+        MailAccount mailAccount = mailAccountQueryService.findById(mailAccountId);
+        validateOwnership(mailAccount, user);
+
+        if (alias != null && !alias.isBlank()) mailAccount.updateAlias(alias);
+        if (icon != null && !icon.isBlank()) mailAccount.updateIcon(icon);
+        if (color != null && !color.isBlank()) mailAccount.updateColor(color);
+    }
+
+    @Transactional
+    public void deactivateMailAccount(User user, UUID mailAccountId) {
+        MailAccount mailAccount = mailAccountQueryService.findById(mailAccountId);
+        validateOwnership(mailAccount, user);
+        mailAccount.deactivate();
+    }
+
+    private void validateOwnership(MailAccount mailAccount, User user) {
+        if (!mailAccount.getUser().getId().equals(user.getId())) {
+            throw new MailAccountException(MailAccountErrorCode.MAIL_ACCOUNT_ACCESS_DENIED);
+        }
+    }
+
     private void validateSameOwnerDuplicate(Optional<MailAccount> existingMailAccount) {
         if (existingMailAccount.isPresent()) {
             throw new MailAccountException(MailAccountErrorCode.MAIL_ACCOUNT_ALREADY_CONNECTED);
         }
-    }
-
-    private void validateAnotherOwnerDuplicate(Optional<MailAccount> existingMailAccount, User user) {
-        existingMailAccount
-                .filter(existing -> !existing.getUser().getId().equals(user.getId()))
-                .ifPresent(existing -> {
-                    throw new MailAccountException(MailAccountErrorCode.MAIL_ACCOUNT_ALREADY_CONNECTED_BY_ANOTHER_USER);
-                });
     }
 
     private void validateSavedMailAccount(MailAccount mailAccount) {

--- a/core/src/main/java/com/mailsangja/core/service/mail/MailAccountCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/mail/MailAccountCommandService.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -22,13 +24,13 @@ import java.util.UUID;
 public class MailAccountCommandService {
 
     private final MailAccountRepositoryPort mailAccountRepositoryPort;
-    private final MailAccountQueryService mailAccountQueryService;
+    private final Clock clock;
 
     public void validateGoogleMailAccountCreation(User user, GoogleMailAccountResult result) {
         validateGoogleMailAccountResult(result);
 
         validateSameOwnerDuplicate(
-                mailAccountQueryService.findByUserIdAndProviderAndEmailAddress(
+                mailAccountRepositoryPort.findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(
                         user.getId(),
                         MailProvider.GMAIL,
                         result.emailAddress()
@@ -79,7 +81,7 @@ public class MailAccountCommandService {
     public MailAccount refreshGoogleAccessToken(UUID mailAccountId, GoogleOAuthTokenResult tokenResult) {
         validateRefreshGoogleAccessTokenInput(mailAccountId, tokenResult);
 
-        MailAccount mailAccount = mailAccountQueryService.findActiveById(mailAccountId);
+        MailAccount mailAccount = findActiveById(mailAccountId);
         validateRefreshableGoogleMailAccount(mailAccount);
         String updatedRefreshToken = isBlank(tokenResult.refreshToken())
                 ? mailAccount.getRefreshToken()
@@ -89,11 +91,11 @@ public class MailAccountCommandService {
                 mailAccountId,
                 mailAccount.getAccessToken(),
                 tokenResult.accessToken(),
-                mailAccountQueryService.getKstNow().plusSeconds(tokenResult.expiresIn()),
+                LocalDateTime.now(clock).plusSeconds(tokenResult.expiresIn()),
                 updatedRefreshToken
         );
 
-        return mailAccountQueryService.findActiveById(mailAccountId);
+        return findActiveById(mailAccountId);
     }
 
     private void validateGoogleMailAccountResult(GoogleMailAccountResult result) {
@@ -152,7 +154,7 @@ public class MailAccountCommandService {
 
     @Transactional
     public void updateMailAccountAppearance(User user, UUID mailAccountId, String alias, String icon, String color) {
-        MailAccount mailAccount = mailAccountQueryService.findById(mailAccountId);
+        MailAccount mailAccount = findById(mailAccountId);
         validateOwnership(mailAccount, user);
 
         if (alias != null && !alias.isBlank()) mailAccount.updateAlias(alias);
@@ -162,24 +164,34 @@ public class MailAccountCommandService {
 
     @Transactional
     public void activateMailAccount(User user, UUID mailAccountId) {
-        MailAccount mailAccount = mailAccountQueryService.findById(mailAccountId);
+        MailAccount mailAccount = findById(mailAccountId);
         validateOwnership(mailAccount, user);
         mailAccount.activate();
     }
 
     @Transactional
     public void deactivateMailAccount(User user, UUID mailAccountId) {
-        MailAccount mailAccount = mailAccountQueryService.findById(mailAccountId);
+        MailAccount mailAccount = findById(mailAccountId);
         validateOwnership(mailAccount, user);
         mailAccount.deactivate();
     }
 
     @Transactional
     public void deleteMailAccount(User user, UUID mailAccountId) {
-        MailAccount mailAccount = mailAccountQueryService.findById(mailAccountId);
+        MailAccount mailAccount = findById(mailAccountId);
         validateOwnership(mailAccount, user);
         mailAccount.deactivate();
         mailAccount.delete();
+    }
+
+    private MailAccount findById(UUID id) {
+        return mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new MailAccountException(MailAccountErrorCode.MAIL_ACCOUNT_NOT_FOUND));
+    }
+
+    private MailAccount findActiveById(UUID id) {
+        return mailAccountRepositoryPort.findByIdAndActiveAndDeletedAtIsNull(id, true)
+                .orElseThrow(() -> new MailAccountException(MailAccountErrorCode.MAIL_ACCOUNT_NOT_FOUND));
     }
 
     private void validateOwnership(MailAccount mailAccount, User user) {

--- a/core/src/test/java/com/mailsangja/core/facade/MailAccountFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/MailAccountFacadeTest.java
@@ -4,7 +4,12 @@ import com.mailsangja.core.dto.contact.GoogleContactResult;
 import com.mailsangja.core.dto.mail.GoogleMailAccountResult;
 import com.mailsangja.core.dto.mail.GoogleMailWatchResult;
 import com.mailsangja.core.dto.mail.InitialMailSyncMessage;
+import com.mailsangja.core.dto.mail.MailAccountAppearanceUpdateRequest;
+import com.mailsangja.core.dto.mail.MailAccountAuthorizeResponse;
+import com.mailsangja.core.dto.mail.MailAccountListResponse;
 import com.mailsangja.core.dto.mail.MailAccountResponse;
+import com.mailsangja.core.common.exception.mail.MailAccountErrorCode;
+import com.mailsangja.core.common.exception.mail.MailAccountException;
 import com.mailsangja.core.service.contact.ContactCommandService;
 import com.mailsangja.core.service.google.GoogleMailWatchQueryService;
 import com.mailsangja.core.service.google.GoogleOAuthQueryService;
@@ -25,6 +30,8 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -36,7 +43,37 @@ import static org.mockito.Mockito.when;
 class MailAccountFacadeTest {
 
     @Test
+    void authorizeGoogle_인가URL을응답으로반환한다() {
+        // given
+        MailAccountCommandService mailAccountCommandService = mock(MailAccountCommandService.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        GoogleOAuthQueryService googleOAuthQueryService = mock(GoogleOAuthQueryService.class);
+        GoogleMailWatchQueryService googleMailWatchQueryService = mock(GoogleMailWatchQueryService.class);
+        InitialMailSyncMessageCommandService initialMailSyncMessageCommandService = mock(InitialMailSyncMessageCommandService.class);
+        GooglePeopleContactQueryService googlePeopleContactQueryService = mock(GooglePeopleContactQueryService.class);
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        MailAccountFacade facade = new MailAccountFacade(
+                mailAccountCommandService,
+                mailAccountQueryService,
+                googleOAuthQueryService,
+                googleMailWatchQueryService,
+                initialMailSyncMessageCommandService,
+                googlePeopleContactQueryService,
+                contactCommandService
+        );
+        when(googleOAuthQueryService.buildAuthorizationUrl("state-123"))
+                .thenReturn("https://accounts.google.com/o/oauth2/v2/auth");
+
+        // when
+        MailAccountAuthorizeResponse response = facade.authorizeGoogle("state-123");
+
+        // then
+        assertEquals("https://accounts.google.com/o/oauth2/v2/auth", response.authorizationUrl());
+    }
+
+    @Test
     void handleGoogleCallback_메일계정저장후MQ를먼저발행하고그다음주소록을가져와저장한다() {
+        // given
         User user = createUser();
         GoogleMailAccountResult accountResult = createAccountResult();
         GoogleMailWatchResult watchResult = createWatchResult();
@@ -71,8 +108,10 @@ class MailAccountFacadeTest {
         )).thenReturn(savedMailAccount);
         when(googlePeopleContactQueryService.getContacts("access-token")).thenReturn(contacts);
 
+        // when
         MailAccountResponse response = facade.handleGoogleCallback(user, "code", "alias", null, null);
 
+        // then
         assertEquals(savedMailAccount.getId(), response.id());
         InOrder inOrder = inOrder(
                 initialMailSyncMessageCommandService,
@@ -86,6 +125,7 @@ class MailAccountFacadeTest {
 
     @Test
     void handleGoogleCallback_주소록조회가실패해도메일계정연동과초기메일동기화발행은유지한다() {
+        // given
         User user = createUser();
         GoogleMailAccountResult accountResult = createAccountResult();
         GoogleMailWatchResult watchResult = createWatchResult();
@@ -121,8 +161,10 @@ class MailAccountFacadeTest {
                 .when(googlePeopleContactQueryService)
                 .getContacts("access-token");
 
+        // when
         MailAccountResponse response = facade.handleGoogleCallback(user, "code", "alias", null, null);
 
+        // then
         assertEquals(savedMailAccount.getId(), response.id());
         verify(initialMailSyncMessageCommandService).publish(InitialMailSyncMessage.from(savedMailAccount));
         verify(googlePeopleContactQueryService).getContacts("access-token");
@@ -130,6 +172,7 @@ class MailAccountFacadeTest {
 
     @Test
     void handleGoogleCallback_주소록저장이실패해도메일계정연동과초기메일동기화발행은유지한다() {
+        // given
         User user = createUser();
         GoogleMailAccountResult accountResult = createAccountResult();
         GoogleMailWatchResult watchResult = createWatchResult();
@@ -167,11 +210,183 @@ class MailAccountFacadeTest {
                 .when(contactCommandService)
                 .saveMissingContacts(user, contacts);
 
+        // when
         MailAccountResponse response = facade.handleGoogleCallback(user, "code", "alias", null, null);
 
+        // then
         assertEquals(savedMailAccount.getId(), response.id());
         verify(initialMailSyncMessageCommandService).publish(InitialMailSyncMessage.from(savedMailAccount));
         verify(contactCommandService).saveMissingContacts(user, contacts);
+    }
+
+    @Test
+    void handleGoogleCallback_인가코드가잘못되면예외를던진다() {
+        // given
+        MailAccountFacade facade = createFacade(
+                mock(MailAccountCommandService.class),
+                mock(MailAccountQueryService.class),
+                mock(GoogleOAuthQueryService.class),
+                mock(GoogleMailWatchQueryService.class),
+                mock(InitialMailSyncMessageCommandService.class),
+                mock(GooglePeopleContactQueryService.class),
+                mock(ContactCommandService.class)
+        );
+
+        // when
+        MailAccountException exception = assertThrows(
+                MailAccountException.class,
+                () -> facade.handleGoogleCallback(createUser(), "invalid code", "alias", "good", "#123456")
+        );
+
+        // then
+        assertEquals(MailAccountErrorCode.INVALID_AUTHORIZATION_CODE, exception.getErrorCode());
+    }
+
+    @Test
+    void handleGoogleCallback_표시값이없으면이메일별칭과기본아이콘과랜덤색상으로생성한다() {
+        // given
+        User user = createUser();
+        GoogleMailAccountResult accountResult = createAccountResult();
+        GoogleMailWatchResult watchResult = createWatchResult();
+        MailAccountCommandService mailAccountCommandService = mock(MailAccountCommandService.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        GoogleOAuthQueryService googleOAuthQueryService = mock(GoogleOAuthQueryService.class);
+        GoogleMailWatchQueryService googleMailWatchQueryService = mock(GoogleMailWatchQueryService.class);
+        InitialMailSyncMessageCommandService initialMailSyncMessageCommandService = mock(InitialMailSyncMessageCommandService.class);
+        GooglePeopleContactQueryService googlePeopleContactQueryService = mock(GooglePeopleContactQueryService.class);
+        ContactCommandService contactCommandService = mock(ContactCommandService.class);
+        MailAccountFacade facade = createFacade(
+                mailAccountCommandService,
+                mailAccountQueryService,
+                googleOAuthQueryService,
+                googleMailWatchQueryService,
+                initialMailSyncMessageCommandService,
+                googlePeopleContactQueryService,
+                contactCommandService
+        );
+        when(googleOAuthQueryService.getGoogleMailAccountResult("code")).thenReturn(accountResult);
+        when(googleMailWatchQueryService.watch("access-token")).thenReturn(watchResult);
+        when(mailAccountCommandService.createGoogleMailAccount(
+                eq(user),
+                eq(accountResult),
+                eq("gmail@example.com"),
+                eq("good"),
+                any(),
+                eq(watchResult)
+        )).thenReturn(createMailAccount(user));
+        when(googlePeopleContactQueryService.getContacts("access-token")).thenReturn(List.of());
+
+        // when
+        MailAccountResponse response = facade.handleGoogleCallback(user, "code", null, null, null);
+
+        // then
+        assertNotNull(response);
+        verify(mailAccountCommandService).createGoogleMailAccount(
+                eq(user),
+                eq(accountResult),
+                eq("gmail@example.com"),
+                eq("good"),
+                org.mockito.ArgumentMatchers.matches("^#[0-9A-F]{6}$"),
+                eq(watchResult)
+        );
+    }
+
+    @Test
+    void handleGoogleCallback_색상형식이잘못되면예외를던진다() {
+        // given
+        GoogleOAuthQueryService googleOAuthQueryService = mock(GoogleOAuthQueryService.class);
+        MailAccountFacade facade = createFacade(
+                mock(MailAccountCommandService.class),
+                mock(MailAccountQueryService.class),
+                googleOAuthQueryService,
+                mock(GoogleMailWatchQueryService.class),
+                mock(InitialMailSyncMessageCommandService.class),
+                mock(GooglePeopleContactQueryService.class),
+                mock(ContactCommandService.class)
+        );
+        when(googleOAuthQueryService.getGoogleMailAccountResult("code")).thenReturn(createAccountResult());
+
+        // when
+        MailAccountException exception = assertThrows(
+                MailAccountException.class,
+                () -> facade.handleGoogleCallback(createUser(), "code", "alias", "good", "123456")
+        );
+
+        // then
+        assertEquals(MailAccountErrorCode.INVALID_MAIL_ACCOUNT_COLOR, exception.getErrorCode());
+    }
+
+    @Test
+    void getMyMailAccounts_사용자메일계정목록을응답으로변환한다() {
+        // given
+        User user = createUser();
+        MailAccountCommandService mailAccountCommandService = mock(MailAccountCommandService.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountFacade facade = createFacade(
+                mailAccountCommandService,
+                mailAccountQueryService,
+                mock(GoogleOAuthQueryService.class),
+                mock(GoogleMailWatchQueryService.class),
+                mock(InitialMailSyncMessageCommandService.class),
+                mock(GooglePeopleContactQueryService.class),
+                mock(ContactCommandService.class)
+        );
+        when(mailAccountQueryService.findAllByUserId(user.getId()))
+                .thenReturn(List.of(createMailAccount(user)));
+
+        // when
+        List<MailAccountListResponse> responses = facade.getMyMailAccounts(user);
+
+        // then
+        assertEquals(1, responses.size());
+        assertEquals("gmail@example.com", responses.getFirst().emailAddress());
+    }
+
+    @Test
+    void updateMailAccountAppearance_요청검증후서비스에위임한다() {
+        // given
+        User user = createUser();
+        UUID mailAccountId = UUID.randomUUID();
+        MailAccountCommandService mailAccountCommandService = mock(MailAccountCommandService.class);
+        MailAccountFacade facade = createFacade(
+                mailAccountCommandService,
+                mock(MailAccountQueryService.class),
+                mock(GoogleOAuthQueryService.class),
+                mock(GoogleMailWatchQueryService.class),
+                mock(InitialMailSyncMessageCommandService.class),
+                mock(GooglePeopleContactQueryService.class),
+                mock(ContactCommandService.class)
+        );
+        MailAccountAppearanceUpdateRequest request = new MailAccountAppearanceUpdateRequest("alias", "good", "#123456");
+
+        // when
+        facade.updateMailAccountAppearance(user, mailAccountId, request);
+
+        // then
+        verify(mailAccountCommandService).updateMailAccountAppearance(user, mailAccountId, "alias", "good", "#123456");
+    }
+
+    @Test
+    void deactivateMailAccount_서비스에위임한다() {
+        // given
+        User user = createUser();
+        UUID mailAccountId = UUID.randomUUID();
+        MailAccountCommandService mailAccountCommandService = mock(MailAccountCommandService.class);
+        MailAccountFacade facade = createFacade(
+                mailAccountCommandService,
+                mock(MailAccountQueryService.class),
+                mock(GoogleOAuthQueryService.class),
+                mock(GoogleMailWatchQueryService.class),
+                mock(InitialMailSyncMessageCommandService.class),
+                mock(GooglePeopleContactQueryService.class),
+                mock(ContactCommandService.class)
+        );
+
+        // when
+        facade.deactivateMailAccount(user, mailAccountId);
+
+        // then
+        verify(mailAccountCommandService).deactivateMailAccount(user, mailAccountId);
     }
 
     private User createUser() {
@@ -214,5 +429,25 @@ class MailAccountFacadeTest {
                 .syncHistoryId("history-id")
                 .watchExpiresAt(LocalDateTime.now().plusDays(1))
                 .build();
+    }
+
+    private MailAccountFacade createFacade(
+            MailAccountCommandService mailAccountCommandService,
+            MailAccountQueryService mailAccountQueryService,
+            GoogleOAuthQueryService googleOAuthQueryService,
+            GoogleMailWatchQueryService googleMailWatchQueryService,
+            InitialMailSyncMessageCommandService initialMailSyncMessageCommandService,
+            GooglePeopleContactQueryService googlePeopleContactQueryService,
+            ContactCommandService contactCommandService
+    ) {
+        return new MailAccountFacade(
+                mailAccountCommandService,
+                mailAccountQueryService,
+                googleOAuthQueryService,
+                googleMailWatchQueryService,
+                initialMailSyncMessageCommandService,
+                googlePeopleContactQueryService,
+                contactCommandService
+        );
     }
 }

--- a/core/src/test/java/com/mailsangja/core/facade/MailFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/MailFacadeTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.client.RestClient;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -236,7 +237,7 @@ class MailFacadeTest {
         MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(mailAccountRepositoryPort);
         GoogleAccessTokenEnsureService googleAccessTokenEnsureService = new GoogleAccessTokenEnsureService(
                 mailAccountQueryService,
-                new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService),
+                new MailAccountCommandService(mailAccountRepositoryPort, Clock.systemUTC()),
                 new FakeGoogleOAuthQueryService()
         );
         MailCommandService mailCommandService = new MailCommandService(
@@ -310,7 +311,7 @@ class MailFacadeTest {
         MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(mailAccountRepositoryPort);
         GoogleAccessTokenEnsureService googleAccessTokenEnsureService = new GoogleAccessTokenEnsureService(
                 mailAccountQueryService,
-                new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService),
+                new MailAccountCommandService(mailAccountRepositoryPort, Clock.systemUTC()),
                 new FakeGoogleOAuthQueryService()
         );
         MailCommandService mailCommandService = new MailCommandService(
@@ -386,7 +387,7 @@ class MailFacadeTest {
         MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(mailAccountRepositoryPort);
         GoogleAccessTokenEnsureService googleAccessTokenEnsureService = new GoogleAccessTokenEnsureService(
                 mailAccountQueryService,
-                new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService),
+                new MailAccountCommandService(mailAccountRepositoryPort, Clock.systemUTC()),
                 new FakeGoogleOAuthQueryService()
         );
         MailCommandService mailCommandService = new MailCommandService(
@@ -461,7 +462,7 @@ class MailFacadeTest {
         MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(mailAccountRepositoryPort);
         GoogleAccessTokenEnsureService googleAccessTokenEnsureService = new GoogleAccessTokenEnsureService(
                 mailAccountQueryService,
-                new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService),
+                new MailAccountCommandService(mailAccountRepositoryPort, Clock.systemUTC()),
                 new FakeGoogleOAuthQueryService()
         );
         MailCommandService mailCommandService = new MailCommandService(
@@ -570,7 +571,7 @@ class MailFacadeTest {
         MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(mailAccountRepositoryPort);
         GoogleAccessTokenEnsureService googleAccessTokenEnsureService = new GoogleAccessTokenEnsureService(
                 mailAccountQueryService,
-                new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService),
+                new MailAccountCommandService(mailAccountRepositoryPort, Clock.systemUTC()),
                 new FakeGoogleOAuthQueryService()
         );
         MailCommandService mailCommandService = new MailCommandService(
@@ -650,7 +651,7 @@ class MailFacadeTest {
         MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(mailAccountRepositoryPort);
         GoogleAccessTokenEnsureService googleAccessTokenEnsureService = new GoogleAccessTokenEnsureService(
                 mailAccountQueryService,
-                new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService),
+                new MailAccountCommandService(mailAccountRepositoryPort, Clock.systemUTC()),
                 new FakeGoogleOAuthQueryService()
         );
         MailCommandService mailCommandService = new MailCommandService(
@@ -785,7 +786,7 @@ class MailFacadeTest {
         MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(mailAccountRepositoryPort);
         GoogleAccessTokenEnsureService googleAccessTokenEnsureService = new GoogleAccessTokenEnsureService(
                 mailAccountQueryService,
-                new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService),
+                new MailAccountCommandService(mailAccountRepositoryPort, Clock.systemUTC()),
                 new FakeGoogleOAuthQueryService()
         );
         MailCommandService mailCommandService = new MailCommandService(

--- a/core/src/test/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/mail/GoogleAccessTokenEnsureServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.RestClient;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Optional;
@@ -97,7 +98,7 @@ class GoogleAccessTokenEnsureServiceTest {
         MailAccountQueryService mailAccountQueryService = new MailAccountQueryService(mailAccountRepositoryPort);
         MailAccountCommandService mailAccountCommandService = new MailAccountCommandService(
                 mailAccountRepositoryPort,
-                mailAccountQueryService
+                Clock.systemUTC()
         );
         return new GoogleAccessTokenEnsureService(
                 mailAccountQueryService,

--- a/core/src/test/java/com/mailsangja/core/service/mail/MailAccountCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/mail/MailAccountCommandServiceTest.java
@@ -1,0 +1,464 @@
+package com.mailsangja.core.service.mail;
+
+import com.mailsangja.core.common.exception.mail.MailAccountErrorCode;
+import com.mailsangja.core.common.exception.mail.MailAccountException;
+import com.mailsangja.core.dto.mail.GoogleMailAccountResult;
+import com.mailsangja.core.dto.mail.GoogleMailWatchResult;
+import com.mailsangja.core.dto.mail.GoogleOAuthTokenResult;
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.MailProvider;
+import com.mailsangja.db.entity.user.Plan;
+import com.mailsangja.db.entity.user.Role;
+import com.mailsangja.db.entity.user.User;
+import com.mailsangja.db.port.MailAccountRepositoryPort;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MailAccountCommandServiceTest {
+
+    @Test
+    void validateGoogleMailAccountCreation_중복계정이없으면통과한다() {
+        // given
+        User user = createUser("user@example.com");
+        GoogleMailAccountResult result = createGoogleMailAccountResult();
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        when(mailAccountQueryService.findByUserIdAndProviderAndEmailAddress(
+                user.getId(),
+                MailProvider.GMAIL,
+                result.emailAddress()
+        )).thenReturn(Optional.empty());
+
+        // when
+        service.validateGoogleMailAccountCreation(user, result);
+
+        // then
+        verify(mailAccountQueryService).findByUserIdAndProviderAndEmailAddress(
+                user.getId(),
+                MailProvider.GMAIL,
+                result.emailAddress()
+        );
+    }
+
+    @Test
+    void validateGoogleMailAccountCreation_OAuth결과가null이면예외를던진다() {
+        // given
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+
+        // when
+        MailAccountException exception = assertThrows(
+                MailAccountException.class,
+                () -> service.validateGoogleMailAccountCreation(createUser("user@example.com"), null)
+        );
+
+        // then
+        assertEquals(MailAccountErrorCode.INVALID_OAUTH_RESULT, exception.getErrorCode());
+    }
+
+    @Test
+    void validateGoogleMailAccountCreation_리프레시토큰이없으면예외를던진다() {
+        // given
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        GoogleMailAccountResult result = new GoogleMailAccountResult(
+                "gmail@example.com",
+                "access-token",
+                LocalDateTime.of(2026, 5, 19, 10, 0),
+                " "
+        );
+
+        // when
+        MailAccountException exception = assertThrows(
+                MailAccountException.class,
+                () -> service.validateGoogleMailAccountCreation(createUser("user@example.com"), result)
+        );
+
+        // then
+        assertEquals(MailAccountErrorCode.GOOGLE_REFRESH_TOKEN_MISSING, exception.getErrorCode());
+    }
+
+    @Test
+    void validateGoogleMailAccountCreation_같은사용자중복계정이면예외를던진다() {
+        // given
+        User user = createUser("user@example.com");
+        GoogleMailAccountResult result = createGoogleMailAccountResult();
+        MailAccount existingMailAccount = createMailAccount(user, MailProvider.GMAIL, true, "access-token", "refresh-token");
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        when(mailAccountQueryService.findByUserIdAndProviderAndEmailAddress(user.getId(), MailProvider.GMAIL, result.emailAddress()))
+                .thenReturn(Optional.of(existingMailAccount));
+
+        // when
+        MailAccountException exception = assertThrows(
+                MailAccountException.class,
+                () -> service.validateGoogleMailAccountCreation(user, result)
+        );
+
+        // then
+        assertEquals(MailAccountErrorCode.MAIL_ACCOUNT_ALREADY_CONNECTED, exception.getErrorCode());
+    }
+
+    @Test
+    void createGoogleMailAccount_구글계정을생성하고저장한다() {
+        // given
+        User user = createUser("user@example.com");
+        GoogleMailAccountResult result = createGoogleMailAccountResult();
+        GoogleMailWatchResult watchResult = createGoogleMailWatchResult();
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        when(mailAccountRepositoryPort.save(any(MailAccount.class)))
+                .thenAnswer(invocation -> {
+                    MailAccount mailAccount = invocation.getArgument(0);
+                    return MailAccount.builder()
+                            .id(UUID.randomUUID())
+                            .user(mailAccount.getUser())
+                            .provider(mailAccount.getProvider())
+                            .emailAddress(mailAccount.getEmailAddress())
+                            .alias(mailAccount.getAlias())
+                            .icon(mailAccount.getIcon())
+                            .color(mailAccount.getColor())
+                            .accessToken(mailAccount.getAccessToken())
+                            .accessTokenExpiresAt(mailAccount.getAccessTokenExpiresAt())
+                            .refreshToken(mailAccount.getRefreshToken())
+                            .active(mailAccount.isActive())
+                            .syncHistoryId(mailAccount.getSyncHistoryId())
+                            .watchExpiresAt(mailAccount.getWatchExpiresAt())
+                            .build();
+                });
+
+        // when
+        MailAccount saved = service.createGoogleMailAccount(
+                user,
+                result,
+                "업무용",
+                "briefcase",
+                "#123456",
+                watchResult
+        );
+
+        // then
+        ArgumentCaptor<MailAccount> mailAccountCaptor = ArgumentCaptor.forClass(MailAccount.class);
+        verify(mailAccountRepositoryPort).save(mailAccountCaptor.capture());
+        MailAccount persisted = mailAccountCaptor.getValue();
+        assertEquals(user, persisted.getUser());
+        assertEquals(MailProvider.GMAIL, persisted.getProvider());
+        assertEquals(result.emailAddress(), persisted.getEmailAddress());
+        assertEquals("업무용", persisted.getAlias());
+        assertEquals("briefcase", persisted.getIcon());
+        assertEquals("#123456", persisted.getColor());
+        assertEquals(result.accessToken(), persisted.getAccessToken());
+        assertEquals(result.accessTokenExpiresAt(), persisted.getAccessTokenExpiresAt());
+        assertEquals(result.refreshToken(), persisted.getRefreshToken());
+        assertEquals(watchResult.historyId(), persisted.getSyncHistoryId());
+        assertEquals(watchResult.expirationAt(), persisted.getWatchExpiresAt());
+        assertTrue(saved.isActive());
+    }
+
+    @Test
+    void createGoogleMailAccount_watchHistoryId가없으면예외를던지고저장하지않는다() {
+        // given
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        GoogleMailWatchResult watchResult = new GoogleMailWatchResult(" ", LocalDateTime.of(2026, 5, 20, 9, 0));
+
+        // when
+        MailAccountException exception = assertThrows(MailAccountException.class, () -> service.createGoogleMailAccount(
+                createUser("user@example.com"),
+                createGoogleMailAccountResult(),
+                "alias",
+                "good",
+                "#123456",
+                watchResult
+        ));
+
+        // then
+        assertEquals(MailAccountErrorCode.INVALID_OAUTH_RESULT, exception.getErrorCode());
+        verify(mailAccountRepositoryPort, never()).save(any(MailAccount.class));
+    }
+
+    @Test
+    void createGoogleMailAccount_저장결과Id가없으면예외를던진다() {
+        // given
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        when(mailAccountRepositoryPort.save(any(MailAccount.class)))
+                .thenReturn(MailAccount.builder().build());
+
+        // when
+        MailAccountException exception = assertThrows(MailAccountException.class, () -> service.createGoogleMailAccount(
+                createUser("user@example.com"),
+                createGoogleMailAccountResult(),
+                "alias",
+                "good",
+                "#123456",
+                createGoogleMailWatchResult()
+        ));
+
+        // then
+        assertEquals(MailAccountErrorCode.INVALID_OAUTH_RESULT, exception.getErrorCode());
+    }
+
+    @Test
+    void refreshGoogleAccessToken_새리프레시토큰이없으면기존리프레시토큰을유지하고갱신한다() {
+        // given
+        UUID mailAccountId = UUID.randomUUID();
+        User user = createUser("user@example.com");
+        MailAccount mailAccount = createMailAccount(user, MailProvider.GMAIL, true, "old-access-token", "old-refresh-token");
+        MailAccount refreshedMailAccount = createMailAccount(user, MailProvider.GMAIL, true, "new-access-token", "old-refresh-token");
+        GoogleOAuthTokenResult tokenResult = new GoogleOAuthTokenResult("new-access-token", " ", 3600L, null, "Bearer");
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        when(mailAccountQueryService.findActiveById(mailAccountId))
+                .thenReturn(mailAccount)
+                .thenReturn(refreshedMailAccount);
+        when(mailAccountQueryService.getKstNow())
+                .thenReturn(LocalDateTime.of(2026, 5, 19, 9, 0));
+
+        // when
+        MailAccount result = service.refreshGoogleAccessToken(mailAccountId, tokenResult);
+
+        // then
+        assertEquals(refreshedMailAccount, result);
+        verify(mailAccountRepositoryPort).updateGoogleTokenIfAccessTokenMatches(
+                eq(mailAccountId),
+                eq("old-access-token"),
+                eq("new-access-token"),
+                eq(LocalDateTime.of(2026, 5, 19, 10, 0)),
+                eq("old-refresh-token")
+        );
+    }
+
+    @Test
+    void refreshGoogleAccessToken_새리프레시토큰이있으면함께갱신한다() {
+        // given
+        UUID mailAccountId = UUID.randomUUID();
+        User user = createUser("user@example.com");
+        MailAccount mailAccount = createMailAccount(user, MailProvider.GMAIL, true, "old-access-token", "old-refresh-token");
+        GoogleOAuthTokenResult tokenResult = new GoogleOAuthTokenResult("new-access-token", "new-refresh-token", 60L, null, "Bearer");
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        when(mailAccountQueryService.findActiveById(mailAccountId))
+                .thenReturn(mailAccount)
+                .thenReturn(mailAccount);
+        when(mailAccountQueryService.getKstNow())
+                .thenReturn(LocalDateTime.of(2026, 5, 19, 9, 0));
+
+        // when
+        service.refreshGoogleAccessToken(mailAccountId, tokenResult);
+
+        // then
+        verify(mailAccountRepositoryPort).updateGoogleTokenIfAccessTokenMatches(
+                eq(mailAccountId),
+                eq("old-access-token"),
+                eq("new-access-token"),
+                eq(LocalDateTime.of(2026, 5, 19, 9, 1)),
+                eq("new-refresh-token")
+        );
+    }
+
+    @Test
+    void refreshGoogleAccessToken_입력이잘못되면예외를던지고갱신하지않는다() {
+        // given
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        GoogleOAuthTokenResult tokenResult = new GoogleOAuthTokenResult(" ", "refresh-token", 3600L, null, "Bearer");
+
+        // when
+        MailAccountException exception = assertThrows(
+                MailAccountException.class,
+                () -> service.refreshGoogleAccessToken(UUID.randomUUID(), tokenResult)
+        );
+
+        // then
+        assertEquals(MailAccountErrorCode.GOOGLE_TOKEN_REFRESH_FAILED, exception.getErrorCode());
+        verify(mailAccountRepositoryPort, never()).updateGoogleTokenIfAccessTokenMatches(
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+        );
+    }
+
+    @Test
+    void refreshGoogleAccessToken_Gmail계정이아니면예외를던진다() {
+        // given
+        UUID mailAccountId = UUID.randomUUID();
+        User user = createUser("user@example.com");
+        MailAccount mailAccount = createMailAccount(user, MailProvider.NAVER, true, "old-access-token", "refresh-token");
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        when(mailAccountQueryService.findActiveById(mailAccountId)).thenReturn(mailAccount);
+
+        // when
+        MailAccountException exception = assertThrows(
+                MailAccountException.class,
+                () -> service.refreshGoogleAccessToken(mailAccountId, new GoogleOAuthTokenResult("new-token", null, 3600L, null, "Bearer"))
+        );
+
+        // then
+        assertEquals(MailAccountErrorCode.UNSUPPORTED_MAIL_PROVIDER, exception.getErrorCode());
+    }
+
+    @Test
+    void updateMailAccountAppearance_소유자이면blank이아닌값만갱신한다() {
+        // given
+        UUID mailAccountId = UUID.randomUUID();
+        User user = createUser("user@example.com");
+        MailAccount mailAccount = createMailAccount(user, MailProvider.GMAIL, true, "access-token", "refresh-token");
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        when(mailAccountQueryService.findById(mailAccountId)).thenReturn(mailAccount);
+
+        // when
+        service.updateMailAccountAppearance(user, mailAccountId, "새 별칭", " ", "#ABCDEF");
+
+        // then
+        assertEquals("새 별칭", mailAccount.getAlias());
+        assertEquals("good", mailAccount.getIcon());
+        assertEquals("#ABCDEF", mailAccount.getColor());
+    }
+
+    @Test
+    void updateMailAccountAppearance_소유자가아니면예외를던진다() {
+        // given
+        UUID mailAccountId = UUID.randomUUID();
+        User owner = createUser("owner@example.com");
+        User otherUser = createUser("other@example.com");
+        MailAccount mailAccount = createMailAccount(owner, MailProvider.GMAIL, true, "access-token", "refresh-token");
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        when(mailAccountQueryService.findById(mailAccountId)).thenReturn(mailAccount);
+
+        // when
+        MailAccountException exception = assertThrows(
+                MailAccountException.class,
+                () -> service.updateMailAccountAppearance(otherUser, mailAccountId, "새 별칭", "good", "#ABCDEF")
+        );
+
+        // then
+        assertEquals(MailAccountErrorCode.MAIL_ACCOUNT_ACCESS_DENIED, exception.getErrorCode());
+        assertEquals("alias", mailAccount.getAlias());
+    }
+
+    @Test
+    void deactivateMailAccount_소유자이면메일계정을비활성화한다() {
+        // given
+        UUID mailAccountId = UUID.randomUUID();
+        User user = createUser("user@example.com");
+        MailAccount mailAccount = createMailAccount(user, MailProvider.GMAIL, true, "access-token", "refresh-token");
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        when(mailAccountQueryService.findById(mailAccountId)).thenReturn(mailAccount);
+
+        // when
+        service.deactivateMailAccount(user, mailAccountId);
+
+        // then
+        assertFalse(mailAccount.isActive());
+    }
+
+    @Test
+    void deactivateMailAccount_소유자가아니면예외를던진다() {
+        // given
+        UUID mailAccountId = UUID.randomUUID();
+        User owner = createUser("owner@example.com");
+        User otherUser = createUser("other@example.com");
+        MailAccount mailAccount = createMailAccount(owner, MailProvider.GMAIL, true, "access-token", "refresh-token");
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        when(mailAccountQueryService.findById(mailAccountId)).thenReturn(mailAccount);
+
+        // when
+        MailAccountException exception = assertThrows(
+                MailAccountException.class,
+                () -> service.deactivateMailAccount(otherUser, mailAccountId)
+        );
+
+        // then
+        assertEquals(MailAccountErrorCode.MAIL_ACCOUNT_ACCESS_DENIED, exception.getErrorCode());
+        assertTrue(mailAccount.isActive());
+    }
+
+    private User createUser(String username) {
+        return User.builder()
+                .id(UUID.randomUUID())
+                .name("사용자")
+                .username(username)
+                .password("password")
+                .plan(Plan.FREE)
+                .role(Role.USER)
+                .build();
+    }
+
+    private GoogleMailAccountResult createGoogleMailAccountResult() {
+        return new GoogleMailAccountResult(
+                "gmail@example.com",
+                "access-token",
+                LocalDateTime.of(2026, 5, 19, 10, 0),
+                "refresh-token"
+        );
+    }
+
+    private GoogleMailWatchResult createGoogleMailWatchResult() {
+        return new GoogleMailWatchResult(
+                "history-id",
+                LocalDateTime.of(2026, 5, 20, 9, 0)
+        );
+    }
+
+    private MailAccount createMailAccount(
+            User user,
+            MailProvider provider,
+            boolean active,
+            String accessToken,
+            String refreshToken
+    ) {
+        return MailAccount.builder()
+                .id(UUID.randomUUID())
+                .user(user)
+                .provider(provider)
+                .emailAddress("gmail@example.com")
+                .alias("alias")
+                .icon("good")
+                .color("#123456")
+                .accessToken(accessToken)
+                .accessTokenExpiresAt(LocalDateTime.of(2026, 5, 19, 10, 0))
+                .refreshToken(refreshToken)
+                .active(active)
+                .syncHistoryId("history-id")
+                .watchExpiresAt(LocalDateTime.of(2026, 5, 20, 9, 0))
+                .build();
+    }
+}

--- a/core/src/test/java/com/mailsangja/core/service/mail/MailAccountCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/mail/MailAccountCommandServiceTest.java
@@ -14,7 +14,10 @@ import com.mailsangja.db.port.MailAccountRepositoryPort;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -31,15 +34,18 @@ import static org.mockito.Mockito.when;
 
 class MailAccountCommandServiceTest {
 
+    // 2026-05-19T00:00:00Z = 2026-05-19T09:00:00 KST
+    private static final Clock KST_FIXED_CLOCK =
+            Clock.fixed(Instant.parse("2026-05-19T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+
     @Test
     void validateGoogleMailAccountCreation_중복계정이없으면통과한다() {
         // given
         User user = createUser("user@example.com");
         GoogleMailAccountResult result = createGoogleMailAccountResult();
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
-        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
-        when(mailAccountQueryService.findByUserIdAndProviderAndEmailAddress(
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, KST_FIXED_CLOCK);
+        when(mailAccountRepositoryPort.findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(
                 user.getId(),
                 MailProvider.GMAIL,
                 result.emailAddress()
@@ -49,7 +55,7 @@ class MailAccountCommandServiceTest {
         service.validateGoogleMailAccountCreation(user, result);
 
         // then
-        verify(mailAccountQueryService).findByUserIdAndProviderAndEmailAddress(
+        verify(mailAccountRepositoryPort).findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(
                 user.getId(),
                 MailProvider.GMAIL,
                 result.emailAddress()
@@ -60,8 +66,7 @@ class MailAccountCommandServiceTest {
     void validateGoogleMailAccountCreation_OAuth결과가null이면예외를던진다() {
         // given
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
-        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, KST_FIXED_CLOCK);
 
         // when
         MailAccountException exception = assertThrows(
@@ -77,8 +82,7 @@ class MailAccountCommandServiceTest {
     void validateGoogleMailAccountCreation_리프레시토큰이없으면예외를던진다() {
         // given
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
-        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, KST_FIXED_CLOCK);
         GoogleMailAccountResult result = new GoogleMailAccountResult(
                 "gmail@example.com",
                 "access-token",
@@ -103,9 +107,9 @@ class MailAccountCommandServiceTest {
         GoogleMailAccountResult result = createGoogleMailAccountResult();
         MailAccount existingMailAccount = createMailAccount(user, MailProvider.GMAIL, true, "access-token", "refresh-token");
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
-        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
-        when(mailAccountQueryService.findByUserIdAndProviderAndEmailAddress(user.getId(), MailProvider.GMAIL, result.emailAddress()))
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, KST_FIXED_CLOCK);
+        when(mailAccountRepositoryPort.findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(
+                user.getId(), MailProvider.GMAIL, result.emailAddress()))
                 .thenReturn(Optional.of(existingMailAccount));
 
         // when
@@ -125,8 +129,7 @@ class MailAccountCommandServiceTest {
         GoogleMailAccountResult result = createGoogleMailAccountResult();
         GoogleMailWatchResult watchResult = createGoogleMailWatchResult();
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
-        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, KST_FIXED_CLOCK);
         when(mailAccountRepositoryPort.save(any(MailAccount.class)))
                 .thenAnswer(invocation -> {
                     MailAccount mailAccount = invocation.getArgument(0);
@@ -179,8 +182,7 @@ class MailAccountCommandServiceTest {
     void createGoogleMailAccount_watchHistoryId가없으면예외를던지고저장하지않는다() {
         // given
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
-        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, KST_FIXED_CLOCK);
         GoogleMailWatchResult watchResult = new GoogleMailWatchResult(" ", LocalDateTime.of(2026, 5, 20, 9, 0));
 
         // when
@@ -202,8 +204,7 @@ class MailAccountCommandServiceTest {
     void createGoogleMailAccount_저장결과Id가없으면예외를던진다() {
         // given
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
-        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, KST_FIXED_CLOCK);
         when(mailAccountRepositoryPort.save(any(MailAccount.class)))
                 .thenReturn(MailAccount.builder().build());
 
@@ -230,13 +231,10 @@ class MailAccountCommandServiceTest {
         MailAccount refreshedMailAccount = createMailAccount(user, MailProvider.GMAIL, true, "new-access-token", "old-refresh-token");
         GoogleOAuthTokenResult tokenResult = new GoogleOAuthTokenResult("new-access-token", " ", 3600L, null, "Bearer");
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
-        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
-        when(mailAccountQueryService.findActiveById(mailAccountId))
-                .thenReturn(mailAccount)
-                .thenReturn(refreshedMailAccount);
-        when(mailAccountQueryService.getKstNow())
-                .thenReturn(LocalDateTime.of(2026, 5, 19, 9, 0));
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, KST_FIXED_CLOCK);
+        when(mailAccountRepositoryPort.findByIdAndActiveAndDeletedAtIsNull(mailAccountId, true))
+                .thenReturn(Optional.of(mailAccount))
+                .thenReturn(Optional.of(refreshedMailAccount));
 
         // when
         MailAccount result = service.refreshGoogleAccessToken(mailAccountId, tokenResult);
@@ -260,13 +258,10 @@ class MailAccountCommandServiceTest {
         MailAccount mailAccount = createMailAccount(user, MailProvider.GMAIL, true, "old-access-token", "old-refresh-token");
         GoogleOAuthTokenResult tokenResult = new GoogleOAuthTokenResult("new-access-token", "new-refresh-token", 60L, null, "Bearer");
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
-        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
-        when(mailAccountQueryService.findActiveById(mailAccountId))
-                .thenReturn(mailAccount)
-                .thenReturn(mailAccount);
-        when(mailAccountQueryService.getKstNow())
-                .thenReturn(LocalDateTime.of(2026, 5, 19, 9, 0));
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, KST_FIXED_CLOCK);
+        when(mailAccountRepositoryPort.findByIdAndActiveAndDeletedAtIsNull(mailAccountId, true))
+                .thenReturn(Optional.of(mailAccount))
+                .thenReturn(Optional.of(mailAccount));
 
         // when
         service.refreshGoogleAccessToken(mailAccountId, tokenResult);
@@ -285,8 +280,7 @@ class MailAccountCommandServiceTest {
     void refreshGoogleAccessToken_입력이잘못되면예외를던지고갱신하지않는다() {
         // given
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
-        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, KST_FIXED_CLOCK);
         GoogleOAuthTokenResult tokenResult = new GoogleOAuthTokenResult(" ", "refresh-token", 3600L, null, "Bearer");
 
         // when
@@ -313,9 +307,9 @@ class MailAccountCommandServiceTest {
         User user = createUser("user@example.com");
         MailAccount mailAccount = createMailAccount(user, MailProvider.NAVER, true, "old-access-token", "refresh-token");
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
-        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
-        when(mailAccountQueryService.findActiveById(mailAccountId)).thenReturn(mailAccount);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, KST_FIXED_CLOCK);
+        when(mailAccountRepositoryPort.findByIdAndActiveAndDeletedAtIsNull(mailAccountId, true))
+                .thenReturn(Optional.of(mailAccount));
 
         // when
         MailAccountException exception = assertThrows(
@@ -334,9 +328,8 @@ class MailAccountCommandServiceTest {
         User user = createUser("user@example.com");
         MailAccount mailAccount = createMailAccount(user, MailProvider.GMAIL, true, "access-token", "refresh-token");
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
-        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
-        when(mailAccountQueryService.findById(mailAccountId)).thenReturn(mailAccount);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, KST_FIXED_CLOCK);
+        when(mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(mailAccountId)).thenReturn(Optional.of(mailAccount));
 
         // when
         service.updateMailAccountAppearance(user, mailAccountId, "새 별칭", " ", "#ABCDEF");
@@ -355,9 +348,8 @@ class MailAccountCommandServiceTest {
         User otherUser = createUser("other@example.com");
         MailAccount mailAccount = createMailAccount(owner, MailProvider.GMAIL, true, "access-token", "refresh-token");
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
-        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
-        when(mailAccountQueryService.findById(mailAccountId)).thenReturn(mailAccount);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, KST_FIXED_CLOCK);
+        when(mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(mailAccountId)).thenReturn(Optional.of(mailAccount));
 
         // when
         MailAccountException exception = assertThrows(
@@ -377,9 +369,8 @@ class MailAccountCommandServiceTest {
         User user = createUser("user@example.com");
         MailAccount mailAccount = createMailAccount(user, MailProvider.GMAIL, true, "access-token", "refresh-token");
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
-        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
-        when(mailAccountQueryService.findById(mailAccountId)).thenReturn(mailAccount);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, KST_FIXED_CLOCK);
+        when(mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(mailAccountId)).thenReturn(Optional.of(mailAccount));
 
         // when
         service.deactivateMailAccount(user, mailAccountId);
@@ -396,9 +387,8 @@ class MailAccountCommandServiceTest {
         User otherUser = createUser("other@example.com");
         MailAccount mailAccount = createMailAccount(owner, MailProvider.GMAIL, true, "access-token", "refresh-token");
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
-        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, mailAccountQueryService);
-        when(mailAccountQueryService.findById(mailAccountId)).thenReturn(mailAccount);
+        MailAccountCommandService service = new MailAccountCommandService(mailAccountRepositoryPort, KST_FIXED_CLOCK);
+        when(mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(mailAccountId)).thenReturn(Optional.of(mailAccount));
 
         // when
         MailAccountException exception = assertThrows(

--- a/core/src/test/java/com/mailsangja/core/service/mail/MailAccountQueryServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/mail/MailAccountQueryServiceTest.java
@@ -1,0 +1,237 @@
+package com.mailsangja.core.service.mail;
+
+import com.mailsangja.core.common.exception.mail.MailAccountErrorCode;
+import com.mailsangja.core.common.exception.mail.MailAccountException;
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.MailProvider;
+import com.mailsangja.db.port.MailAccountRepositoryPort;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MailAccountQueryServiceTest {
+
+    @Test
+    void findById_삭제되지않은메일계정을반환한다() {
+        // given
+        UUID mailAccountId = UUID.randomUUID();
+        MailAccount mailAccount = createMailAccount(mailAccountId);
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(mailAccountId))
+                .thenReturn(Optional.of(mailAccount));
+
+        // when
+        MailAccount found = service.findById(mailAccountId);
+
+        // then
+        assertEquals(mailAccount, found);
+    }
+
+    @Test
+    void findById_메일계정이없으면예외를던진다() {
+        // given
+        UUID mailAccountId = UUID.randomUUID();
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(mailAccountId))
+                .thenReturn(Optional.empty());
+
+        // when
+        MailAccountException exception = assertThrows(MailAccountException.class, () -> service.findById(mailAccountId));
+
+        // then
+        assertEquals(MailAccountErrorCode.MAIL_ACCOUNT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void findActiveById_활성메일계정을반환한다() {
+        // given
+        UUID mailAccountId = UUID.randomUUID();
+        MailAccount mailAccount = createMailAccount(mailAccountId);
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findByIdAndActiveAndDeletedAtIsNull(mailAccountId, true))
+                .thenReturn(Optional.of(mailAccount));
+
+        // when
+        MailAccount found = service.findActiveById(mailAccountId);
+
+        // then
+        assertEquals(mailAccount, found);
+    }
+
+    @Test
+    void findActiveById_활성메일계정이없으면예외를던진다() {
+        // given
+        UUID mailAccountId = UUID.randomUUID();
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findByIdAndActiveAndDeletedAtIsNull(mailAccountId, true))
+                .thenReturn(Optional.empty());
+
+        // when
+        MailAccountException exception = assertThrows(MailAccountException.class, () -> service.findActiveById(mailAccountId));
+
+        // then
+        assertEquals(MailAccountErrorCode.MAIL_ACCOUNT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void findActiveByUserIdAndEmailAddress_활성메일계정을반환한다() {
+        // given
+        UUID userId = UUID.randomUUID();
+        MailAccount mailAccount = createMailAccount(UUID.randomUUID());
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findByUserIdAndEmailAddressAndActiveAndDeletedAtIsNull(
+                userId,
+                "user@example.com",
+                true
+        )).thenReturn(Optional.of(mailAccount));
+
+        // when
+        MailAccount found = service.findActiveByUserIdAndEmailAddress(userId, "user@example.com");
+
+        // then
+        assertEquals(mailAccount, found);
+    }
+
+    @Test
+    void findActiveByUserIdAndEmailAddress_활성메일계정이없으면예외를던진다() {
+        // given
+        UUID userId = UUID.randomUUID();
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findByUserIdAndEmailAddressAndActiveAndDeletedAtIsNull(
+                userId,
+                "user@example.com",
+                true
+        )).thenReturn(Optional.empty());
+
+        // when
+        MailAccountException exception = assertThrows(
+                MailAccountException.class,
+                () -> service.findActiveByUserIdAndEmailAddress(userId, "user@example.com")
+        );
+
+        // then
+        assertEquals(MailAccountErrorCode.MAIL_ACCOUNT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void findByUserIdAndProviderAndEmailAddress_포트결과를반환한다() {
+        // given
+        UUID userId = UUID.randomUUID();
+        MailAccount mailAccount = createMailAccount(UUID.randomUUID());
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(
+                userId,
+                MailProvider.GMAIL,
+                "user@example.com"
+        )).thenReturn(Optional.of(mailAccount));
+
+        // when
+        Optional<MailAccount> found = service.findByUserIdAndProviderAndEmailAddress(
+                userId,
+                MailProvider.GMAIL,
+                "user@example.com"
+        );
+
+        // then
+        assertTrue(found.isPresent());
+        assertEquals(mailAccount, found.get());
+    }
+
+    @Test
+    void findByProviderAndEmailAddress_포트결과를반환한다() {
+        // given
+        MailAccount mailAccount = createMailAccount(UUID.randomUUID());
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findByProviderAndEmailAddressAndDeletedAtIsNull(
+                MailProvider.GMAIL,
+                "user@example.com"
+        )).thenReturn(Optional.of(mailAccount));
+
+        // when
+        Optional<MailAccount> found = service.findByProviderAndEmailAddress(MailProvider.GMAIL, "user@example.com");
+
+        // then
+        assertTrue(found.isPresent());
+        assertEquals(mailAccount, found.get());
+    }
+
+    @Test
+    void findAllByUserId_사용자의메일계정목록을반환한다() {
+        // given
+        UUID userId = UUID.randomUUID();
+        List<MailAccount> mailAccounts = List.of(createMailAccount(UUID.randomUUID()));
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findAllByUserIdAndDeletedAtIsNull(userId))
+                .thenReturn(mailAccounts);
+
+        // when
+        List<MailAccount> found = service.findAllByUserId(userId);
+
+        // then
+        assertEquals(mailAccounts, found);
+    }
+
+    @Test
+    void findAllActiveByUserId_사용자의활성메일계정목록을반환한다() {
+        // given
+        UUID userId = UUID.randomUUID();
+        List<MailAccount> mailAccounts = List.of(createMailAccount(UUID.randomUUID()));
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findAllByUserIdAndActiveAndDeletedAtIsNull(userId, true))
+                .thenReturn(mailAccounts);
+
+        // when
+        List<MailAccount> found = service.findAllActiveByUserId(userId);
+
+        // then
+        assertEquals(mailAccounts, found);
+        verify(mailAccountRepositoryPort).findAllByUserIdAndActiveAndDeletedAtIsNull(userId, true);
+    }
+
+    @Test
+    void getKstNow_KST현재시각을반환한다() {
+        // given
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+
+        // when
+        boolean present = service.getKstNow() != null;
+
+        // then
+        assertTrue(present);
+        assertFalse(service.getKstNow().toString().isBlank());
+    }
+
+    private MailAccount createMailAccount(UUID id) {
+        return MailAccount.builder()
+                .id(id)
+                .provider(MailProvider.GMAIL)
+                .emailAddress("user@example.com")
+                .alias("alias")
+                .icon("good")
+                .color("#123456")
+                .accessToken("access-token")
+                .active(true)
+                .build();
+    }
+}

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/MailAccountRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/MailAccountRepositoryAdapter.java
@@ -59,6 +59,11 @@ public class MailAccountRepositoryAdapter implements MailAccountRepositoryPort {
     }
 
     @Override
+    public List<MailAccount> findAllByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress) {
+        return mailAccountJpaRepositoryModule.findAllByProviderAndEmailAddressAndDeletedAtIsNull(provider, emailAddress);
+    }
+
+    @Override
     public List<MailAccount> findAllByUserIdAndDeletedAtIsNull(UUID userId) {
         return mailAccountJpaRepositoryModule.findAllByUserIdAndDeletedAtIsNull(userId);
     }

--- a/db/src/main/java/com/mailsangja/db/module/label/LabelJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/label/LabelJpaRepositoryModule.java
@@ -53,6 +53,8 @@ public interface LabelJpaRepositoryModule extends JpaRepository<Label, UUID> {
               AND ml.label.deletedAt IS NULL
               AND ml.message.deletedAt IS NULL
               AND ml.message.thread.deletedAt IS NULL
+              AND ml.message.thread.mailAccount.active = true
+              AND ml.message.thread.mailAccount.deletedAt IS NULL
               AND ml.message.thread.read = false
               AND ml.message.thread.direction = com.mailsangja.db.entity.mail.Direction.INBOUND
             GROUP BY ml.label.id

--- a/db/src/main/java/com/mailsangja/db/module/mail/MailAccountJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MailAccountJpaRepositoryModule.java
@@ -85,7 +85,6 @@ public interface MailAccountJpaRepositoryModule extends JpaRepository<MailAccoun
             SELECT ma
             FROM MailAccount ma
             WHERE ma.provider = :provider
-              AND ma.active = true
               AND ma.deletedAt IS NULL
               AND ma.watchExpiresAt IS NOT NULL
               AND ma.watchExpiresAt <= :watchExpiresAtThreshold

--- a/db/src/main/java/com/mailsangja/db/module/mail/MailAccountJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MailAccountJpaRepositoryModule.java
@@ -28,6 +28,9 @@ public interface MailAccountJpaRepositoryModule extends JpaRepository<MailAccoun
     Optional<MailAccount> findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress);
 
     @EntityGraph(attributePaths = {"user"})
+    List<MailAccount> findAllByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress);
+
+    @EntityGraph(attributePaths = {"user"})
     @Query("SELECT ma FROM MailAccount ma WHERE ma.id = :id AND ma.deletedAt IS NULL")
     Optional<MailAccount> findByIdAndDeletedAtIsNull(@Param("id") UUID id);
 

--- a/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
@@ -21,7 +21,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             SELECT t FROM Thread t
             WHERE t.mailAccount.id IN (
                 SELECT ma.id FROM MailAccount ma
-                WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
             )
               AND t.direction = 'INBOUND'
               AND t.deletedAt IS NULL
@@ -32,7 +32,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
                   WHERE m.id = :markerId
                     AND m.mailAccount.id IN (
                       SELECT ma.id FROM MailAccount ma
-                      WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                      WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
                     )
                     AND m.direction = 'INBOUND'
                 )
@@ -42,7 +42,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
                     WHERE m.id = :markerId
                       AND m.mailAccount.id IN (
                         SELECT ma.id FROM MailAccount ma
-                        WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                        WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
                       )
                       AND m.direction = 'INBOUND'
                   )
@@ -62,7 +62,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             SELECT t FROM Thread t
             WHERE t.mailAccount.id IN (
                 SELECT ma.id FROM MailAccount ma
-                WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
             )
               AND t.direction = 'INBOUND'
               AND t.deletedAt IS NULL
@@ -74,7 +74,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
                   WHERE m.id = :markerId
                     AND m.mailAccount.id IN (
                       SELECT ma.id FROM MailAccount ma
-                      WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                      WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
                     )
                     AND m.direction = 'INBOUND'
                 )
@@ -84,7 +84,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
                     WHERE m.id = :markerId
                       AND m.mailAccount.id IN (
                         SELECT ma.id FROM MailAccount ma
-                        WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                        WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
                       )
                       AND m.direction = 'INBOUND'
                   )
@@ -105,7 +105,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             SELECT t FROM Thread t
             WHERE t.mailAccount.id IN (
                 SELECT ma.id FROM MailAccount ma
-                WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
             )
               AND t.direction = 'OUTBOUND'
               AND t.deletedAt IS NULL
@@ -116,7 +116,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
                   WHERE m.id = :markerId
                     AND m.mailAccount.id IN (
                       SELECT ma.id FROM MailAccount ma
-                      WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                      WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
                     )
                     AND m.direction = 'OUTBOUND'
                 )
@@ -126,7 +126,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
                     WHERE m.id = :markerId
                       AND m.mailAccount.id IN (
                         SELECT ma.id FROM MailAccount ma
-                        WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                        WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
                       )
                       AND m.direction = 'OUTBOUND'
                   )
@@ -146,7 +146,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             SELECT t FROM Thread t
             WHERE t.mailAccount.id IN (
                 SELECT ma.id FROM MailAccount ma
-                WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
             )
               AND t.direction = 'OUTBOUND'
               AND t.deletedAt IS NULL
@@ -158,7 +158,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
                   WHERE m.id = :markerId
                     AND m.mailAccount.id IN (
                       SELECT ma.id FROM MailAccount ma
-                      WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                      WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
                     )
                     AND m.direction = 'OUTBOUND'
                 )
@@ -168,7 +168,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
                     WHERE m.id = :markerId
                       AND m.mailAccount.id IN (
                         SELECT ma.id FROM MailAccount ma
-                        WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                        WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
                       )
                       AND m.direction = 'OUTBOUND'
                   )
@@ -198,14 +198,14 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             @Param("gmailThreadId") String gmailThreadId
     );
 
-    @Query("SELECT COUNT(t) FROM Thread t WHERE t.mailAccount.id IN (SELECT ma.id FROM MailAccount ma WHERE ma.user.id = :userId AND ma.deletedAt IS NULL) AND t.direction = 'INBOUND' AND t.read = false AND t.deletedAt IS NULL")
+    @Query("SELECT COUNT(t) FROM Thread t WHERE t.mailAccount.id IN (SELECT ma.id FROM MailAccount ma WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL) AND t.direction = 'INBOUND' AND t.read = false AND t.deletedAt IS NULL")
     long countUnreadInboxByUserId(@Param("userId") UUID userId);
 
     @Query("""
             SELECT COUNT(t) FROM Thread t
             WHERE t.mailAccount.id IN (
                 SELECT ma.id FROM MailAccount ma
-                WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
             )
               AND t.direction = 'INBOUND'
               AND t.deletedAt IS NULL
@@ -216,14 +216,14 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             @Param("read") Boolean read
     );
 
-    @Query("SELECT COUNT(t) FROM Thread t WHERE t.mailAccount.id IN (SELECT ma.id FROM MailAccount ma WHERE ma.user.id = :userId AND ma.deletedAt IS NULL) AND t.direction = 'OUTBOUND' AND t.read = false AND t.deletedAt IS NULL")
+    @Query("SELECT COUNT(t) FROM Thread t WHERE t.mailAccount.id IN (SELECT ma.id FROM MailAccount ma WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL) AND t.direction = 'OUTBOUND' AND t.read = false AND t.deletedAt IS NULL")
     long countUnreadSentByUserId(@Param("userId") UUID userId);
 
     @Query("""
             SELECT COUNT(t) FROM Thread t
             WHERE t.mailAccount.id IN (
                 SELECT ma.id FROM MailAccount ma
-                WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
             )
               AND t.direction = 'OUTBOUND'
               AND t.deletedAt IS NULL
@@ -238,7 +238,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             SELECT COUNT(DISTINCT t) FROM Thread t
             WHERE t.mailAccount.id IN (
                 SELECT ma.id FROM MailAccount ma
-                WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
             )
               AND t.direction = 'INBOUND'
               AND t.read = false
@@ -260,7 +260,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             SELECT COUNT(DISTINCT t) FROM Thread t
             WHERE t.mailAccount.id IN (
                 SELECT ma.id FROM MailAccount ma
-                WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
             )
               AND t.direction = 'INBOUND'
               AND t.deletedAt IS NULL
@@ -283,7 +283,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             SELECT COUNT(DISTINCT t) FROM Thread t
             WHERE t.mailAccount.id IN (
                 SELECT ma.id FROM MailAccount ma
-                WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
             )
               AND t.direction = 'OUTBOUND'
               AND t.read = false
@@ -305,7 +305,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             SELECT COUNT(DISTINCT t) FROM Thread t
             WHERE t.mailAccount.id IN (
                 SELECT ma.id FROM MailAccount ma
-                WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
             )
               AND t.direction = 'OUTBOUND'
               AND t.deletedAt IS NULL
@@ -356,7 +356,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
     );
 
     @EntityGraph(attributePaths = {"mailAccount"})
-    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN (SELECT ma.id FROM MailAccount ma WHERE ma.user.id = :userId AND ma.deletedAt IS NULL) AND t.deletedAt IS NOT NULL AND (:markerId IS NULL OR t.deletedAt < (SELECT m.deletedAt FROM Thread m WHERE m.id = :markerId)) ORDER BY t.deletedAt DESC")
+    @Query("SELECT t FROM Thread t WHERE t.mailAccount.id IN (SELECT ma.id FROM MailAccount ma WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL) AND t.deletedAt IS NOT NULL AND (:markerId IS NULL OR t.deletedAt < (SELECT m.deletedAt FROM Thread m WHERE m.id = :markerId)) ORDER BY t.deletedAt DESC")
     Slice<Thread> findTrashByUserId(
             @Param("userId") UUID userId,
             @Param("markerId") UUID markerId,
@@ -368,7 +368,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             SELECT DISTINCT t FROM Thread t
             WHERE t.mailAccount.id IN (
                 SELECT ma.id FROM MailAccount ma
-                WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
             )
              AND t.direction = 'INBOUND'
              AND t.deletedAt IS NULL
@@ -386,7 +386,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
                     WHERE m.id = :markerId
                       AND m.mailAccount.id IN (
                         SELECT ma.id FROM MailAccount ma
-                        WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                        WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
                       )
                       AND m.direction = 'INBOUND'
                 )
@@ -396,7 +396,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
                         WHERE m.id = :markerId
                           AND m.mailAccount.id IN (
                             SELECT ma.id FROM MailAccount ma
-                            WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                            WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
                           )
                           AND m.direction = 'INBOUND'
                     )
@@ -417,7 +417,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             SELECT DISTINCT t FROM Thread t
             WHERE t.mailAccount.id IN (
                 SELECT ma.id FROM MailAccount ma
-                WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
             )
              AND t.direction = 'INBOUND'
              AND t.deletedAt IS NULL
@@ -436,7 +436,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
                     WHERE m.id = :markerId
                       AND m.mailAccount.id IN (
                         SELECT ma.id FROM MailAccount ma
-                        WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                        WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
                       )
                       AND m.direction = 'INBOUND'
                 )
@@ -446,7 +446,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
                         WHERE m.id = :markerId
                           AND m.mailAccount.id IN (
                             SELECT ma.id FROM MailAccount ma
-                            WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                            WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
                           )
                           AND m.direction = 'INBOUND'
                     )
@@ -468,7 +468,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             SELECT DISTINCT t FROM Thread t
             WHERE t.mailAccount.id IN (
                 SELECT ma.id FROM MailAccount ma
-                WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
             )
              AND t.direction = 'OUTBOUND'
              AND t.deletedAt IS NULL
@@ -487,7 +487,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
                     WHERE m.id = :markerId
                       AND m.mailAccount.id IN (
                         SELECT ma.id FROM MailAccount ma
-                        WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                        WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
                       )
                       AND m.direction = 'OUTBOUND'
                 )
@@ -497,7 +497,7 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
                         WHERE m.id = :markerId
                           AND m.mailAccount.id IN (
                             SELECT ma.id FROM MailAccount ma
-                            WHERE ma.user.id = :userId AND ma.deletedAt IS NULL
+                            WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
                           )
                           AND m.direction = 'OUTBOUND'
                     )

--- a/db/src/main/java/com/mailsangja/db/port/MailAccountRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/MailAccountRepositoryPort.java
@@ -17,6 +17,7 @@ public interface MailAccountRepositoryPort {
     Optional<MailAccount> findByUserIdAndProviderAndEmailAddressAndDeletedAtIsNull(UUID userId, MailProvider provider, String emailAddress);
     Optional<MailAccount> findByUserIdAndEmailAddressAndActiveAndDeletedAtIsNull(UUID userId, String emailAddress, boolean active);
     Optional<MailAccount> findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress);
+    List<MailAccount> findAllByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider provider, String emailAddress);
     List<MailAccount> findAllByUserIdAndDeletedAtIsNull(UUID userId);
     int updateGoogleTokenIfAccessTokenMatches(
             UUID id,

--- a/db/src/main/resources/init.sql
+++ b/db/src/main/resources/init.sql
@@ -2,6 +2,10 @@ CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS hstore;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
+CREATE UNIQUE INDEX IF NOT EXISTS uq_mail_accounts_user_provider_email_active
+    ON mail_accounts (user_id, provider, email_address)
+    WHERE deleted_at IS NULL;
+
 CREATE UNIQUE INDEX IF NOT EXISTS uq_user_devices_fcm_token_active
     ON user_devices (fcm_token)
     WHERE deleted_at IS NULL;

--- a/db/src/test/java/com/mailsangja/db/DbApplicationTests.java
+++ b/db/src/test/java/com/mailsangja/db/DbApplicationTests.java
@@ -1,13 +1,17 @@
 package com.mailsangja.db;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 class DbApplicationTests {
 
     @Test
-    void contextLoads() {
-    }
+    void applicationClassLoads() {
+        // given
+        Class<DbApplication> applicationClass = DbApplication.class;
 
+        // when & then
+        assertNotNull(applicationClass);
+    }
 }

--- a/db/src/test/java/com/mailsangja/db/entity/mail/MailAccountTest.java
+++ b/db/src/test/java/com/mailsangja/db/entity/mail/MailAccountTest.java
@@ -1,0 +1,191 @@
+package com.mailsangja.db.entity.mail;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MailAccountTest {
+
+    @Test
+    void updateAccessToken_액세스토큰을갱신한다() {
+        // given
+        MailAccount mailAccount = createMailAccount();
+
+        // when
+        mailAccount.updateAccessToken("new-access-token");
+
+        // then
+        assertEquals("new-access-token", mailAccount.getAccessToken());
+    }
+
+    @Test
+    void updateAccessTokenExpiresAt_액세스토큰만료시각을갱신한다() {
+        // given
+        MailAccount mailAccount = createMailAccount();
+        LocalDateTime newExpiresAt = LocalDateTime.of(2026, 5, 19, 10, 30);
+
+        // when
+        mailAccount.updateAccessTokenExpiresAt(newExpiresAt);
+
+        // then
+        assertEquals(newExpiresAt, mailAccount.getAccessTokenExpiresAt());
+    }
+
+    @Test
+    void updateRefreshToken_리프레시토큰을갱신한다() {
+        // given
+        MailAccount mailAccount = createMailAccount();
+
+        // when
+        mailAccount.updateRefreshToken("new-refresh-token");
+
+        // then
+        assertEquals("new-refresh-token", mailAccount.getRefreshToken());
+    }
+
+    @Test
+    void updateAlias_별칭을갱신한다() {
+        // given
+        MailAccount mailAccount = createMailAccount();
+
+        // when
+        mailAccount.updateAlias("업무용 Gmail");
+
+        // then
+        assertEquals("업무용 Gmail", mailAccount.getAlias());
+    }
+
+    @Test
+    void updateIcon_아이콘을갱신한다() {
+        // given
+        MailAccount mailAccount = createMailAccount();
+
+        // when
+        mailAccount.updateIcon("briefcase");
+
+        // then
+        assertEquals("briefcase", mailAccount.getIcon());
+    }
+
+    @Test
+    void updateColor_색상을갱신한다() {
+        // given
+        MailAccount mailAccount = createMailAccount();
+
+        // when
+        mailAccount.updateColor("#ABCDEF");
+
+        // then
+        assertEquals("#ABCDEF", mailAccount.getColor());
+    }
+
+    @Test
+    void updateSyncHistoryId_동기화히스토리Id를갱신한다() {
+        // given
+        MailAccount mailAccount = createMailAccount();
+
+        // when
+        mailAccount.updateSyncHistoryId("new-history-id");
+
+        // then
+        assertEquals("new-history-id", mailAccount.getSyncHistoryId());
+    }
+
+    @Test
+    void updateWatchExpiresAt_watch만료시각을갱신한다() {
+        // given
+        MailAccount mailAccount = createMailAccount();
+        LocalDateTime newWatchExpiresAt = LocalDateTime.of(2026, 5, 20, 11, 0);
+
+        // when
+        mailAccount.updateWatchExpiresAt(newWatchExpiresAt);
+
+        // then
+        assertEquals(newWatchExpiresAt, mailAccount.getWatchExpiresAt());
+    }
+
+    @Test
+    void activate_메일계정을활성화한다() {
+        // given
+        MailAccount mailAccount = createMailAccount();
+        mailAccount.deactivate();
+
+        // when
+        mailAccount.activate();
+
+        // then
+        assertTrue(mailAccount.isActive());
+    }
+
+    @Test
+    void deactivate_메일계정을비활성화한다() {
+        // given
+        MailAccount mailAccount = createMailAccount();
+
+        // when
+        mailAccount.deactivate();
+
+        // then
+        assertFalse(mailAccount.isActive());
+    }
+
+    @Test
+    void resolveStartHistoryId_syncHistoryId가있으면해당값을반환한다() {
+        // given
+        MailAccount mailAccount = createMailAccount();
+
+        // when
+        String startHistoryId = mailAccount.resolveStartHistoryId("fallback-history-id");
+
+        // then
+        assertEquals("sync-history-id", startHistoryId);
+    }
+
+    @Test
+    void resolveStartHistoryId_syncHistoryId가null이면fallback을반환한다() {
+        // given
+        MailAccount mailAccount = createMailAccount();
+        mailAccount.updateSyncHistoryId(null);
+
+        // when
+        String startHistoryId = mailAccount.resolveStartHistoryId("fallback-history-id");
+
+        // then
+        assertEquals("fallback-history-id", startHistoryId);
+    }
+
+    @Test
+    void resolveStartHistoryId_syncHistoryId가blank이면fallback을반환한다() {
+        // given
+        MailAccount mailAccount = createMailAccount();
+        mailAccount.updateSyncHistoryId("   ");
+
+        // when
+        String startHistoryId = mailAccount.resolveStartHistoryId("fallback-history-id");
+
+        // then
+        assertEquals("fallback-history-id", startHistoryId);
+    }
+
+    private MailAccount createMailAccount() {
+        return MailAccount.builder()
+                .id(UUID.randomUUID())
+                .provider(MailProvider.GMAIL)
+                .emailAddress("user@example.com")
+                .alias("alias")
+                .icon("good")
+                .color("#123456")
+                .accessToken("access-token")
+                .accessTokenExpiresAt(LocalDateTime.of(2026, 5, 19, 9, 0))
+                .refreshToken("refresh-token")
+                .active(true)
+                .syncHistoryId("sync-history-id")
+                .watchExpiresAt(LocalDateTime.of(2026, 5, 20, 9, 0))
+                .build();
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/common/exception/mail/MailAccountNotFoundException.java
+++ b/worker/src/main/java/com/mailsangja/worker/common/exception/mail/MailAccountNotFoundException.java
@@ -1,0 +1,8 @@
+package com.mailsangja.worker.common.exception.mail;
+
+public class MailAccountNotFoundException extends MailPushException {
+
+    public MailAccountNotFoundException() {
+        super(MailPushErrorCode.MAIL_ACCOUNT_NOT_FOUND);
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/GmailMessageAddedRabbitConfig.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/GmailMessageAddedRabbitConfig.java
@@ -86,7 +86,7 @@ public class GmailMessageAddedRabbitConfig {
             @Qualifier("gmailMessageAddedMessageRecoverer") MessageRecoverer gmailMessageAddedMessageRecoverer
     ) {
         return RetryInterceptorBuilder.stateless()
-                .maxRetries(properties.getRetryMaxAttempts())
+                .retryPolicy(RabbitMqConfig.createRetryPolicy(properties.getRetryMaxAttempts()))
                 .recoverer(gmailMessageAddedMessageRecoverer)
                 .build();
     }

--- a/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/GmailMessagePermanentlyDeletedRabbitConfig.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/GmailMessagePermanentlyDeletedRabbitConfig.java
@@ -86,7 +86,7 @@ public class GmailMessagePermanentlyDeletedRabbitConfig {
             @Qualifier("gmailHistoryStateMessageRecoverer") MessageRecoverer gmailHistoryStateMessageRecoverer
     ) {
         return RetryInterceptorBuilder.stateless()
-                .maxRetries(properties.getRetryMaxAttempts())
+                .retryPolicy(RabbitMqConfig.createRetryPolicy(properties.getRetryMaxAttempts()))
                 .recoverer(gmailHistoryStateMessageRecoverer)
                 .build();
     }

--- a/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/InitialMailSyncRabbitConfig.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/InitialMailSyncRabbitConfig.java
@@ -84,7 +84,7 @@ public class InitialMailSyncRabbitConfig {
             @Qualifier("initialMailSyncMessageRecoverer") MessageRecoverer initialMailSyncMessageRecoverer
     ) {
         return RetryInterceptorBuilder.stateless()
-                .maxRetries(properties.getRetryMaxAttempts())
+                .retryPolicy(RabbitMqConfig.createRetryPolicy(properties.getRetryMaxAttempts()))
                 .recoverer(initialMailSyncMessageRecoverer)
                 .build();
     }

--- a/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/InitialMailSyncThreadBatchRabbitConfig.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/InitialMailSyncThreadBatchRabbitConfig.java
@@ -84,7 +84,7 @@ public class InitialMailSyncThreadBatchRabbitConfig {
             @Qualifier("initialMailSyncThreadBatchMessageRecoverer") MessageRecoverer initialMailSyncThreadBatchMessageRecoverer
     ) {
         return RetryInterceptorBuilder.stateless()
-                .maxRetries(properties.getRetryMaxAttempts())
+                .retryPolicy(RabbitMqConfig.createRetryPolicy(properties.getRetryMaxAttempts()))
                 .recoverer(initialMailSyncThreadBatchMessageRecoverer)
                 .build();
     }

--- a/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/LabelReclassifyRabbitConfig.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/LabelReclassifyRabbitConfig.java
@@ -84,7 +84,7 @@ public class LabelReclassifyRabbitConfig {
             @Qualifier("labelReclassifyMessageRecoverer") MessageRecoverer labelReclassifyMessageRecoverer
     ) {
         return RetryInterceptorBuilder.stateless()
-                .maxRetries(properties.getRetryMaxAttempts())
+                .retryPolicy(RabbitMqConfig.createRetryPolicy(properties.getRetryMaxAttempts()))
                 .recoverer(labelReclassifyMessageRecoverer)
                 .build();
     }

--- a/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/MailEmbeddingRabbitConfig.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/MailEmbeddingRabbitConfig.java
@@ -84,7 +84,7 @@ public class MailEmbeddingRabbitConfig {
             @Qualifier("mailEmbeddingMessageRecoverer") MessageRecoverer mailEmbeddingMessageRecoverer
     ) {
         return RetryInterceptorBuilder.stateless()
-                .maxRetries(properties.getRetryMaxAttempts())
+                .retryPolicy(RabbitMqConfig.createRetryPolicy(properties.getRetryMaxAttempts()))
                 .recoverer(mailEmbeddingMessageRecoverer)
                 .build();
     }

--- a/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/RabbitMqConfig.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/RabbitMqConfig.java
@@ -1,5 +1,6 @@
 package com.mailsangja.worker.config.rabbitmq;
 
+import com.mailsangja.worker.common.exception.mail.MailAccountNotFoundException;
 import com.mailsangja.worker.common.exception.mq.MqErrorCode;
 import com.mailsangja.worker.common.exception.mq.MqException;
 import com.mailsangja.worker.config.properties.MailTaskRabbitProperties;
@@ -10,6 +11,7 @@ import org.springframework.amqp.support.converter.JacksonJsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.retry.RetryPolicy;
 
 import java.time.Duration;
 
@@ -57,6 +59,13 @@ public class RabbitMqConfig {
             throw new MqException(MqErrorCode.INVALID_RABBITMQ_QUEUE_TTL, propertyName + " must be less than or equal to " + MAX_QUEUE_TTL_MILLIS + "ms.");
         }
         return (int) ttlMillis;
+    }
+
+    static RetryPolicy createRetryPolicy(int maxRetries) {
+        return RetryPolicy.builder()
+                .maxRetries(maxRetries)
+                .excludes(MailAccountNotFoundException.class)
+                .build();
     }
 
     static void validateTaskName(String taskName, String propertyName) {

--- a/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/WatchRenewalRabbitConfig.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/rabbitmq/WatchRenewalRabbitConfig.java
@@ -84,7 +84,7 @@ public class WatchRenewalRabbitConfig {
             @Qualifier("watchRenewalMessageRecoverer") MessageRecoverer watchRenewalMessageRecoverer
     ) {
         return RetryInterceptorBuilder.stateless()
-                .maxRetries(properties.getRetryMaxAttempts())
+                .retryPolicy(RabbitMqConfig.createRetryPolicy(properties.getRetryMaxAttempts()))
                 .recoverer(watchRenewalMessageRecoverer)
                 .build();
     }

--- a/worker/src/main/java/com/mailsangja/worker/facade/GmailPushFacade.java
+++ b/worker/src/main/java/com/mailsangja/worker/facade/GmailPushFacade.java
@@ -39,7 +39,7 @@ public class GmailPushFacade {
         GoogleMailPushNotificationResult notification = request.decode(objectMapper);
 
         MailAccount mailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(
-                mailAccountQueryService.findActiveGoogleMailAccountByEmailAddress(notification.emailAddress())
+                mailAccountQueryService.findSyncableGoogleMailAccountByEmailAddress(notification.emailAddress())
         );
 
         GoogleMailHistoryListResult historyResult = gmailHistoryApiService.getHistory(

--- a/worker/src/main/java/com/mailsangja/worker/facade/GmailPushFacade.java
+++ b/worker/src/main/java/com/mailsangja/worker/facade/GmailPushFacade.java
@@ -38,9 +38,15 @@ public class GmailPushFacade {
 
         GoogleMailPushNotificationResult notification = request.decode(objectMapper);
 
-        MailAccount mailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(
-                mailAccountQueryService.findSyncableGoogleMailAccountByEmailAddress(notification.emailAddress())
-        );
+        List<MailAccount> mailAccounts = mailAccountQueryService.findSyncableGoogleMailAccountsByEmailAddress(notification.emailAddress());
+
+        for (MailAccount rawAccount : mailAccounts) {
+            processAccountPush(notification, rawAccount);
+        }
+    }
+
+    private void processAccountPush(GoogleMailPushNotificationResult notification, MailAccount rawAccount) {
+        MailAccount mailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(rawAccount);
 
         GoogleMailHistoryListResult historyResult = gmailHistoryApiService.getHistory(
                 mailAccount.getAccessToken(),

--- a/worker/src/main/java/com/mailsangja/worker/handler/mail/MessagePermanentlyDeletedHistoryEventHandler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/mail/MessagePermanentlyDeletedHistoryEventHandler.java
@@ -22,7 +22,7 @@ public class MessagePermanentlyDeletedHistoryEventHandler implements GmailHistor
 
     @Override
     public void handle(GmailHistoryEvent event) {
-        MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(event.mailAccountId());
+        MailAccount mailAccount = mailAccountQueryService.findSyncableMailAccountById(event.mailAccountId());
         gmailHistoryDeleteApplyCommandService.applyMessagePermanentlyDeleted(mailAccount, event);
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageReadHistoryEventHandler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageReadHistoryEventHandler.java
@@ -35,7 +35,7 @@ public class MessageReadHistoryEventHandler implements GmailHistoryEventHandler 
     @Override
     public void handle(GmailHistoryEvent event) {
         MailAccount mailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(
-                mailAccountQueryService.findActiveMailAccountById(event.mailAccountId())
+                mailAccountQueryService.findSyncableMailAccountById(event.mailAccountId())
         );
         InitialMailSyncThreadSaveCommand syncCommand = prepareSyncCommandIfNeeded(mailAccount, event);
         gmailHistoryStateApplyCommandService.applyMessageReadState(mailAccount, event, true, syncCommand);

--- a/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageRestoredHistoryEventHandler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageRestoredHistoryEventHandler.java
@@ -22,7 +22,7 @@ public class MessageRestoredHistoryEventHandler implements GmailHistoryEventHand
 
     @Override
     public void handle(GmailHistoryEvent event) {
-        MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(event.mailAccountId());
+        MailAccount mailAccount = mailAccountQueryService.findSyncableMailAccountById(event.mailAccountId());
         gmailHistoryDeleteApplyCommandService.applyMessageRestored(mailAccount, event);
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageTrashedHistoryEventHandler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageTrashedHistoryEventHandler.java
@@ -22,7 +22,7 @@ public class MessageTrashedHistoryEventHandler implements GmailHistoryEventHandl
 
     @Override
     public void handle(GmailHistoryEvent event) {
-        MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(event.mailAccountId());
+        MailAccount mailAccount = mailAccountQueryService.findSyncableMailAccountById(event.mailAccountId());
         gmailHistoryDeleteApplyCommandService.applyMessageTrashed(mailAccount, event);
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageUnreadHistoryEventHandler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageUnreadHistoryEventHandler.java
@@ -35,7 +35,7 @@ public class MessageUnreadHistoryEventHandler implements GmailHistoryEventHandle
     @Override
     public void handle(GmailHistoryEvent event) {
         MailAccount mailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(
-                mailAccountQueryService.findActiveMailAccountById(event.mailAccountId())
+                mailAccountQueryService.findSyncableMailAccountById(event.mailAccountId())
         );
         InitialMailSyncThreadSaveCommand syncCommand = prepareSyncCommandIfNeeded(mailAccount, event);
         gmailHistoryStateApplyCommandService.applyMessageReadState(mailAccount, event, false, syncCommand);

--- a/worker/src/main/java/com/mailsangja/worker/messaging/listener/GmailHistoryEventListener.java
+++ b/worker/src/main/java/com/mailsangja/worker/messaging/listener/GmailHistoryEventListener.java
@@ -29,7 +29,7 @@ public class GmailHistoryEventListener {
     )
     public void handleMessageAdded(GmailHistoryEvent event) {
         MailAccount mailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(
-                mailAccountQueryService.findActiveMailAccountById(event.mailAccountId())
+                mailAccountQueryService.findSyncableMailAccountById(event.mailAccountId())
         );
         messageAddedHandler.handle(mailAccount, event);
     }

--- a/worker/src/main/java/com/mailsangja/worker/messaging/listener/GmailWatchRenewalListener.java
+++ b/worker/src/main/java/com/mailsangja/worker/messaging/listener/GmailWatchRenewalListener.java
@@ -29,7 +29,7 @@ public class GmailWatchRenewalListener {
             containerFactory = "watchRenewalRabbitListenerContainerFactory"
     )
     public void handle(WatchRenewalMessage message) {
-        MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(message.mailAccountId());
+        MailAccount mailAccount = mailAccountQueryService.findSyncableMailAccountById(message.mailAccountId());
         GoogleOAuthTokenResult tokenResult = googleOAuthApiService.refreshAccessToken(mailAccount.getRefreshToken());
         GoogleMailWatchResult watchResult = gmailWatchApiService.watch(tokenResult.accessToken());
 

--- a/worker/src/main/java/com/mailsangja/worker/messaging/listener/InitialMailSyncListener.java
+++ b/worker/src/main/java/com/mailsangja/worker/messaging/listener/InitialMailSyncListener.java
@@ -46,7 +46,7 @@ public class InitialMailSyncListener {
     @RabbitListener(queues = "#{@initialMailSyncQueue.name}")
     public void handle(InitialMailSyncMessage message) {
         MailAccount mailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(
-                mailAccountQueryService.findActiveMailAccountById(message.mailAccountId())
+                mailAccountQueryService.findSyncableMailAccountById(message.mailAccountId())
         );
 
         GoogleMailMessageListResult result = gmailMessageApiService.getLatestMessages(
@@ -82,7 +82,7 @@ public class InitialMailSyncListener {
     )
     public void handleThreadBatch(InitialMailSyncThreadBatchMessage message) {
         MailAccount mailAccount = googleAccessTokenEnsureService.ensureValidGoogleAccessToken(
-                mailAccountQueryService.findActiveMailAccountById(message.mailAccountId())
+                mailAccountQueryService.findSyncableMailAccountById(message.mailAccountId())
         );
 
         List<InitialMailSyncThreadResult> threadResults = gmailMessageApiService.getThreads(

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/MailAccountCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/MailAccountCommandService.java
@@ -42,7 +42,7 @@ public class MailAccountCommandService {
         GoogleOAuthTokenResult tokenResult = command.tokenResult();
         GoogleMailWatchResult watchResult = command.watchResult();
 
-        MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(mailAccountId);
+        MailAccount mailAccount = mailAccountQueryService.findSyncableMailAccountById(mailAccountId);
         validateRefreshableGoogleMailAccount(mailAccount);
         String updatedRefreshToken = isBlank(tokenResult.refreshToken())
                 ? mailAccount.getRefreshToken()
@@ -63,7 +63,7 @@ public class MailAccountCommandService {
     public MailAccount refreshGoogleAccessToken(UUID mailAccountId, GoogleOAuthTokenResult tokenResult) {
         validateRefreshGoogleAccessTokenInput(mailAccountId, tokenResult);
 
-        MailAccount mailAccount = mailAccountQueryService.findActiveMailAccountById(mailAccountId);
+        MailAccount mailAccount = mailAccountQueryService.findSyncableMailAccountById(mailAccountId);
         validateRefreshableGoogleMailAccount(mailAccount);
         String updatedRefreshToken = isBlank(tokenResult.refreshToken())
                 ? mailAccount.getRefreshToken()
@@ -77,7 +77,7 @@ public class MailAccountCommandService {
                 updatedRefreshToken
         );
 
-        return mailAccountQueryService.findActiveMailAccountById(mailAccountId);
+        return mailAccountQueryService.findSyncableMailAccountById(mailAccountId);
     }
 
     private void validateRenewGoogleWatchCommand(RenewGoogleWatchCommand command) {

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/MailAccountQueryService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/MailAccountQueryService.java
@@ -3,6 +3,7 @@ package com.mailsangja.worker.service.mail;
 import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.MailProvider;
 import com.mailsangja.db.port.MailAccountRepositoryPort;
+import com.mailsangja.worker.common.exception.mail.MailAccountNotFoundException;
 import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
 import com.mailsangja.worker.common.exception.mail.MailPushException;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +26,7 @@ public class MailAccountQueryService {
         List<MailAccount> mailAccounts = mailAccountRepositoryPort.findAllByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, emailAddress);
 
         if (mailAccounts.isEmpty()) {
-            throw new MailPushException(MailPushErrorCode.MAIL_ACCOUNT_NOT_FOUND);
+            throw new MailAccountNotFoundException();
         }
 
         return mailAccounts.stream()
@@ -35,7 +36,7 @@ public class MailAccountQueryService {
 
     public MailAccount findSyncableMailAccountById(UUID id) {
         MailAccount mailAccount = mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(id)
-                .orElseThrow(() -> new MailPushException(MailPushErrorCode.MAIL_ACCOUNT_NOT_FOUND));
+                .orElseThrow(MailAccountNotFoundException::new);
 
         validateSyncableMailAccount(mailAccount);
         return mailAccount;

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/MailAccountQueryService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/MailAccountQueryService.java
@@ -21,19 +21,19 @@ public class MailAccountQueryService {
 
     private final MailAccountRepositoryPort mailAccountRepositoryPort;
 
-    public MailAccount findActiveGoogleMailAccountByEmailAddress(String emailAddress) {
+    public MailAccount findSyncableGoogleMailAccountByEmailAddress(String emailAddress) {
         MailAccount mailAccount = mailAccountRepositoryPort.findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, emailAddress)
                 .orElseThrow(() -> new MailPushException(MailPushErrorCode.MAIL_ACCOUNT_NOT_FOUND));
 
-        validateActiveMailAccount(mailAccount);
+        validateSyncableMailAccount(mailAccount);
         return mailAccount;
     }
 
-    public MailAccount findActiveMailAccountById(UUID id) {
+    public MailAccount findSyncableMailAccountById(UUID id) {
         MailAccount mailAccount = mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new MailPushException(MailPushErrorCode.MAIL_ACCOUNT_NOT_FOUND));
 
-        validateActiveMailAccount(mailAccount);
+        validateSyncableMailAccount(mailAccount);
         return mailAccount;
     }
 
@@ -49,9 +49,8 @@ public class MailAccountQueryService {
         return LocalDateTime.now(KST_ZONE_ID);
     }
 
-    private void validateActiveMailAccount(MailAccount mailAccount) {
-        if (!mailAccount.isActive()
-                || mailAccount.isDeleted()
+    private void validateSyncableMailAccount(MailAccount mailAccount) {
+        if (mailAccount.isDeleted()
                 || mailAccount.getProvider() != MailProvider.GMAIL
                 || isBlank(mailAccount.getAccessToken())) {
             throw new MailPushException(MailPushErrorCode.INVALID_MAIL_ACCOUNT_STATE);

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/MailAccountQueryService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/MailAccountQueryService.java
@@ -21,12 +21,16 @@ public class MailAccountQueryService {
 
     private final MailAccountRepositoryPort mailAccountRepositoryPort;
 
-    public MailAccount findSyncableGoogleMailAccountByEmailAddress(String emailAddress) {
-        MailAccount mailAccount = mailAccountRepositoryPort.findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, emailAddress)
-                .orElseThrow(() -> new MailPushException(MailPushErrorCode.MAIL_ACCOUNT_NOT_FOUND));
+    public List<MailAccount> findSyncableGoogleMailAccountsByEmailAddress(String emailAddress) {
+        List<MailAccount> mailAccounts = mailAccountRepositoryPort.findAllByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, emailAddress);
 
-        validateSyncableMailAccount(mailAccount);
-        return mailAccount;
+        if (mailAccounts.isEmpty()) {
+            throw new MailPushException(MailPushErrorCode.MAIL_ACCOUNT_NOT_FOUND);
+        }
+
+        return mailAccounts.stream()
+                .filter(this::isSyncable)
+                .toList();
     }
 
     public MailAccount findSyncableMailAccountById(UUID id) {
@@ -50,11 +54,15 @@ public class MailAccountQueryService {
     }
 
     private void validateSyncableMailAccount(MailAccount mailAccount) {
-        if (mailAccount.isDeleted()
-                || mailAccount.getProvider() != MailProvider.GMAIL
-                || isBlank(mailAccount.getAccessToken())) {
+        if (!isSyncable(mailAccount)) {
             throw new MailPushException(MailPushErrorCode.INVALID_MAIL_ACCOUNT_STATE);
         }
+    }
+
+    private boolean isSyncable(MailAccount mailAccount) {
+        return !mailAccount.isDeleted()
+                && mailAccount.getProvider() == MailProvider.GMAIL
+                && !isBlank(mailAccount.getAccessToken());
     }
 
     private boolean isBlank(String value) {

--- a/worker/src/test/java/com/mailsangja/worker/messaging/listener/InitialMailSyncListenerTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/messaging/listener/InitialMailSyncListenerTest.java
@@ -98,7 +98,7 @@ class InitialMailSyncListenerTest {
                 List.of("gmail-thread-1")
         );
 
-        when(mailAccountQueryService.findActiveMailAccountById(mailAccountId)).thenReturn(mailAccount);
+        when(mailAccountQueryService.findSyncableMailAccountById(mailAccountId)).thenReturn(mailAccount);
         when(googleAccessTokenEnsureService.ensureValidGoogleAccessToken(mailAccount)).thenReturn(mailAccount);
         when(gmailMessageApiService.getThreads("access-token", List.of("gmail-thread-1")))
                 .thenReturn(List.of(new InitialMailSyncThreadResult("gmail-thread-1", "history-1", List.of())));

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandServiceTest.java
@@ -115,7 +115,7 @@ class GmailNewMessageApplyCommandServiceTest {
         assertFalse(deletedThread.isDeleted());
         assertTrue(oldMessage.isDeleted());
         assertEquals("message-new", messageCaptor.getValue().getGmailMessageId());
-        assertEquals(1, deletedThread.getMessageCount());
+        assertEquals(2, deletedThread.getMessageCount());
         assertEquals("new subject", deletedThread.getLatestSubject());
         assertEquals("new snippet", deletedThread.getLatestSnippet());
         assertEquals(LocalDateTime.of(2026, 4, 14, 10, 0), deletedThread.getLastMessageAt());

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/MailAccountCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/MailAccountCommandServiceTest.java
@@ -3,6 +3,8 @@ package com.mailsangja.worker.service.mail;
 import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.MailProvider;
 import com.mailsangja.db.port.MailAccountRepositoryPort;
+import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
+import com.mailsangja.worker.common.exception.mail.MailPushException;
 import com.mailsangja.worker.dto.gmail.oauth.GoogleOAuthTokenResult;
 import com.mailsangja.worker.dto.gmail.watch.GoogleMailWatchResult;
 import com.mailsangja.worker.dto.mail.watch.RenewGoogleWatchCommand;
@@ -17,6 +19,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -31,6 +34,7 @@ class MailAccountCommandServiceTest {
 
     @Test
     void renewGoogleWatch_액세스토큰이일치하면토큰과워치정보를함께갱신한다() {
+        // given
         MailAccount mailAccount = createMailAccount("old-access-token", "old-refresh-token");
         when(mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(mailAccount.getId()))
                 .thenReturn(Optional.of(mailAccount));
@@ -47,6 +51,7 @@ class MailAccountCommandServiceTest {
         MailAccountCommandService service = createService();
         LocalDateTime newWatchExpiresAt = LocalDateTime.now().plusDays(7);
 
+        // when
         service.renewGoogleWatch(
                 RenewGoogleWatchCommand.of(
                         mailAccount.getId(),
@@ -55,6 +60,7 @@ class MailAccountCommandServiceTest {
                 )
         );
 
+        // then
         ArgumentCaptor<LocalDateTime> tokenExpiresAtCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
         verify(mailAccountRepositoryPort).renewGoogleWatchIfAccessTokenMatches(
                 eq(mailAccount.getId()),
@@ -69,6 +75,7 @@ class MailAccountCommandServiceTest {
 
     @Test
     void renewGoogleWatch_경쟁상황으로조건부업데이트에실패하면기존값을유지한다() {
+        // given
         MailAccount mailAccount = createMailAccount("latest-access-token", "latest-refresh-token");
         when(mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(mailAccount.getId()))
                 .thenReturn(Optional.of(mailAccount));
@@ -84,6 +91,7 @@ class MailAccountCommandServiceTest {
 
         MailAccountCommandService service = createService();
 
+        // when
         service.renewGoogleWatch(
                 RenewGoogleWatchCommand.of(
                         mailAccount.getId(),
@@ -92,6 +100,7 @@ class MailAccountCommandServiceTest {
                 )
         );
 
+        // then
         verify(mailAccountRepositoryPort).renewGoogleWatchIfAccessTokenMatches(
                 eq(mailAccount.getId()),
                 eq("latest-access-token"),
@@ -105,6 +114,121 @@ class MailAccountCommandServiceTest {
         assertEquals("latest-access-token", mailAccount.getAccessToken());
         assertEquals("latest-refresh-token", mailAccount.getRefreshToken());
         assertEquals("sync-history-id", mailAccount.getSyncHistoryId());
+    }
+
+    @Test
+    void updateSyncHistoryId_히스토리Id를갱신한다() {
+        // given
+        MailAccount mailAccount = createMailAccount("access-token", "refresh-token");
+        MailAccountCommandService service = createService();
+
+        // when
+        service.updateSyncHistoryId(mailAccount, "new-history-id");
+
+        // then
+        assertEquals("new-history-id", mailAccount.getSyncHistoryId());
+    }
+
+    @Test
+    void updateSyncHistoryId_메일계정이null이면예외를던진다() {
+        // given
+        MailAccountCommandService service = createService();
+
+        // when
+        MailPushException exception = assertThrows(
+                MailPushException.class,
+                () -> service.updateSyncHistoryId(null, "new-history-id")
+        );
+
+        // then
+        assertEquals(MailPushErrorCode.INVALID_GMAIL_PUSH_NOTIFICATION, exception.getErrorCode());
+    }
+
+    @Test
+    void updateSyncHistoryId_히스토리Id가blank이면예외를던진다() {
+        // given
+        MailAccount mailAccount = createMailAccount("access-token", "refresh-token");
+        MailAccountCommandService service = createService();
+
+        // when
+        MailPushException exception = assertThrows(
+                MailPushException.class,
+                () -> service.updateSyncHistoryId(mailAccount, " ")
+        );
+
+        // then
+        assertEquals(MailPushErrorCode.INVALID_GMAIL_PUSH_NOTIFICATION, exception.getErrorCode());
+        assertEquals("sync-history-id", mailAccount.getSyncHistoryId());
+    }
+
+    @Test
+    void renewGoogleWatch_명령이null이면예외를던지고갱신하지않는다() {
+        // given
+        MailAccountCommandService service = createService();
+
+        // when
+        MailPushException exception = assertThrows(MailPushException.class, () -> service.renewGoogleWatch(null));
+
+        // then
+        assertEquals(MailPushErrorCode.INVALID_GMAIL_WATCH_RENEWAL_REQUEST, exception.getErrorCode());
+        verify(mailAccountRepositoryPort, never()).renewGoogleWatchIfAccessTokenMatches(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+        );
+    }
+
+    @Test
+    void refreshGoogleAccessToken_새리프레시토큰이없으면기존리프레시토큰을유지한다() {
+        // given
+        MailAccount mailAccount = createMailAccount("old-access-token", "old-refresh-token");
+        MailAccount refreshedMailAccount = createMailAccount("new-access-token", "old-refresh-token");
+        when(mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(mailAccount.getId()))
+                .thenReturn(Optional.of(mailAccount))
+                .thenReturn(Optional.of(refreshedMailAccount));
+        MailAccountCommandService service = createService();
+
+        // when
+        MailAccount result = service.refreshGoogleAccessToken(
+                mailAccount.getId(),
+                new GoogleOAuthTokenResult("new-access-token", " ", 3600L, null, "Bearer")
+        );
+
+        // then
+        assertEquals(refreshedMailAccount, result);
+        verify(mailAccountRepositoryPort).updateGoogleTokenIfAccessTokenMatches(
+                eq(mailAccount.getId()),
+                eq("old-access-token"),
+                eq("new-access-token"),
+                any(LocalDateTime.class),
+                eq("old-refresh-token")
+        );
+    }
+
+    @Test
+    void refreshGoogleAccessToken_입력이잘못되면예외를던지고갱신하지않는다() {
+        // given
+        MailAccountCommandService service = createService();
+
+        // when
+        MailPushException exception = assertThrows(
+                MailPushException.class,
+                () -> service.refreshGoogleAccessToken(UUID.randomUUID(), new GoogleOAuthTokenResult(" ", null, 3600L, null, "Bearer"))
+        );
+
+        // then
+        assertEquals(MailPushErrorCode.GOOGLE_TOKEN_REFRESH_FAILED, exception.getErrorCode());
+        verify(mailAccountRepositoryPort, never()).updateGoogleTokenIfAccessTokenMatches(
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+        );
     }
 
     private MailAccountCommandService createService() {

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/MailAccountQueryServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/MailAccountQueryServiceTest.java
@@ -1,0 +1,192 @@
+package com.mailsangja.worker.service.mail;
+
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.MailProvider;
+import com.mailsangja.db.port.MailAccountRepositoryPort;
+import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
+import com.mailsangja.worker.common.exception.mail.MailPushException;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MailAccountQueryServiceTest {
+
+    @Test
+    void findSyncableGoogleMailAccountByEmailAddress_동기화가능한Gmail계정을반환한다() {
+        // given
+        MailAccount mailAccount = createMailAccount(MailProvider.GMAIL, true, "access-token");
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, "user@example.com"))
+                .thenReturn(Optional.of(mailAccount));
+
+        // when
+        MailAccount found = service.findSyncableGoogleMailAccountByEmailAddress("user@example.com");
+
+        // then
+        assertEquals(mailAccount, found);
+    }
+
+    @Test
+    void findSyncableGoogleMailAccountByEmailAddress_계정이없으면예외를던진다() {
+        // given
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, "user@example.com"))
+                .thenReturn(Optional.empty());
+
+        // when
+        MailPushException exception = assertThrows(
+                MailPushException.class,
+                () -> service.findSyncableGoogleMailAccountByEmailAddress("user@example.com")
+        );
+
+        // then
+        assertEquals(MailPushErrorCode.MAIL_ACCOUNT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void findSyncableGoogleMailAccountByEmailAddress_삭제된계정이면예외를던진다() {
+        // given
+        MailAccount mailAccount = createMailAccount(MailProvider.GMAIL, true, "access-token");
+        mailAccount.delete();
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, "user@example.com"))
+                .thenReturn(Optional.of(mailAccount));
+
+        // when
+        MailPushException exception = assertThrows(
+                MailPushException.class,
+                () -> service.findSyncableGoogleMailAccountByEmailAddress("user@example.com")
+        );
+
+        // then
+        assertEquals(MailPushErrorCode.INVALID_MAIL_ACCOUNT_STATE, exception.getErrorCode());
+    }
+
+    @Test
+    void findSyncableGoogleMailAccountByEmailAddress_액세스토큰이없으면예외를던진다() {
+        // given
+        MailAccount mailAccount = createMailAccount(MailProvider.GMAIL, true, " ");
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, "user@example.com"))
+                .thenReturn(Optional.of(mailAccount));
+
+        // when
+        MailPushException exception = assertThrows(
+                MailPushException.class,
+                () -> service.findSyncableGoogleMailAccountByEmailAddress("user@example.com")
+        );
+
+        // then
+        assertEquals(MailPushErrorCode.INVALID_MAIL_ACCOUNT_STATE, exception.getErrorCode());
+    }
+
+    @Test
+    void findSyncableMailAccountById_동기화가능한메일계정을반환한다() {
+        // given
+        UUID mailAccountId = UUID.randomUUID();
+        MailAccount mailAccount = createMailAccount(MailProvider.GMAIL, true, "access-token");
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(mailAccountId))
+                .thenReturn(Optional.of(mailAccount));
+
+        // when
+        MailAccount found = service.findSyncableMailAccountById(mailAccountId);
+
+        // then
+        assertEquals(mailAccount, found);
+    }
+
+    @Test
+    void findSyncableMailAccountById_계정이없으면예외를던진다() {
+        // given
+        UUID mailAccountId = UUID.randomUUID();
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findByIdAndDeletedAtIsNull(mailAccountId))
+                .thenReturn(Optional.empty());
+
+        // when
+        MailPushException exception = assertThrows(
+                MailPushException.class,
+                () -> service.findSyncableMailAccountById(mailAccountId)
+        );
+
+        // then
+        assertEquals(MailPushErrorCode.MAIL_ACCOUNT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void findRenewalTargetGmailAccounts_갱신대상계정을조회한다() {
+        // given
+        LocalDateTime threshold = LocalDateTime.of(2026, 5, 19, 9, 0);
+        List<MailAccount> mailAccounts = List.of(createMailAccount(MailProvider.GMAIL, true, "access-token"));
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findRenewalTargetGmailAccounts(MailProvider.GMAIL, threshold, 100))
+                .thenReturn(mailAccounts);
+
+        // when
+        List<MailAccount> found = service.findRenewalTargetGmailAccounts(threshold, 100);
+
+        // then
+        assertEquals(mailAccounts, found);
+        verify(mailAccountRepositoryPort).findRenewalTargetGmailAccounts(MailProvider.GMAIL, threshold, 100);
+    }
+
+    @Test
+    void findRenewalTargetGmailAccounts_조회조건이잘못되면예외를던진다() {
+        // given
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+
+        // when
+        MailPushException exception = assertThrows(
+                MailPushException.class,
+                () -> service.findRenewalTargetGmailAccounts(null, 100)
+        );
+
+        // then
+        assertEquals(MailPushErrorCode.INVALID_GMAIL_WATCH_RENEWAL_REQUEST, exception.getErrorCode());
+    }
+
+    @Test
+    void getKstNow_KST현재시각을반환한다() {
+        // given
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+
+        // when
+        LocalDateTime now = service.getKstNow();
+
+        // then
+        assertTrue(now != null);
+    }
+
+    private MailAccount createMailAccount(MailProvider provider, boolean active, String accessToken) {
+        return MailAccount.builder()
+                .id(UUID.randomUUID())
+                .provider(provider)
+                .emailAddress("user@example.com")
+                .alias("alias")
+                .icon("good")
+                .color("#123456")
+                .accessToken(accessToken)
+                .active(active)
+                .build();
+    }
+}

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/MailAccountQueryServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/MailAccountQueryServiceTest.java
@@ -22,33 +22,51 @@ import static org.mockito.Mockito.when;
 class MailAccountQueryServiceTest {
 
     @Test
-    void findSyncableGoogleMailAccountByEmailAddress_동기화가능한Gmail계정을반환한다() {
+    void findSyncableGoogleMailAccountsByEmailAddress_동기화가능한Gmail계정을반환한다() {
         // given
         MailAccount mailAccount = createMailAccount(MailProvider.GMAIL, true, "access-token");
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
         MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
-        when(mailAccountRepositoryPort.findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, "user@example.com"))
-                .thenReturn(Optional.of(mailAccount));
+        when(mailAccountRepositoryPort.findAllByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, "user@example.com"))
+                .thenReturn(List.of(mailAccount));
 
         // when
-        MailAccount found = service.findSyncableGoogleMailAccountByEmailAddress("user@example.com");
+        List<MailAccount> found = service.findSyncableGoogleMailAccountsByEmailAddress("user@example.com");
 
         // then
-        assertEquals(mailAccount, found);
+        assertEquals(1, found.size());
+        assertEquals(mailAccount, found.get(0));
     }
 
     @Test
-    void findSyncableGoogleMailAccountByEmailAddress_계정이없으면예외를던진다() {
+    void findSyncableGoogleMailAccountsByEmailAddress_다중사용자Gmail계정을모두반환한다() {
+        // given
+        MailAccount account1 = createMailAccount(MailProvider.GMAIL, true, "token-1");
+        MailAccount account2 = createMailAccount(MailProvider.GMAIL, true, "token-2");
+        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
+        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
+        when(mailAccountRepositoryPort.findAllByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, "user@example.com"))
+                .thenReturn(List.of(account1, account2));
+
+        // when
+        List<MailAccount> found = service.findSyncableGoogleMailAccountsByEmailAddress("user@example.com");
+
+        // then
+        assertEquals(2, found.size());
+    }
+
+    @Test
+    void findSyncableGoogleMailAccountsByEmailAddress_계정이없으면예외를던진다() {
         // given
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
         MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
-        when(mailAccountRepositoryPort.findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, "user@example.com"))
-                .thenReturn(Optional.empty());
+        when(mailAccountRepositoryPort.findAllByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, "user@example.com"))
+                .thenReturn(List.of());
 
         // when
         MailPushException exception = assertThrows(
                 MailPushException.class,
-                () -> service.findSyncableGoogleMailAccountByEmailAddress("user@example.com")
+                () -> service.findSyncableGoogleMailAccountsByEmailAddress("user@example.com")
         );
 
         // then
@@ -56,42 +74,19 @@ class MailAccountQueryServiceTest {
     }
 
     @Test
-    void findSyncableGoogleMailAccountByEmailAddress_삭제된계정이면예외를던진다() {
+    void findSyncableGoogleMailAccountsByEmailAddress_동기화불가계정은필터링한다() {
         // given
-        MailAccount mailAccount = createMailAccount(MailProvider.GMAIL, true, "access-token");
-        mailAccount.delete();
+        MailAccount unsyncableAccount = createMailAccount(MailProvider.GMAIL, true, " ");
         MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
         MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
-        when(mailAccountRepositoryPort.findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, "user@example.com"))
-                .thenReturn(Optional.of(mailAccount));
+        when(mailAccountRepositoryPort.findAllByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, "user@example.com"))
+                .thenReturn(List.of(unsyncableAccount));
 
         // when
-        MailPushException exception = assertThrows(
-                MailPushException.class,
-                () -> service.findSyncableGoogleMailAccountByEmailAddress("user@example.com")
-        );
+        List<MailAccount> found = service.findSyncableGoogleMailAccountsByEmailAddress("user@example.com");
 
         // then
-        assertEquals(MailPushErrorCode.INVALID_MAIL_ACCOUNT_STATE, exception.getErrorCode());
-    }
-
-    @Test
-    void findSyncableGoogleMailAccountByEmailAddress_액세스토큰이없으면예외를던진다() {
-        // given
-        MailAccount mailAccount = createMailAccount(MailProvider.GMAIL, true, " ");
-        MailAccountRepositoryPort mailAccountRepositoryPort = mock(MailAccountRepositoryPort.class);
-        MailAccountQueryService service = new MailAccountQueryService(mailAccountRepositoryPort);
-        when(mailAccountRepositoryPort.findByProviderAndEmailAddressAndDeletedAtIsNull(MailProvider.GMAIL, "user@example.com"))
-                .thenReturn(Optional.of(mailAccount));
-
-        // when
-        MailPushException exception = assertThrows(
-                MailPushException.class,
-                () -> service.findSyncableGoogleMailAccountByEmailAddress("user@example.com")
-        );
-
-        // then
-        assertEquals(MailPushErrorCode.INVALID_MAIL_ACCOUNT_STATE, exception.getErrorCode());
+        assertTrue(found.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#2

### 📌 Task
- Closes #7 


## 💡 작업 내용

1. **사용자 단위 unique 검사로 변경**
  - MailAccountCommandService에서 validateAnotherOwnerDuplicate 호출 제거
  - 이제 같은 이메일 주소를 서로 다른 사용자가 각자 등록 가능
  - 동일 사용자가 같은 이메일을 중복 등록하는 검사는 그대로 유지

2. **외관 변경 API**
    - PATCH /api/v1/mail-accounts/{mailAccountId}

4. **계정 활성/비활성/삭제**
  - 활성/비활성 → sync/watch 모두 지속 (active 체크 제거)
  - 삭제 → deletedAt 설정, sync/watch 완전 차단
  - API
      - PATCH /{id}/activate
      - PATCH /{id}/deactivate
      - DELETE /{id} (삭제)


## 📝 추가 설명

### 메일 계정 3-State 모델 도입

메일 계정 상태를 `활성`, `비활성`, `삭제`의 3가지 상태로 구분하도록 변경했습니다.

| 상태 | active | deletedAt | UI 표시 | 동기화 / Watch |
|---|---:|---|---:|---:|
| 활성 | `true` | `null` | ✅ | ✅ |
| 비활성 | `false` | `null` | ❌ | ✅ |
| 삭제 | `false` | `now` | ❌ | ❌ |

### 상태별 의미

- **활성**
  - 사용자 화면에 표시됩니다.
  - 메일 동기화 및 Gmail Watch 갱신 대상에 포함됩니다.

- **비활성**
  - 사용자 화면에는 표시되지 않습니다.
  - 단, 메일 동기화 및 Gmail Watch 갱신 대상에는 포함됩니다.
  - 계정을 완전히 삭제하지 않고 숨김 처리하는 상태입니다.

- **삭제**
  - `deletedAt`이 설정된 soft delete 상태입니다.
  - 사용자 화면에 표시되지 않습니다.
  - 메일 동기화 및 Gmail Watch 갱신 대상에서도 제외됩니다.

## ⚡️ Test 결과

| 계정 비활성화 | 계정 활성화 | 계정 삭제 |
| -- | -- | -- |
| <img width="1107" height="727" alt="image" src="https://github.com/user-attachments/assets/10dc20f8-20d1-4494-9d59-801f1cb7b0c9" /> | <img width="1122" height="738" alt="image" src="https://github.com/user-attachments/assets/8d66496e-7e71-4f68-9baf-12badd5a0568" />  | <img width="1381" height="756" alt="image" src="https://github.com/user-attachments/assets/ab3c7e54-7708-4340-8b2d-eeaefe66780c" /> | 