### PR TITLE
[STORY-501] LLM 직접 호출 API

### DIFF
--- a/core/src/main/java/com/mailsangja/core/common/exception/ai/AiPlaygroundErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/ai/AiPlaygroundErrorCode.java
@@ -1,0 +1,19 @@
+package com.mailsangja.core.common.exception.ai;
+
+import com.mailsangja.core.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AiPlaygroundErrorCode implements ErrorCode {
+
+    INVALID_REQUEST(400, "MS-AI-PLAYGROUND-INVALID-REQUEST", "AI 플레이그라운드 요청이 올바르지 않습니다."),
+    MAIL_ACCOUNT_REQUIRED(403, "MS-AI-PLAYGROUND-MAIL-ACCOUNT-REQUIRED", "AI 플레이그라운드는 메일 계정을 등록한 사용자만 사용할 수 있습니다."),
+    CHAT_MODEL_NOT_AVAILABLE(503, "MS-AI-PLAYGROUND-CHAT-MODEL-NOT-AVAILABLE", "사용 가능한 AI 채팅 모델이 없습니다."),
+    PROVIDER_FAILURE(502, "MS-AI-PLAYGROUND-PROVIDER-FAILURE", "AI Provider 호출에 실패했습니다.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/core/src/main/java/com/mailsangja/core/common/exception/ai/AiPlaygroundException.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/ai/AiPlaygroundException.java
@@ -1,0 +1,14 @@
+package com.mailsangja.core.common.exception.ai;
+
+import com.mailsangja.core.common.exception.BaseException;
+
+public class AiPlaygroundException extends BaseException {
+
+    public AiPlaygroundException(AiPlaygroundErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AiPlaygroundException(AiPlaygroundErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/controller/AiController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/AiController.java
@@ -3,11 +3,15 @@ package com.mailsangja.core.controller;
 import com.mailsangja.core.common.auth.AuthUser;
 import com.mailsangja.core.controller.docs.AiControllerDocs;
 import com.mailsangja.core.dto.ai.AiModelListResponse;
+import com.mailsangja.core.dto.ai.AiPlaygroundChatRequest;
+import com.mailsangja.core.dto.ai.AiPlaygroundChatResponse;
 import com.mailsangja.core.facade.AiFacade;
 import com.mailsangja.db.entity.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -15,6 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class AiController implements AiControllerDocs {
 
     private final AiFacade aiFacade;
+
+    @Override
+    @PostMapping("/api/v1/ai/playground/chat")
+    public ResponseEntity<AiPlaygroundChatResponse> chat(
+            @AuthUser User user,
+            @RequestBody AiPlaygroundChatRequest request
+    ) {
+        return ResponseEntity.ok(aiFacade.chat(user, request));
+    }
 
     @Override
     @GetMapping("/api/v1/ai/models")

--- a/core/src/main/java/com/mailsangja/core/controller/docs/AiControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/AiControllerDocs.java
@@ -2,6 +2,8 @@ package com.mailsangja.core.controller.docs;
 
 import com.mailsangja.core.common.auth.AuthUser;
 import com.mailsangja.core.dto.ai.AiModelListResponse;
+import com.mailsangja.core.dto.ai.AiPlaygroundChatRequest;
+import com.mailsangja.core.dto.ai.AiPlaygroundChatResponse;
 import com.mailsangja.db.entity.user.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,6 +13,16 @@ import org.springframework.http.ResponseEntity;
 
 @Tag(name = "AI", description = "AI 기능 API")
 public interface AiControllerDocs {
+
+    @Operation(
+            summary = "AI 플레이그라운드 채팅 호출",
+            description = "프론트 실험용 LLM 호출 API입니다. messages, model, options, context를 프론트에서 직접 구성해 호출합니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    ResponseEntity<AiPlaygroundChatResponse> chat(
+            @Parameter(hidden = true) @AuthUser User user,
+            AiPlaygroundChatRequest request
+    );
 
     @Operation(
             summary = "AI 모델 목록 조회",

--- a/core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundChatRequest.java
+++ b/core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundChatRequest.java
@@ -1,0 +1,22 @@
+package com.mailsangja.core.dto.ai;
+
+import java.util.List;
+import java.util.Map;
+
+public record AiPlaygroundChatRequest(
+        String provider,
+        String model,
+        String systemPrompt,
+        String userPrompt,
+        List<AiPlaygroundMessageRequest> messages,
+        Map<String, Object> context,
+        AiPlaygroundOptionsRequest options,
+        Map<String, Object> metadata
+) {
+
+    public AiPlaygroundChatRequest {
+        messages = messages == null ? List.of() : List.copyOf(messages);
+        context = context == null ? Map.of() : Map.copyOf(context);
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundChatResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundChatResponse.java
@@ -1,0 +1,26 @@
+package com.mailsangja.core.dto.ai;
+
+import java.util.Map;
+
+public record AiPlaygroundChatResponse(
+        String provider,
+        String model,
+        String content,
+        AiPlaygroundUsageResponse usage,
+        Map<String, Object> raw
+) {
+
+    public AiPlaygroundChatResponse {
+        raw = raw == null ? Map.of() : Map.copyOf(raw);
+    }
+
+    public static AiPlaygroundChatResponse from(AiPlaygroundChatResult result) {
+        return new AiPlaygroundChatResponse(
+                result.provider(),
+                result.model(),
+                result.content(),
+                AiPlaygroundUsageResponse.from(result.usage()),
+                result.raw()
+        );
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundChatResult.java
+++ b/core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundChatResult.java
@@ -1,0 +1,16 @@
+package com.mailsangja.core.dto.ai;
+
+import java.util.Map;
+
+public record AiPlaygroundChatResult(
+        String provider,
+        String model,
+        String content,
+        AiPlaygroundUsageResult usage,
+        Map<String, Object> raw
+) {
+
+    public AiPlaygroundChatResult {
+        raw = raw == null ? Map.of() : Map.copyOf(raw);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundMessageRequest.java
+++ b/core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundMessageRequest.java
@@ -1,0 +1,7 @@
+package com.mailsangja.core.dto.ai;
+
+public record AiPlaygroundMessageRequest(
+        String role,
+        String content
+) {
+}

--- a/core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundOptionsRequest.java
+++ b/core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundOptionsRequest.java
@@ -1,0 +1,27 @@
+package com.mailsangja.core.dto.ai;
+
+import java.util.List;
+import java.util.Map;
+
+public record AiPlaygroundOptionsRequest(
+        Double temperature,
+        Integer maxOutputTokens,
+        Integer maxCompletionTokens,
+        Double topP,
+        Double presencePenalty,
+        Double frequencyPenalty,
+        String responseFormat,
+        String jsonSchema,
+        Integer seed,
+        List<String> stop,
+        String reasoningEffort,
+        String verbosity,
+        String serviceTier,
+        Map<String, Object> extraBody
+) {
+
+    public AiPlaygroundOptionsRequest {
+        stop = stop == null ? List.of() : List.copyOf(stop);
+        extraBody = extraBody == null ? Map.of() : Map.copyOf(extraBody);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundUsageResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundUsageResponse.java
@@ -1,0 +1,15 @@
+package com.mailsangja.core.dto.ai;
+
+public record AiPlaygroundUsageResponse(
+        Integer inputTokens,
+        Integer outputTokens,
+        Integer totalTokens
+) {
+
+    public static AiPlaygroundUsageResponse from(AiPlaygroundUsageResult result) {
+        if (result == null) {
+            return new AiPlaygroundUsageResponse(null, null, null);
+        }
+        return new AiPlaygroundUsageResponse(result.inputTokens(), result.outputTokens(), result.totalTokens());
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundUsageResult.java
+++ b/core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundUsageResult.java
@@ -1,0 +1,8 @@
+package com.mailsangja.core.dto.ai;
+
+public record AiPlaygroundUsageResult(
+        Integer inputTokens,
+        Integer outputTokens,
+        Integer totalTokens
+) {
+}

--- a/core/src/main/java/com/mailsangja/core/facade/AiFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/AiFacade.java
@@ -1,7 +1,14 @@
 package com.mailsangja.core.facade;
 
+import com.mailsangja.core.common.exception.ai.AiPlaygroundErrorCode;
+import com.mailsangja.core.common.exception.ai.AiPlaygroundException;
+import com.mailsangja.core.dto.ai.AiPlaygroundChatRequest;
+import com.mailsangja.core.dto.ai.AiPlaygroundChatResponse;
 import com.mailsangja.core.dto.ai.AiModelListResponse;
+import com.mailsangja.core.service.ai.AiPlaygroundCommandService;
 import com.mailsangja.core.service.ai.AiQueryService;
+import com.mailsangja.core.service.mail.MailAccountQueryService;
+import com.mailsangja.db.entity.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -9,9 +16,22 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AiFacade {
 
+    private final AiPlaygroundCommandService aiPlaygroundCommandService;
     private final AiQueryService aiQueryService;
+    private final MailAccountQueryService mailAccountQueryService;
+
+    public AiPlaygroundChatResponse chat(User user, AiPlaygroundChatRequest request) {
+        validateRegisteredMailAccount(user);
+        return AiPlaygroundChatResponse.from(aiPlaygroundCommandService.chat(request));
+    }
 
     public AiModelListResponse getModels() {
         return AiModelListResponse.from(aiQueryService.getModels());
+    }
+
+    private void validateRegisteredMailAccount(User user) {
+        if (mailAccountQueryService.findAllActiveByUserId(user.getId()).isEmpty()) {
+            throw new AiPlaygroundException(AiPlaygroundErrorCode.MAIL_ACCOUNT_REQUIRED);
+        }
     }
 }

--- a/core/src/main/java/com/mailsangja/core/service/ai/AiPlaygroundCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/ai/AiPlaygroundCommandService.java
@@ -1,0 +1,262 @@
+package com.mailsangja.core.service.ai;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mailsangja.core.common.exception.ai.AiPlaygroundErrorCode;
+import com.mailsangja.core.common.exception.ai.AiPlaygroundException;
+import com.mailsangja.core.dto.ai.AiPlaygroundChatRequest;
+import com.mailsangja.core.dto.ai.AiPlaygroundChatResult;
+import com.mailsangja.core.dto.ai.AiPlaygroundMessageRequest;
+import com.mailsangja.core.dto.ai.AiPlaygroundOptionsRequest;
+import com.mailsangja.core.dto.ai.AiPlaygroundUsageResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AiPlaygroundCommandService {
+
+    private final ObjectProvider<ChatModel> chatModelProvider;
+    private final ObjectMapper objectMapper;
+
+    public AiPlaygroundChatResult chat(AiPlaygroundChatRequest request) {
+        if (request == null) {
+            throw new AiPlaygroundException(AiPlaygroundErrorCode.INVALID_REQUEST);
+        }
+        Prompt prompt = createPrompt(request);
+        try {
+            ChatResponse response = chatModel().call(prompt);
+            return toResult(request, response);
+        } catch (AiPlaygroundException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            log.warn("AI playground provider call failed. provider={} model={}", request.provider(), request.model(), e);
+            throw new AiPlaygroundException(AiPlaygroundErrorCode.PROVIDER_FAILURE, providerFailureMessage(e));
+        }
+    }
+
+    private Prompt createPrompt(AiPlaygroundChatRequest request) {
+        return new Prompt(messagesOf(request), optionsOf(request));
+    }
+
+    private List<Message> messagesOf(AiPlaygroundChatRequest request) {
+        if (!request.messages().isEmpty()) {
+            return request.messages().stream()
+                    .map(this::messageOf)
+                    .toList();
+        }
+
+        List<Message> messages = new ArrayList<>();
+        if (hasText(request.systemPrompt())) {
+            messages.add(new SystemMessage(request.systemPrompt()));
+        }
+        if (!request.context().isEmpty() || hasText(request.userPrompt())) {
+            messages.add(new UserMessage(userPromptWithContext(request)));
+        }
+        if (messages.isEmpty()) {
+            throw new AiPlaygroundException(AiPlaygroundErrorCode.INVALID_REQUEST);
+        }
+        return messages;
+    }
+
+    private Message messageOf(AiPlaygroundMessageRequest request) {
+        if (request == null || !hasText(request.role()) || request.content() == null) {
+            throw new AiPlaygroundException(AiPlaygroundErrorCode.INVALID_REQUEST);
+        }
+
+        return switch (request.role().strip().toLowerCase(Locale.ROOT)) {
+            case "system" -> new SystemMessage(request.content());
+            case "developer" -> new SystemMessage(request.content());
+            case "assistant" -> new AssistantMessage(request.content());
+            case "user" -> new UserMessage(request.content());
+            default -> throw new AiPlaygroundException(AiPlaygroundErrorCode.INVALID_REQUEST);
+        };
+    }
+
+    private String userPromptWithContext(AiPlaygroundChatRequest request) {
+        if (request.context().isEmpty()) {
+            return safeText(request.userPrompt());
+        }
+        if (!hasText(request.userPrompt())) {
+            return contextJson(request.context());
+        }
+        return "Context:\n" + contextJson(request.context()) + "\n\nUser Prompt:\n" + request.userPrompt();
+    }
+
+    private String contextJson(Map<String, Object> context) {
+        try {
+            return objectMapper.writeValueAsString(context);
+        } catch (JsonProcessingException e) {
+            throw new AiPlaygroundException(AiPlaygroundErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    private OpenAiChatOptions optionsOf(AiPlaygroundChatRequest request) {
+        OpenAiChatOptions.Builder builder = OpenAiChatOptions.builder();
+        if (hasText(request.model())) {
+            builder.model(request.model().strip());
+        }
+
+        AiPlaygroundOptionsRequest options = request.options();
+        if (options == null) {
+            return builder.build();
+        }
+
+        builder.temperature(options.temperature())
+                .maxTokens(options.maxOutputTokens())
+                .maxCompletionTokens(options.maxCompletionTokens())
+                .topP(options.topP())
+                .presencePenalty(options.presencePenalty())
+                .frequencyPenalty(options.frequencyPenalty())
+                .seed(options.seed())
+                .stop(options.stop())
+                .reasoningEffort(options.reasoningEffort())
+                .verbosity(options.verbosity())
+                .serviceTier(options.serviceTier())
+                .extraBody(options.extraBody());
+
+        if (hasText(options.responseFormat())) {
+            builder.responseFormat(responseFormatOf(options));
+        }
+        return builder.build();
+    }
+
+    private OpenAiChatModel.ResponseFormat responseFormatOf(AiPlaygroundOptionsRequest options) {
+        OpenAiChatModel.ResponseFormat.Type type = switch (options.responseFormat().strip().toUpperCase(Locale.ROOT)) {
+            case "JSON", "JSON_OBJECT" -> OpenAiChatModel.ResponseFormat.Type.JSON_OBJECT;
+            case "JSON_SCHEMA" -> OpenAiChatModel.ResponseFormat.Type.JSON_SCHEMA;
+            case "TEXT" -> OpenAiChatModel.ResponseFormat.Type.TEXT;
+            default -> throw new AiPlaygroundException(AiPlaygroundErrorCode.INVALID_REQUEST);
+        };
+
+        return OpenAiChatModel.ResponseFormat.builder()
+                .type(type)
+                .jsonSchema(options.jsonSchema())
+                .build();
+    }
+
+    private AiPlaygroundChatResult toResult(AiPlaygroundChatRequest request, ChatResponse response) {
+        ChatResponseMetadata metadata = metadataOf(response);
+        Usage usage = usageOf(metadata);
+        return new AiPlaygroundChatResult(
+                request.provider(),
+                modelOf(request, metadata),
+                textOf(response),
+                new AiPlaygroundUsageResult(promptTokens(usage), completionTokens(usage), totalTokens(usage)),
+                rawOf(metadata)
+        );
+    }
+
+    private ChatModel chatModel() {
+        ChatModel chatModel = chatModelProvider.getIfAvailable();
+        if (chatModel == null) {
+            throw new AiPlaygroundException(AiPlaygroundErrorCode.CHAT_MODEL_NOT_AVAILABLE);
+        }
+        return chatModel;
+    }
+
+    private String textOf(ChatResponse response) {
+        if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
+            return "";
+        }
+        return safeText(response.getResult().getOutput().getText());
+    }
+
+    private ChatResponseMetadata metadataOf(ChatResponse response) {
+        if (response == null) {
+            return ChatResponseMetadata.builder().build();
+        }
+        return response.getMetadata();
+    }
+
+    private Usage usageOf(ChatResponseMetadata metadata) {
+        if (metadata == null) {
+            return null;
+        }
+        return metadata.getUsage();
+    }
+
+    private String modelOf(AiPlaygroundChatRequest request, ChatResponseMetadata metadata) {
+        if (metadata != null && hasText(metadata.getModel())) {
+            return metadata.getModel();
+        }
+        return request.model();
+    }
+
+    private Map<String, Object> rawOf(ChatResponseMetadata metadata) {
+        Map<String, Object> raw = new LinkedHashMap<>();
+        if (metadata == null) {
+            return raw;
+        }
+        raw.put("model", metadata.getModel());
+        raw.put("usage", usageMap(usageOf(metadata)));
+        return raw;
+    }
+
+    private Map<String, Object> usageMap(Usage usage) {
+        Map<String, Object> rawUsage = new LinkedHashMap<>();
+        if (usage == null) {
+            return rawUsage;
+        }
+        rawUsage.put("inputTokens", promptTokens(usage));
+        rawUsage.put("outputTokens", completionTokens(usage));
+        rawUsage.put("totalTokens", totalTokens(usage));
+        return rawUsage;
+    }
+
+    private Integer promptTokens(Usage usage) {
+        if (usage == null) {
+            return null;
+        }
+        return usage.getPromptTokens();
+    }
+
+    private Integer completionTokens(Usage usage) {
+        if (usage == null) {
+            return null;
+        }
+        return usage.getCompletionTokens();
+    }
+
+    private Integer totalTokens(Usage usage) {
+        if (usage == null) {
+            return null;
+        }
+        return usage.getTotalTokens();
+    }
+
+    private String providerFailureMessage(RuntimeException e) {
+        if (hasText(e.getMessage())) {
+            return e.getMessage();
+        }
+        return AiPlaygroundErrorCode.PROVIDER_FAILURE.getMessage();
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private String safeText(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/core/src/test/java/com/mailsangja/core/facade/AiFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/AiFacadeTest.java
@@ -1,14 +1,29 @@
 package com.mailsangja.core.facade;
 
+import com.mailsangja.core.common.exception.ai.AiPlaygroundErrorCode;
+import com.mailsangja.core.common.exception.ai.AiPlaygroundException;
 import com.mailsangja.core.dto.ai.AiModelListResult;
 import com.mailsangja.core.dto.ai.AiModelListResponse;
+import com.mailsangja.core.dto.ai.AiPlaygroundChatRequest;
+import com.mailsangja.core.dto.ai.AiPlaygroundChatResponse;
+import com.mailsangja.core.dto.ai.AiPlaygroundChatResult;
+import com.mailsangja.core.dto.ai.AiPlaygroundUsageResult;
+import com.mailsangja.core.service.ai.AiPlaygroundCommandService;
 import com.mailsangja.core.service.ai.AiQueryService;
+import com.mailsangja.core.service.mail.MailAccountQueryService;
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.user.User;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class AiFacadeTest {
@@ -17,7 +32,11 @@ class AiFacadeTest {
     void getModels_ResponseDto로조립한다() {
         // given
         AiQueryService queryService = mock(AiQueryService.class);
-        AiFacade facade = new AiFacade(queryService);
+        AiFacade facade = new AiFacade(
+                mock(AiPlaygroundCommandService.class),
+                queryService,
+                mock(MailAccountQueryService.class)
+        );
         when(queryService.getModels()).thenReturn(AiModelListResult.of(
                 "google/gemini-3.5-flash",
                 List.of("google/gemini-3.5-flash", "openai/gpt-5.5")
@@ -31,5 +50,82 @@ class AiFacadeTest {
         assertEquals(2, response.models().size());
         assertEquals("google/gemini-3.5-flash", response.models().getFirst().id());
         assertEquals(true, response.models().getFirst().defaultModel());
+    }
+
+    @Test
+    void chat_활성메일계정이있으면_Playground응답을ResponseDto로조립한다() {
+        // given
+        User user = createUser();
+        AiPlaygroundChatRequest request = createChatRequest();
+        AiPlaygroundCommandService playgroundCommandService = mock(AiPlaygroundCommandService.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        AiFacade facade = new AiFacade(playgroundCommandService, mock(AiQueryService.class), mailAccountQueryService);
+
+        when(mailAccountQueryService.findAllActiveByUserId(user.getId()))
+                .thenReturn(List.of(mock(MailAccount.class)));
+        when(playgroundCommandService.chat(request))
+                .thenReturn(new AiPlaygroundChatResult(
+                        "OPENROUTER",
+                        "google/gemini-3.5-flash",
+                        "content",
+                        new AiPlaygroundUsageResult(10, 20, 30),
+                        Map.of("model", "google/gemini-3.5-flash")
+                ));
+
+        // when
+        AiPlaygroundChatResponse response = facade.chat(user, request);
+
+        // then
+        assertEquals("OPENROUTER", response.provider());
+        assertEquals("google/gemini-3.5-flash", response.model());
+        assertEquals("content", response.content());
+        assertEquals(10, response.usage().inputTokens());
+        assertEquals(20, response.usage().outputTokens());
+        assertEquals(30, response.usage().totalTokens());
+        verify(playgroundCommandService).chat(request);
+    }
+
+    @Test
+    void chat_활성메일계정이없으면_예외를던지고_LLM을호출하지않는다() {
+        // given
+        User user = createUser();
+        AiPlaygroundChatRequest request = createChatRequest();
+        AiPlaygroundCommandService playgroundCommandService = mock(AiPlaygroundCommandService.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        AiFacade facade = new AiFacade(playgroundCommandService, mock(AiQueryService.class), mailAccountQueryService);
+
+        when(mailAccountQueryService.findAllActiveByUserId(user.getId())).thenReturn(List.of());
+
+        // when
+        AiPlaygroundException exception = assertThrows(
+                AiPlaygroundException.class,
+                () -> facade.chat(user, request)
+        );
+
+        // then
+        assertEquals(AiPlaygroundErrorCode.MAIL_ACCOUNT_REQUIRED, exception.getErrorCode());
+        verify(playgroundCommandService, never()).chat(request);
+    }
+
+    private AiPlaygroundChatRequest createChatRequest() {
+        return new AiPlaygroundChatRequest(
+                "OPENROUTER",
+                "google/gemini-3.5-flash",
+                null,
+                "메일을 작성해줘.",
+                List.of(),
+                Map.of(),
+                null,
+                Map.of()
+        );
+    }
+
+    private User createUser() {
+        return User.builder()
+                .id(UUID.randomUUID())
+                .name("테스트 사용자")
+                .username("tester@example.com")
+                .password("encoded")
+                .build();
     }
 }


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#24

### 📌 Task
- Closes #125


## 💡 작업 내용

- 프론트에서 LLM 프롬프트와 옵션을 직접 구성해 호출할 수 있는 실험용 API를 추가했습니다.
- API Key는 서버 환경 변수와 Spring AI 설정을 사용하고, 프론트는 `model`, `messages`, `context`, `options`를 직접 전달합니다.
- 기존 공용 AI 설정과 OpenRouter 호환 ChatModel 구성을 재사용합니다.
- 최소 인증 정책으로 로그인 사용자 중 활성 메일 계정을 하나 이상 등록한 사용자만 호출할 수 있도록 제한했습니다.
- 요청/응답 DTO는 모두 `record`로 작성하고, Controller -> Facade -> CommandService 흐름을 따릅니다.


## 📝 추가 설명

### 1. API 개요

| 항목 | 값 |
| --- | --- |
| API | `POST /api/v1/ai/playground/chat` |
| 목적 | 프론트 실험용 범용 LLM 채팅 호출 |
| 인증 | 로그인 쿠키 필요 |
| 추가 권한 | 활성 메일 계정 1개 이상 필요 |
| Controller | `AiController` |
| Facade | `AiFacade` |
| Service | `AiPlaygroundCommandService` |
| Request DTO | `AiPlaygroundChatRequest` |
| Response DTO | `AiPlaygroundChatResponse` |

이 API는 운영용 고수준 AI 기능이 아니라 프론트에서 프롬프트, 컨텍스트, 모델 옵션을 빠르게 실험하기 위한 playground API입니다.

따라서 서버는 다음을 하지 않습니다.

- 시스템 프롬프트 템플릿 강제
- useCase enum 강제
- 모델 allowlist 검증
- temperature, token 값 clamp
- 서버 주도 RAG 컨텍스트 삽입
- 서버 주도 메일 본문 조회
- 대화 기록 저장
- tool calling 도구 등록

서버가 담당하는 최소 책임은 다음입니다.

- 로그인 사용자 확인
- 활성 메일 계정 등록 여부 확인
- 서버에 설정된 LLM API Key 사용
- Spring AI `ChatModel` 호출
- provider 호출 실패를 서비스 예외로 변환
- 응답 content와 usage 반환

### 2. 인증 및 접근 조건

요청에는 기존 서비스 로그인 쿠키가 필요합니다.

추가로 `AiFacade`에서 다음 조건을 확인합니다.

```java
mailAccountQueryService.findAllActiveByUserId(user.getId()).isEmpty()
```

즉, 현재 사용자가 활성 메일 계정을 하나 이상 가지고 있어야 합니다.

| 상태 | 호출 가능 여부 | 설명 |
| --- | --- | --- |
| 비로그인 | 불가 | `@AuthUser`에서 인증 실패 |
| 로그인 + 활성 메일 계정 없음 | 불가 | `MS-AI-PLAYGROUND-MAIL-ACCOUNT-REQUIRED` |
| 로그인 + 활성 메일 계정 1개 이상 | 가능 | LLM 호출 진행 |

활성 메일 계정이 없을 때 응답 예시는 다음과 같습니다.

```json
{
  "status": 403,
  "code": "MS-AI-PLAYGROUND-MAIL-ACCOUNT-REQUIRED",
  "message": "AI 플레이그라운드는 메일 계정을 등록한 사용자만 사용할 수 있습니다."
}
```

### 3. 전체 호출 흐름

```mermaid
sequenceDiagram
    participant FE as Frontend
    participant Controller as AiController
    participant Facade as AiFacade
    participant MailAccount as MailAccountQueryService
    participant Playground as AiPlaygroundCommandService
    participant LLM as Spring AI ChatModel

    FE->>Controller: POST /api/v1/ai/playground/chat
    Controller->>Facade: @AuthUser User + AiPlaygroundChatRequest
    Facade->>MailAccount: findAllActiveByUserId(user.id)
    alt 활성 메일 계정 없음
        Facade-->>FE: 403 MS-AI-PLAYGROUND-MAIL-ACCOUNT-REQUIRED
    else 활성 메일 계정 있음
        Facade->>Playground: chat(request)
        Playground->>Playground: messages 또는 systemPrompt/userPrompt/context로 Prompt 생성
        Playground->>LLM: ChatModel.call(prompt)
        LLM-->>Playground: ChatResponse
        Playground-->>Facade: AiPlaygroundChatResult
        Facade-->>Controller: AiPlaygroundChatResponse
        Controller-->>FE: 200 OK
    end
```

### 4. Request 전체 구조

```json
{
  "provider": "OPENAI",
  "model": "openai/gpt-4.1-mini",
  "systemPrompt": "너는 메일 작성 도우미야.",
  "userPrompt": "거래처에 일정 변경 메일을 정중하게 작성해줘.",
  "messages": [
    {
      "role": "system",
      "content": "너는 메일 작성 도우미야."
    },
    {
      "role": "user",
      "content": "거래처에 일정 변경 메일을 정중하게 작성해줘."
    }
  ],
  "context": {
    "selectedText": "기존 메일 일부",
    "draftText": "작성 중인 초안",
    "tone": "polite",
    "language": "ko"
  },
  "options": {
    "temperature": 0.7,
    "maxOutputTokens": 2000,
    "maxCompletionTokens": null,
    "topP": 1.0,
    "presencePenalty": 0.0,
    "frequencyPenalty": 0.0,
    "responseFormat": "TEXT",
    "jsonSchema": null,
    "seed": null,
    "stop": [],
    "reasoningEffort": "medium",
    "verbosity": "medium",
    "serviceTier": "auto",
    "extraBody": {}
  },
  "metadata": {
    "experimentName": "reply-v1",
    "clientRequestId": "client-generated-id"
  }
}
```

### 5. Request 필드 상세

#### 5.1 최상위 필드

| 필드 | 타입 | 필수 | 프론트 입력 기준 | 서버 동작 |
| --- | --- | --- | --- | --- |
| `provider` | `string` | 선택 | `"OPENAI"`, `"OPENROUTER"` 등 실험 구분값 | 현재는 실제 provider 선택에 사용하지 않고 응답에 그대로 반영 |
| `model` | `string` | 선택 | OpenRouter 모델 ID 또는 현재 ChatModel이 이해하는 모델명 | `OpenAiChatOptions.model`에 전달 |
| `systemPrompt` | `string` | 조건부 | `messages`를 쓰지 않을 때 system message로 사용할 내용 | `messages`가 비어 있을 때만 사용 |
| `userPrompt` | `string` | 조건부 | `messages`를 쓰지 않을 때 user message로 사용할 내용 | `messages`가 비어 있을 때만 사용 |
| `messages` | `AiPlaygroundMessageRequest[]` | 조건부 | provider-native에 가까운 대화 메시지 배열 | 값이 있으면 `systemPrompt`, `userPrompt`, `context`보다 우선 |
| `context` | `object` | 선택 | 프론트가 LLM에 같이 넘기고 싶은 자유 JSON | `messages`가 비어 있을 때 user message 앞에 JSON 문자열로 붙임 |
| `options` | `AiPlaygroundOptionsRequest` | 선택 | 모델 생성 옵션 | Spring AI `OpenAiChatOptions`로 변환 |
| `metadata` | `object` | 선택 | 프론트 추적용 실험 정보 | 현재 LLM 호출에는 사용하지 않음 |

필수 조건은 다음 중 하나입니다.

1. `messages`에 하나 이상의 메시지가 있다.
2. `messages`가 비어 있고, `systemPrompt`, `userPrompt`, `context` 중 하나 이상이 있다.

위 조건을 만족하지 않으면 `MS-AI-PLAYGROUND-INVALID-REQUEST`가 발생합니다.

#### 5.2 `provider`

현재 구현에서 `provider`는 실제 provider 라우팅 필드가 아닙니다.

실제 LLM provider는 애플리케이션 설정을 따릅니다.

```yaml
spring:
  ai:
    model:
      chat: ${AI_CHAT_PROVIDER:openai}
    openai:
      chat:
        api-key: ${OPENROUTER_API_KEY:${OPENAI_API_KEY}}
        base-url: ${OPENROUTER_BASE_URL:https://openrouter.ai/api/v1}
```

프론트에서는 다음 용도로만 사용하면 됩니다.

- 어떤 provider를 의도했는지 실험 로그에 남기기
- 응답에서 요청 provider 값을 다시 확인하기
- 추후 provider 라우팅 기능이 생겼을 때를 대비한 UI 필드 유지

권장 값:

```json
{
  "provider": "OPENROUTER"
}
```

#### 5.3 `model`

`model`은 프론트가 직접 지정할 수 있습니다.

예시:

```json
{
  "model": "google/gemini-3.5-flash"
}
```

또는:

```json
{
  "model": "openai/gpt-4.1-mini"
}
```

주의사항:

- 이 playground API에서는 `GET /api/v1/ai/models`의 allowed model 목록으로 제한하지 않습니다.
- 존재하지 않거나 provider가 지원하지 않는 모델을 넣으면 provider 호출 단계에서 실패합니다.
- 실패 시 `MS-AI-PLAYGROUND-PROVIDER-FAILURE`가 반환될 수 있습니다.
- `model`을 생략하면 Spring AI 설정의 기본 모델이 사용됩니다.

프론트 권장 UX:

- 기본 선택값은 `GET /api/v1/ai/models`의 `defaultModel`을 사용합니다.
- 사용자가 직접 모델 ID를 입력할 수 있는 input도 열어둡니다.
- 실험용이므로 목록 밖 모델 입력을 막지 않습니다.

#### 5.4 `messages`

가장 권장하는 입력 방식입니다.

```json
{
  "messages": [
    {
      "role": "system",
      "content": "너는 메일 작성 도우미야."
    },
    {
      "role": "user",
      "content": "아래 내용을 정중한 메일로 바꿔줘.\n\n내일 회의 못 감"
    }
  ]
}
```

지원 role:

| role | 서버 변환 | 사용 용도 |
| --- | --- | --- |
| `system` | `SystemMessage` | 전체 지시, 역할, 출력 형식 |
| `developer` | `SystemMessage` | OpenAI developer message처럼 쓰고 싶을 때. 서버에서는 system과 동일 처리 |
| `user` | `UserMessage` | 사용자 요청, 메일 컨텍스트, 질문 |
| `assistant` | `AssistantMessage` | 이전 LLM 답변, few-shot 예시 |

각 message의 규칙:

- `role`은 필수입니다.
- `content`는 필수입니다.
- `content`는 빈 문자열도 허용됩니다.
- 알 수 없는 role이면 `MS-AI-PLAYGROUND-INVALID-REQUEST`가 발생합니다.

`messages`가 하나라도 있으면 서버는 아래 필드를 LLM prompt 생성에 사용하지 않습니다.

- `systemPrompt`
- `userPrompt`
- `context`

즉, `messages`를 사용할 때는 필요한 컨텍스트를 `messages[].content` 안에 직접 넣어야 합니다.

예시:

```json
{
  "messages": [
    {
      "role": "system",
      "content": "너는 한국어 비즈니스 메일 작성 도우미야. 결과는 JSON으로만 반환해."
    },
    {
      "role": "user",
      "content": "Context:\n{\"recipient\":\"교수님\",\"tone\":\"polite\"}\n\nUser Prompt:\n회의 일정을 다음 주로 미루는 메일을 작성해줘."
    }
  ],
  "options": {
    "responseFormat": "JSON_OBJECT"
  }
}
```

#### 5.5 `systemPrompt`, `userPrompt`, `context`

간단한 호출에는 `messages` 대신 이 세 필드를 사용할 수 있습니다.

```json
{
  "systemPrompt": "너는 한국어 비즈니스 메일 작성 도우미야.",
  "userPrompt": "일정 변경 요청 메일을 작성해줘.",
  "context": {
    "recipient": "거래처 담당자",
    "reason": "내부 일정 충돌",
    "newDate": "다음 주 화요일 오후 2시"
  }
}
```

서버는 위 요청을 내부적으로 다음과 비슷한 user message로 만듭니다.

```text
Context:
{"recipient":"거래처 담당자","reason":"내부 일정 충돌","newDate":"다음 주 화요일 오후 2시"}

User Prompt:
일정 변경 요청 메일을 작성해줘.
```

조립 규칙:

| 입력 상태 | 생성되는 메시지 |
| --- | --- |
| `systemPrompt` 있음 | `SystemMessage(systemPrompt)` 추가 |
| `context` 없음 + `userPrompt` 있음 | `UserMessage(userPrompt)` 추가 |
| `context` 있음 + `userPrompt` 없음 | `UserMessage(context JSON)` 추가 |
| `context` 있음 + `userPrompt` 있음 | `UserMessage("Context:\n{...}\n\nUser Prompt:\n...")` 추가 |

프론트 권장 기준:

- 프롬프트 에디터가 `system`, `user`, `assistant` 메시지를 직접 편집하는 구조라면 `messages`를 사용합니다.
- 간단한 메일 작성 버튼이나 폼 기반 UX라면 `systemPrompt`, `userPrompt`, `context`를 사용합니다.
- `messages`와 `systemPrompt/userPrompt/context`를 동시에 보내도 되지만, `messages`가 우선이라 나머지는 무시됩니다.

#### 5.6 `context`

`context`는 자유 JSON입니다. 서버는 필드명을 해석하지 않습니다.

프론트에서 넣기 좋은 값:

| 필드 예시 | 타입 | 의미 |
| --- | --- | --- |
| `selectedText` | `string` | 사용자가 에디터 또는 메일 본문에서 선택한 텍스트 |
| `draftText` | `string` | 현재 작성 중인 초안 |
| `subject` | `string` | 현재 메일 제목 |
| `threadSummary` | `string` | 프론트가 요약한 스레드 맥락 |
| `latestMail` | `object` | 답장 대상 메일 정보 |
| `recipients` | `array` | 수신자 목록 |
| `tone` | `string` | 원하는 어투 |
| `language` | `string` | 출력 언어 |
| `constraints` | `array` | 길이, 형식, 금지사항 |
| `outputSchemaHint` | `object` | 프론트가 기대하는 응답 구조 설명 |

예시:

```json
{
  "context": {
    "selectedText": "내일 회의 못 갑니다.",
    "draftText": "",
    "subject": "",
    "recipients": [
      {
        "name": "김민수",
        "email": "minsu@example.com",
        "relationship": "거래처 담당자"
      }
    ],
    "tone": "polite",
    "language": "ko",
    "constraints": [
      "제목과 본문을 모두 작성",
      "사과 표현 포함",
      "대체 일정 제안"
    ]
  }
}
```

주의사항:

- 서버는 `context.mailId`, `context.threadId`를 보고 DB에서 메일을 조회하지 않습니다.
- 메일 본문이 필요하면 프론트가 직접 `context` 또는 `messages`에 넣어야 합니다.
- 민감 정보 마스킹도 이 API에서는 서버가 수행하지 않습니다.
- 너무 큰 `context`를 보내면 provider token limit에 걸릴 수 있습니다.

### 6. Options 필드 상세

`options`는 Spring AI `OpenAiChatOptions`로 변환됩니다.

```json
{
  "options": {
    "temperature": 0.7,
    "maxOutputTokens": 2000,
    "maxCompletionTokens": null,
    "topP": 1.0,
    "presencePenalty": 0.0,
    "frequencyPenalty": 0.0,
    "responseFormat": "TEXT",
    "jsonSchema": null,
    "seed": null,
    "stop": [],
    "reasoningEffort": "medium",
    "verbosity": "medium",
    "serviceTier": "auto",
    "extraBody": {}
  }
}
```

| 필드 | 타입 | 필수 | 전달 위치 | 프론트 입력 기준 |
| --- | --- | --- | --- | --- |
| `temperature` | `number` | 선택 | `OpenAiChatOptions.temperature` | 낮을수록 안정적, 높을수록 다양함 |
| `maxOutputTokens` | `integer` | 선택 | `OpenAiChatOptions.maxTokens` | 일반적인 최대 출력 토큰 |
| `maxCompletionTokens` | `integer` | 선택 | `OpenAiChatOptions.maxCompletionTokens` | reasoning 계열 모델에서 completion 상한을 별도로 줄 때 사용 |
| `topP` | `number` | 선택 | `OpenAiChatOptions.topP` | nucleus sampling 값 |
| `presencePenalty` | `number` | 선택 | `OpenAiChatOptions.presencePenalty` | 새 주제 등장 유도 |
| `frequencyPenalty` | `number` | 선택 | `OpenAiChatOptions.frequencyPenalty` | 반복 표현 억제 |
| `responseFormat` | `string` | 선택 | `OpenAiChatOptions.responseFormat` | `TEXT`, `JSON_OBJECT`, `JSON_SCHEMA`, `JSON` |
| `jsonSchema` | `string` | 선택 | `ResponseFormat.jsonSchema` | `responseFormat=JSON_SCHEMA`일 때 사용 |
| `seed` | `integer` | 선택 | `OpenAiChatOptions.seed` | 재현성 실험용 |
| `stop` | `string[]` | 선택 | `OpenAiChatOptions.stop` | 생성 중단 문자열 목록 |
| `reasoningEffort` | `string` | 선택 | `OpenAiChatOptions.reasoningEffort` | reasoning 모델용 |
| `verbosity` | `string` | 선택 | `OpenAiChatOptions.verbosity` | verbosity 지원 모델용 |
| `serviceTier` | `string` | 선택 | `OpenAiChatOptions.serviceTier` | provider service tier |
| `extraBody` | `object` | 선택 | `OpenAiChatOptions.extraBody` | provider-specific 추가 body |

#### 6.1 `temperature`

권장값:

| 목적 | 값 |
| --- | --- |
| JSON 구조 안정성 | `0.0` ~ `0.3` |
| 일반 메일 작성 | `0.3` ~ `0.7` |
| 문체 실험 | `0.7` ~ `1.0` |

이 API에서는 서버가 값을 제한하지 않습니다. provider가 허용하지 않는 값이면 provider 오류가 납니다.

#### 6.2 `maxOutputTokens`와 `maxCompletionTokens`

일반적으로는 `maxOutputTokens`만 사용하면 됩니다.

```json
{
  "options": {
    "maxOutputTokens": 1200
  }
}
```

reasoning 계열 모델에서 provider가 `max_completion_tokens`를 요구하거나 별도 제어가 필요하면 `maxCompletionTokens`를 사용합니다.

```json
{
  "options": {
    "maxCompletionTokens": 2000
  }
}
```

둘 다 넣을 수 있지만 provider별 처리 방식이 다를 수 있으므로, 프론트 실험 UI에서는 둘을 별도 입력으로 노출하고 실제 동작을 비교할 수 있게 두는 것이 좋습니다.

#### 6.3 `responseFormat`

지원 값:

| 값 | 의미 |
| --- | --- |
| `TEXT` | 일반 텍스트 응답 |
| `JSON_OBJECT` | JSON object 응답 유도 |
| `JSON` | `JSON_OBJECT`와 동일 처리 |
| `JSON_SCHEMA` | JSON Schema 기반 구조화 응답 |

텍스트 응답 예시:

```json
{
  "options": {
    "responseFormat": "TEXT"
  }
}
```

JSON object 응답 예시:

```json
{
  "messages": [
    {
      "role": "system",
      "content": "Return JSON only. Shape: {\"subject\":\"...\",\"body\":\"...\"}"
    },
    {
      "role": "user",
      "content": "거래처에 일정 변경 메일을 작성해줘."
    }
  ],
  "options": {
    "responseFormat": "JSON_OBJECT",
    "temperature": 0.2
  }
}
```

JSON Schema 응답 예시:

```json
{
  "messages": [
    {
      "role": "system",
      "content": "Return a valid mail draft object."
    },
    {
      "role": "user",
      "content": "교수님께 면담 일정 변경 요청 메일을 작성해줘."
    }
  ],
  "options": {
    "responseFormat": "JSON_SCHEMA",
    "jsonSchema": "{\"type\":\"object\",\"properties\":{\"subject\":{\"type\":\"string\"},\"body\":{\"type\":\"string\"}},\"required\":[\"subject\",\"body\"],\"additionalProperties\":false}"
  }
}
```

주의사항:

- `jsonSchema`는 문자열로 보내야 합니다.
- provider가 JSON schema를 지원하지 않으면 provider 오류가 발생할 수 있습니다.
- JSON 안정성을 높이려면 `temperature`를 낮게 설정하는 것이 좋습니다.

#### 6.4 `reasoningEffort`, `verbosity`, `serviceTier`

이 값들은 모든 provider와 모델에서 지원되는 값이 아닙니다.

프론트에서는 다음처럼 자유 입력 또는 select로 열어둘 수 있습니다.

```json
{
  "options": {
    "reasoningEffort": "medium",
    "verbosity": "medium",
    "serviceTier": "auto"
  }
}
```

권장 UI:

| 필드 | 추천 기본값 | 입력 방식 |
| --- | --- | --- |
| `reasoningEffort` | 빈 값 또는 `medium` | text/select |
| `verbosity` | 빈 값 또는 `medium` | text/select |
| `serviceTier` | 빈 값 또는 `auto` | text/select |

provider가 지원하지 않으면 요청이 실패할 수 있으므로, 실험 UI에서는 오류 메시지를 그대로 보여주는 것이 좋습니다.

#### 6.5 `extraBody`

`extraBody`는 OpenAI 호환 API에 추가 body를 전달하기 위한 자유 객체입니다.

예시:

```json
{
  "options": {
    "extraBody": {
      "provider": {
        "order": ["Google", "OpenAI"]
      }
    }
  }
}
```

주의사항:

- 서버는 `extraBody`의 의미를 해석하지 않습니다.
- provider가 허용하지 않는 key를 넣으면 provider 오류가 발생할 수 있습니다.
- API key, 토큰, 비밀값은 넣지 않습니다.

### 7. Response 구조

```json
{
  "provider": "OPENROUTER",
  "model": "google/gemini-3.5-flash",
  "content": "안녕하세요...\n\n회의 일정 변경 요청드립니다...",
  "usage": {
    "inputTokens": 123,
    "outputTokens": 456,
    "totalTokens": 579
  },
  "raw": {
    "model": "google/gemini-3.5-flash",
    "usage": {
      "inputTokens": 123,
      "outputTokens": 456,
      "totalTokens": 579
    }
  }
}
```

| 필드 | 타입 | 설명 |
| --- | --- | --- |
| `provider` | `string` | 요청의 `provider` 값을 그대로 반환 |
| `model` | `string` | provider metadata의 모델명. 없으면 요청 `model` |
| `content` | `string` | LLM이 생성한 텍스트 |
| `usage.inputTokens` | `integer/null` | 입력 토큰 수 |
| `usage.outputTokens` | `integer/null` | 출력 토큰 수 |
| `usage.totalTokens` | `integer/null` | 총 토큰 수 |
| `raw` | `object` | 현재는 model, usage 중심의 원시 메타데이터 |

주의사항:

- `content`가 JSON 문자열일 수 있습니다. `responseFormat=JSON_OBJECT`여도 응답 DTO의 `content` 타입은 string입니다.
- 프론트에서 JSON이 필요하면 `JSON.parse(response.content)`를 수행해야 합니다.
- provider가 usage를 주지 않으면 usage 값은 `null`일 수 있습니다.

### 8. 프론트 구현 가이드

#### 8.1 기본 호출 예시

```ts
const response = await fetch("/api/v1/ai/playground/chat", {
  method: "POST",
  headers: {
    "Content-Type": "application/json"
  },
  credentials: "include",
  body: JSON.stringify({
    provider: "OPENROUTER",
    model: "google/gemini-3.5-flash",
    messages: [
      {
        role: "system",
        content: "너는 한국어 비즈니스 메일 작성 도우미야."
      },
      {
        role: "user",
        content: "거래처에 일정 변경 요청 메일을 작성해줘."
      }
    ],
    options: {
      temperature: 0.4,
      maxOutputTokens: 1200,
      responseFormat: "TEXT"
    },
    metadata: {
      experimentName: "mail-draft-basic"
    }
  })
});

const data = await response.json();
```

#### 8.2 메일 초안 JSON 응답 예시

프론트가 제목과 본문을 분리해서 쓰고 싶으면 JSON 응답을 요청합니다.

```json
{
  "provider": "OPENROUTER",
  "model": "google/gemini-3.5-flash",
  "messages": [
    {
      "role": "system",
      "content": "너는 한국어 비즈니스 메일 작성 도우미야. 반드시 JSON만 반환해. 형식은 {\"subject\":\"string\",\"body\":\"string\"}이야."
    },
    {
      "role": "user",
      "content": "다음 조건으로 메일을 작성해줘.\n- 대상: 거래처 담당자\n- 목적: 회의 일정 변경\n- 사유: 내부 일정 충돌\n- 대체 일정: 다음 주 화요일 오후 2시"
    }
  ],
  "options": {
    "temperature": 0.2,
    "maxOutputTokens": 1000,
    "responseFormat": "JSON_OBJECT"
  },
  "metadata": {
    "experimentName": "draft-json-v1"
  }
}
```

프론트 처리:

```ts
const result = await response.json();
const draft = JSON.parse(result.content);

setSubject(draft.subject);
setBody(draft.body);
```

#### 8.3 답장 추천 3개 생성 예시

```json
{
  "provider": "OPENROUTER",
  "model": "openai/gpt-4.1-mini",
  "messages": [
    {
      "role": "system",
      "content": "너는 메일 답장 추천 엔진이야. 반드시 JSON만 반환해. 형식은 {\"replies\":[{\"label\":\"string\",\"body\":\"string\"}]}이고 replies는 2개 이상 3개 이하야."
    },
    {
      "role": "user",
      "content": "Context:\n{\"latestMail\":{\"from\":\"client@example.com\",\"subject\":\"견적 문의\",\"body\":\"견적서를 오늘 중 받을 수 있을까요?\"},\"tone\":\"polite\",\"language\":\"ko\"}\n\nUser Prompt:\n사용자가 선택할 수 있는 답장 후보를 만들어줘."
    }
  ],
  "options": {
    "temperature": 0.5,
    "maxOutputTokens": 1600,
    "responseFormat": "JSON_OBJECT"
  },
  "metadata": {
    "experimentName": "reply-options-v1"
  }
}
```

#### 8.4 `messages` 대신 `context`를 쓰는 예시

```json
{
  "provider": "OPENROUTER",
  "model": "google/gemini-3.5-flash",
  "systemPrompt": "너는 한국어 메일 문장 개선 도우미야.",
  "userPrompt": "selectedText를 더 정중하고 자연스럽게 바꿔줘.",
  "context": {
    "selectedText": "내일까지 주세요.",
    "tone": "polite",
    "language": "ko",
    "constraints": [
      "한 문장으로 유지",
      "너무 과하게 사과하지 않기"
    ]
  },
  "options": {
    "temperature": 0.3,
    "maxOutputTokens": 300
  },
  "metadata": {
    "experimentName": "rewrite-selected-text-v1"
  }
}
```

### 9. 에러 응답

| 상황 | HTTP Status | code | 원인 |
| --- | ---: | --- | --- |
| 인증 없음 | 401 | 인증 공통 에러 | 로그인 쿠키 없음 |
| 활성 메일 계정 없음 | 403 | `MS-AI-PLAYGROUND-MAIL-ACCOUNT-REQUIRED` | 메일 계정 등록 필요 |
| 요청 형식 오류 | 400 | `MS-AI-PLAYGROUND-INVALID-REQUEST` | 메시지 없음, role 오류, responseFormat 오류 등 |
| ChatModel 없음 | 503 | `MS-AI-PLAYGROUND-CHAT-MODEL-NOT-AVAILABLE` | Spring AI ChatModel bean 미생성 |
| Provider 호출 실패 | 502 | `MS-AI-PLAYGROUND-PROVIDER-FAILURE` | 모델명 오류, provider 오류, 옵션 미지원 등 |

프론트 처리 권장:

- 401: 로그인 화면 또는 재로그인 유도
- 403 + `MS-AI-PLAYGROUND-MAIL-ACCOUNT-REQUIRED`: 메일 계정 연동 화면으로 안내
- 400: 요청 JSON 또는 UI 입력값 확인
- 502: provider 응답 메시지를 실험 패널에 표시
- 503: 서버 설정 문제로 표시

### 10. 프론트 입력 폼 권장 구성

| UI 영역 | 필드 | 기본값 |
| --- | --- | --- |
| Provider | `provider` | `OPENROUTER` |
| Model | `model` | `GET /api/v1/ai/models`의 `defaultModel` |
| Messages Editor | `messages[]` | system 1개, user 1개 |
| Simple Prompt Mode | `systemPrompt`, `userPrompt`, `context` | 비활성 또는 별도 탭 |
| Generation | `temperature`, `maxOutputTokens`, `topP` | `0.4`, `1200`, `1.0` |
| Penalty | `presencePenalty`, `frequencyPenalty` | `0`, `0` |
| Format | `responseFormat`, `jsonSchema` | `TEXT`, 빈 값 |
| Advanced | `reasoningEffort`, `verbosity`, `serviceTier`, `extraBody` | 빈 값 또는 provider별 기본값 |
| Metadata | `experimentName`, `clientRequestId` | 프론트에서 생성 |

권장 UX:

- `messages` 모드와 `simple prompt` 모드를 탭으로 분리합니다.
- `messages` 모드가 켜져 있으면 `systemPrompt`, `userPrompt`, `context`는 요청에 넣지 않거나, 넣더라도 무시된다는 안내를 표시합니다.
- JSON 응답 모드에서는 `responseFormat=JSON_OBJECT`와 낮은 `temperature`를 함께 추천합니다.
- 응답 패널에는 `content`, `usage`, `raw`를 모두 보여줍니다.
- `content`가 JSON으로 파싱 가능하면 pretty print를 같이 보여줍니다.

### 11. 구현 파일

| 역할 | 파일 |
| --- | --- |
| Controller | `core/src/main/java/com/mailsangja/core/controller/AiController.java` |
| Swagger Docs | `core/src/main/java/com/mailsangja/core/controller/docs/AiControllerDocs.java` |
| Facade | `core/src/main/java/com/mailsangja/core/facade/AiFacade.java` |
| LLM 호출 Service | `core/src/main/java/com/mailsangja/core/service/ai/AiPlaygroundCommandService.java` |
| Request | `core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundChatRequest.java` |
| Message Request | `core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundMessageRequest.java` |
| Options Request | `core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundOptionsRequest.java` |
| Response | `core/src/main/java/com/mailsangja/core/dto/ai/AiPlaygroundChatResponse.java` |
| ErrorCode | `core/src/main/java/com/mailsangja/core/common/exception/ai/AiPlaygroundErrorCode.java` |

### 12. 현재 제한과 주의사항

- 이 API는 SSE 스트리밍이 아니라 단건 응답입니다.
- tool calling은 지원하지 않습니다.
- 멀티모달 input은 지원하지 않습니다.
- provider별 모든 option을 타입 필드로 열어둔 것은 아닙니다. 필요한 provider-specific 값은 `extraBody`를 사용합니다.
- `metadata`는 현재 저장하지 않습니다.
- `provider`는 현재 실제 provider switching에 사용하지 않습니다.
- 서버는 `context`의 `mailId`, `threadId`를 검증하거나 조회하지 않습니다.
- 서버는 playground 요청의 프롬프트나 컨텍스트를 마스킹하지 않습니다.
- 활성 메일 계정이 없는 사용자는 호출할 수 없습니다.


## ⚡️ Test 결과

| 기능 | 종류 | 결과 |
| --- | --- | --- |
| AI Playground Chat API 컴파일 | Compile | `BUILD SUCCESSFUL` |
| 활성 메일 계정 권한 체크 | Compile | `BUILD SUCCESSFUL` |
| DTO record 규칙 | Compile | `BUILD SUCCESSFUL` |

실행한 명령:

```bash
./gradlew compileJava
```
