### PR TITLE
[STORY-601] 답장 초안 생성 조건 강화

### DIFF
--- a/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
@@ -82,6 +82,19 @@ public class MessageRepositoryAdapter implements MessageRepositoryPort {
     }
 
     @Override
+    public boolean existsByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+            UUID mailAccountId,
+            String gmailThreadId,
+            Direction direction
+    ) {
+        return messageJpaRepositoryModule.existsByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccountId,
+                gmailThreadId,
+                direction
+        );
+    }
+
+    @Override
     public List<Message> findAllByThreadIdAndDeletedAtIsNull(UUID threadId) {
         return messageJpaRepositoryModule.findAllByThreadIdAndDeletedAtIsNull(threadId);
     }

--- a/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
@@ -64,6 +64,22 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
             @Param("gmailMessageId") String gmailMessageId
     );
 
+    @Query("""
+            SELECT COUNT(m) > 0
+            FROM Message m
+            WHERE m.thread.mailAccount.id = :mailAccountId
+              AND m.thread.gmailThreadId = :gmailThreadId
+              AND m.direction = :direction
+              AND m.deletedAt IS NULL
+              AND m.thread.deletedAt IS NULL
+              AND m.thread.mailAccount.deletedAt IS NULL
+            """)
+    boolean existsByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+            @Param("mailAccountId") UUID mailAccountId,
+            @Param("gmailThreadId") String gmailThreadId,
+            @Param("direction") Direction direction
+    );
+
     @EntityGraph(attributePaths = {"attachments"})
     @Query("SELECT m FROM Message m WHERE m.thread.id = :threadId AND m.deletedAt IS NULL ORDER BY m.sentAt ASC")
     List<Message> findAllByThreadIdAndDeletedAtIsNull(@Param("threadId") UUID threadId);

--- a/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
@@ -31,6 +31,11 @@ public interface MessageRepositoryPort {
             String gmailThreadId,
             String gmailMessageId
     );
+    boolean existsByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+            UUID mailAccountId,
+            String gmailThreadId,
+            Direction direction
+    );
     Optional<Message> findByIdIncludingDeleted(UUID messageId);
     List<Message> findAllByThreadIdAndDeletedAtIsNull(UUID threadId);
     List<Message> findAllByThreadIdIncludingDeleted(UUID threadId);

--- a/worker/src/main/java/com/mailsangja/worker/dto/notification/NewMailPushContext.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/notification/NewMailPushContext.java
@@ -2,6 +2,7 @@ package com.mailsangja.worker.dto.notification;
 
 import com.mailsangja.db.entity.mail.Direction;
 
