### PR TITLE
[STORY-901] Message bcc_names 참조 제거

### DIFF
--- a/db/src/main/resources/init.sql
+++ b/db/src/main/resources/init.sql
@@ -49,9 +49,6 @@ BEGIN
         ), '') || ' ' ||
         coalesce(array_to_string(
             ARRAY(SELECT jsonb_array_elements_text(coalesce(NEW.cc_names, '[]'::jsonb))), ' '
-        ), '') || ' ' ||
-        coalesce(array_to_string(
-            ARRAY(SELECT jsonb_array_elements_text(coalesce(NEW.bcc_names, '[]'::jsonb))), ' '
         ), '')
     );
     RETURN NEW;
@@ -96,8 +93,7 @@ CREATE INDEX IF NOT EXISTS idx_threads_last_message_at ON threads(last_message_a
 --     coalesce(subject, '') || ' ' || coalesce(from_name, '') || ' ' ||
 --     coalesce(body_text, '') || ' ' ||
 --     coalesce(array_to_string(ARRAY(SELECT jsonb_array_elements_text(coalesce(to_names, '[]'::jsonb))), ' '), '') || ' ' ||
---     coalesce(array_to_string(ARRAY(SELECT jsonb_array_elements_text(coalesce(cc_names, '[]'::jsonb))), ' '), '') || ' ' ||
---     coalesce(array_to_string(ARRAY(SELECT jsonb_array_elements_text(coalesce(bcc_names, '[]'::jsonb))), ' '), ''))
+--     coalesce(array_to_string(ARRAY(SELECT jsonb_array_elements_text(coalesce(cc_names, '[]'::jsonb))), ' '), ''))
 -- WHERE search_vector IS NULL;
 --
 -- UPDATE attachments


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#31

### 📌 Task
- Closes #129 


## 💡 작업 내용

-  messages 테이블과 Entity에는 bcc_names 컬럼이 없는데 트리거 함수가 그것을 참조하고 있습니다. init.sql의 트리거 함수에서 bcc_names 부분을 제거