+import java.util.List;
 import java.util.UUID;
 
 public record NewMailPushContext(
@@ -12,6 +13,7 @@ public record NewMailPushContext(
         UUID threadId,
         UUID messageId,
         Direction direction,
+        List<String> toAddresses,
         int threadMessageCount
 ) {
     public NewMailPushContext(
@@ -23,6 +25,6 @@ public record NewMailPushContext(
             UUID messageId,
             Direction direction
     ) {
-        this(mailAccountId, alias, subject, snippet, threadId, messageId, direction, 0);
+        this(mailAccountId, alias, subject, snippet, threadId, messageId, direction, List.of(), 0);
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
@@ -46,7 +46,7 @@ public class MessageAddedHistoryEventHandler {
     public void handle(MailAccount mailAccount, GmailHistoryEvent event) {
         gmailNewMessageSyncCommandService.syncNewMessage(mailAccount, event).ifPresent(context -> {
             mailEmbeddingPublisher.publish(new MailEmbeddingMessage(context.messageId()));
-            publishReplyDraftSuggestionIfEligible(event, context);
+            publishReplyDraftSuggestionIfEligible(mailAccount, event, context);
 
             List<Label> activeLabels = labelQueryService.findAllActiveByUserId(mailAccount.getUser().getId());
 
@@ -67,14 +67,31 @@ public class MessageAddedHistoryEventHandler {
         });
     }
 
-    private void publishReplyDraftSuggestionIfEligible(GmailHistoryEvent event, NewMailPushContext context) {
+    private void publishReplyDraftSuggestionIfEligible(MailAccount mailAccount, GmailHistoryEvent event, NewMailPushContext context) {
         if (context.direction() != Direction.INBOUND) {
             return;
         }
-        if (!replyDraftSuggestionQueryService.isEligible(context.threadMessageCount())) {
+        if (!isSentToConnectedMailAccount(mailAccount, context.toAddresses())) {
+            return;
+        }
+        if (!replyDraftSuggestionQueryService.isEligible(
+                mailAccount.getId(),
+                event.gmailThreadId(),
+                context.threadMessageCount()
+        )) {
             return;
         }
         replyDraftSuggestionPublisher.publish(new ReplyDraftSuggestionMessage(context.messageId()));
+    }
+
+    private boolean isSentToConnectedMailAccount(MailAccount mailAccount, List<String> toAddresses) {
+        if (mailAccount == null || mailAccount.getEmailAddress() == null || toAddresses == null || toAddresses.isEmpty()) {
+            return false;
+        }
+        String connectedEmail = mailAccount.getEmailAddress().trim();
+        return toAddresses.stream()
+                .filter(address -> address != null && !address.isBlank())
+                .anyMatch(address -> connectedEmail.equalsIgnoreCase(address.trim()));
     }
 
     private boolean applyLabelsAndCheckNotification(NewMailPushContext context, List<Label> activeLabels) {

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/GmailNewMessageSyncCommandService.java
@@ -60,6 +60,7 @@ public class GmailNewMessageSyncCommandService {
                         applyResult.threadId(),
                         applyResult.messageId(),
                         message.direction(),
+                        message.toAddresses(),
                         applyResult.threadMessageCount()
                 ));
             }

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionQueryService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionQueryService.java
@@ -1,6 +1,7 @@
 package com.mailsangja.worker.service.mail;
 
 import com.mailsangja.db.dto.MailDraftReferenceMessageResult;
+import com.mailsangja.db.entity.mail.Direction;
 import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.port.MailDraftReferenceQueryPort;
 import com.mailsangja.db.port.MessageRepositoryPort;
@@ -101,6 +102,17 @@ public class ReplyDraftSuggestionQueryService {
 
     public boolean isEligible(int threadMessageCount) {
         return threadMessageCount >= replyDraftSuggestionProperties.getMinThreadMessageCount();
+    }
+
+    public boolean isEligible(UUID mailAccountId, String gmailThreadId, int threadMessageCount) {
+        if (!isEligible(threadMessageCount)) {
+            return false;
+        }
+        return messageRepositoryPort.existsByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccountId,
+                gmailThreadId,
+                Direction.OUTBOUND
+        );
     }
 
     private Message findActiveMessage(UUID messageId) {

--- a/worker/src/test/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandlerTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandlerTest.java
@@ -10,6 +10,7 @@ import com.mailsangja.db.port.AttachmentRepositoryPort;
 import com.mailsangja.worker.dto.ai.embedding.MailEmbeddingMessage;
 import com.mailsangja.worker.dto.gmail.history.GmailHistoryEvent;
 import com.mailsangja.worker.dto.gmail.history.GmailHistoryEventType;
+import com.mailsangja.worker.dto.mail.reply.ReplyDraftSuggestionMessage;
 import com.mailsangja.worker.dto.notification.NewMailPushContext;
 import com.mailsangja.worker.handler.label.LabelRuleCompiler;
 import com.mailsangja.worker.messaging.publisher.MailEmbeddingPublisher;
@@ -114,6 +115,102 @@ class MessageAddedHistoryEventHandlerTest {
         verify(mailEmbeddingPublisher).publish(messageCaptor.capture());
         assertEquals(messageId, messageCaptor.getValue().messageId());
         verify(fcmPushCommandService).sendNewMailPush(context);
+    }
+
+    @Test
+    void handle_수신메일To에연결계정이있으면답장초안메시지를발행한다() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID mailAccountId = UUID.randomUUID();
+        UUID threadId = UUID.randomUUID();
+        UUID messageId = UUID.randomUUID();
+        MailAccount mailAccount = createMailAccount(userId, mailAccountId);
+        GmailHistoryEvent event = createEvent(mailAccountId);
+        NewMailPushContext context = new NewMailPushContext(
+                mailAccountId,
+                "Alice",
+                "subject",
+                "snippet",
+                threadId,
+                messageId,
+                Direction.INBOUND,
+                List.of(" ALICE@example.com "),
+                3
+        );
+
+        when(gmailNewMessageSyncCommandService.syncNewMessage(mailAccount, event)).thenReturn(Optional.of(context));
+        when(replyDraftSuggestionQueryService.isEligible(mailAccountId, "gmail-thread-1", 3)).thenReturn(true);
+        when(labelQueryService.findAllActiveByUserId(userId)).thenReturn(List.of());
+
+        // when
+        handler.handle(mailAccount, event);
+
+        // then
+        ArgumentCaptor<ReplyDraftSuggestionMessage> messageCaptor = ArgumentCaptor.forClass(ReplyDraftSuggestionMessage.class);
+        verify(replyDraftSuggestionPublisher).publish(messageCaptor.capture());
+        assertEquals(messageId, messageCaptor.getValue().messageId());
+    }
+
+    @Test
+    void handle_수신메일To에연결계정이있어도답장초안대상이아니면발행하지않는다() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID mailAccountId = UUID.randomUUID();
+        UUID messageId = UUID.randomUUID();
+        MailAccount mailAccount = createMailAccount(userId, mailAccountId);
+        GmailHistoryEvent event = createEvent(mailAccountId);
+        NewMailPushContext context = new NewMailPushContext(
+                mailAccountId,
+                "Alice",
+                "subject",
+                "snippet",
+                UUID.randomUUID(),
+                messageId,
+                Direction.INBOUND,
+                List.of("alice@example.com"),
+                3
+        );
+
+        when(gmailNewMessageSyncCommandService.syncNewMessage(mailAccount, event)).thenReturn(Optional.of(context));
+        when(replyDraftSuggestionQueryService.isEligible(mailAccountId, "gmail-thread-1", 3)).thenReturn(false);
+        when(labelQueryService.findAllActiveByUserId(userId)).thenReturn(List.of());
+
+        // when
+        handler.handle(mailAccount, event);
+
+        // then
+        verifyNoInteractions(replyDraftSuggestionPublisher);
+    }
+
+    @Test
+    void handle_수신메일To에연결계정이없으면답장초안메시지를발행하지않는다() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID mailAccountId = UUID.randomUUID();
+        UUID messageId = UUID.randomUUID();
+        MailAccount mailAccount = createMailAccount(userId, mailAccountId);
+        GmailHistoryEvent event = createEvent(mailAccountId);
+        NewMailPushContext context = new NewMailPushContext(
+                mailAccountId,
+                "Alice",
+                "subject",
+                "snippet",
+                UUID.randomUUID(),
+                messageId,
+                Direction.INBOUND,
+                List.of("other@example.com"),
+                3
+        );
+
+        when(gmailNewMessageSyncCommandService.syncNewMessage(mailAccount, event)).thenReturn(Optional.of(context));
+        when(labelQueryService.findAllActiveByUserId(userId)).thenReturn(List.of());
+
+        // when
+        handler.handle(mailAccount, event);
+
+        // then
+        verifyNoInteractions(replyDraftSuggestionQueryService);
+        verifyNoInteractions(replyDraftSuggestionPublisher);
     }
 
     @Test

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionQueryServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionQueryServiceTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -51,6 +52,60 @@ class ReplyDraftSuggestionQueryServiceTest {
 
     @Mock
     private PhileasMaskingService maskingService;
+
+    @Test
+    void isEligible_스레드메시지가3개미만이면Outbound조회없이실패한다() {
+        // given
+        ReplyDraftSuggestionQueryService service = createService();
+        UUID mailAccountId = UUID.randomUUID();
+
+        // when
+        boolean result = service.isEligible(mailAccountId, "gmail-thread-1", 2);
+
+        // then
+        assertFalse(result);
+        verify(messageRepositoryPort, never()).existsByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                any(),
+                anyString(),
+                any()
+        );
+    }
+
+    @Test
+    void isEligible_스레드에Outbound메시지가있으면성공한다() {
+        // given
+        ReplyDraftSuggestionQueryService service = createService();
+        UUID mailAccountId = UUID.randomUUID();
+        when(messageRepositoryPort.existsByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccountId,
+                "gmail-thread-1",
+                Direction.OUTBOUND
+        )).thenReturn(true);
+
+        // when
+        boolean result = service.isEligible(mailAccountId, "gmail-thread-1", 3);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    void isEligible_스레드에Outbound메시지가없으면실패한다() {
+        // given
+        ReplyDraftSuggestionQueryService service = createService();
+        UUID mailAccountId = UUID.randomUUID();
+        when(messageRepositoryPort.existsByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccountId,
+                "gmail-thread-1",
+                Direction.OUTBOUND
+        )).thenReturn(false);
+
+        // when
+        boolean result = service.isEligible(mailAccountId, "gmail-thread-1", 3);
+
+        // then
+        assertFalse(result);
+    }
 
     @Test
     void createPrompt_latest_thread_recent_recipientHistory를역할별섹션으로구성한다() {


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#26

### 📌 Task
- Closes #126


## 💡 작업 내용

- 답장 초안 추천 작업 발행 전에 새 수신 메시지의 `To`에 연결 계정 이메일이 포함되어 있는지 검증하도록 추가했습니다.
- 같은 Gmail thread 안에 사용자가 보낸 `OUTBOUND` 메시지가 있는 경우에만 답장 초안 추천 작업을 발행하도록 변경했습니다.
- 기존 스레드 메시지 수 최소 조건(`min-thread-message-count`, 기본값 3)을 유지하면서 OUTBOUND 이력 조건을 함께 적용했습니다.
- `NewMailPushContext`에 새 메시지의 `toAddresses`를 포함해 worker message-added 후처리 단계에서 필터링할 수 있도록 확장했습니다.
- `MessageRepositoryPort`/Adapter/JPA Module에 `mailAccountId + gmailThreadId + direction` 기준 메시지 존재 여부 조회를 추가했습니다.


## 📝 추가 설명

### 1. 답장 초안 생성 필터링 조건

```mermaid
flowchart TD
    A[message-added 이벤트 수신] --> B[새 메시지 동기화 및 저장]
    B --> C{INBOUND 메시지인가?}
    C -- 아니오 --> X[답장 초안 작업 발행 안 함]
    C -- 예 --> D{To에 연결 계정 이메일 포함?}
    D -- 아니오 --> X
    D -- 예 --> E{스레드 메시지 수 >= 3?}
    E -- 아니오 --> X
    E -- 예 --> F{같은 Gmail thread에 OUTBOUND 메시지 존재?}
    F -- 아니오 --> X
    F -- 예 --> G[ReplyDraftSuggestionMessage 발행]
```

- `To`에 연결 계정 이메일이 없는 수신 메시지는 사용자가 직접 답장할 가능성이 낮다고 보고 초안 생성을 건너뜁니다.
- 사용자가 한 번도 보낸 적 없는 Gmail thread는 답장 맥락과 사용자 응답 의도가 약하므로 초안 생성을 건너뜁니다.
- 스레드 메시지 수 조건은 기존 설정값을 그대로 사용하며 기본값은 `3`입니다.

### 2. Worker 발행 흐름 변경

- `GmailNewMessageSyncCommandService`가 Gmail 메시지 파싱 결과의 `toAddresses`를 `NewMailPushContext`에 전달합니다.
- `MessageAddedHistoryEventHandler`는 임베딩 메시지는 기존처럼 발행하고, 답장 초안 추천 MQ 발행 전에 아래 조건을 순서대로 확인합니다.

| 순서 | 조건 | 실패 시 처리 |
| --- | --- | --- |
| 1 | `Direction.INBOUND` | 답장 초안 작업 발행 안 함 |
| 2 | `To`에 연결 계정 이메일 포함 | 답장 초안 작업 발행 안 함 |
| 3 | 스레드 메시지 수 `minThreadMessageCount` 이상 | 답장 초안 작업 발행 안 함 |
| 4 | 같은 Gmail thread의 `OUTBOUND` 메시지 존재 | 답장 초안 작업 발행 안 함 |

### 3. Repository 조회 조건

- `MessageRepositoryPort`에 `existsByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(...)`를 추가했습니다.
- Gmail thread는 INBOUND/OUTBOUND `Thread` 행이 분리될 수 있으므로 `threadId`가 아니라 `mailAccountId + gmailThreadId` 기준으로 조회합니다.
- soft delete된 메시지, thread, mail account는 OUTBOUND 이력 판단에서 제외합니다.


## ⚡️ Test 결과

| To 필터링 | OUTBOUND 이력 필터링 | 스레드 개수 조건 | Repository 연동 |
| -- | -- | -- | -- |
| Unit Test | Unit Test | Unit Test | Compile |
| `MessageAddedHistoryEventHandlerTest` | `ReplyDraftSuggestionQueryServiceTest` | `ReplyDraftSuggestionQueryServiceTest` | `MessageRepositoryPort` |
| `BUILD SUCCESSFUL` | `BUILD SUCCESSFUL` | `BUILD SUCCESSFUL` | `BUILD SUCCESSFUL` |

실행한 테스트:

```bash
./gradlew :test --tests com.mailsangja.worker.handler.mail.MessageAddedHistoryEventHandlerTest --tests com.mailsangja.worker.service.mail.ReplyDraftSuggestionQueryServiceTest -x :db:test --rerun-tasks
```