### PR TITLE
[STORY-402] 민감 라벨 로직

### DIFF
--- a/core/src/main/java/com/mailsangja/core/controller/docs/LabelControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/LabelControllerDocs.java
@@ -28,7 +28,7 @@ public interface LabelControllerDocs {
 
     @Operation(
             summary = "라벨 목록 조회",
-            description = "로그인한 사용자의 활성 라벨 목록을 displayOrder ASC 정렬로 반환합니다. 라벨별 읽지 않은 스레드 수를 포함합니다.",
+            description = "로그인한 사용자의 활성 라벨 목록을 displayOrder ASC 정렬로 반환합니다. 라벨별 읽지 않은 스레드 수와 민감 라벨 여부를 포함합니다.",
             security = @SecurityRequirement(name = "cookieAuth")
     )
     @ApiResponses({
@@ -42,7 +42,7 @@ public interface LabelControllerDocs {
 
     @Operation(
             summary = "라벨 상세 조회",
-            description = "특정 라벨의 메타 정보와 타입이 고정된 rule 객체를 반환합니다.",
+            description = "특정 라벨의 메타 정보, 민감 라벨 여부, 타입이 고정된 rule 객체를 반환합니다.",
             security = @SecurityRequirement(name = "cookieAuth")
     )
     @ApiResponses({
@@ -59,7 +59,7 @@ public interface LabelControllerDocs {
 
     @Operation(
             summary = "라벨 생성",
-            description = "새 라벨을 생성합니다. rule이 존재하면 과거 메일 재분류 작업이 비동기로 발행됩니다.",
+            description = "새 라벨을 생성합니다. isSensitive로 AI 기능 제외 대상 여부를 지정할 수 있습니다. rule이 존재하면 과거 메일 재분류 작업이 비동기로 발행됩니다.",
             security = @SecurityRequirement(name = "cookieAuth")
     )
     @ApiResponses({
@@ -78,7 +78,7 @@ public interface LabelControllerDocs {
 
     @Operation(
             summary = "라벨 수정",
-            description = "라벨의 이름, 색상, 알림 설정, 순서를 수정합니다. null 필드는 변경하지 않습니다.",
+            description = "라벨의 이름, 색상, 알림 설정, 순서, 민감 라벨 여부를 수정합니다. null 필드는 변경하지 않습니다.",
             security = @SecurityRequirement(name = "cookieAuth")
     )
     @ApiResponses({
@@ -186,7 +186,7 @@ public interface LabelControllerDocs {
 
     @Operation(
             summary = "라벨 제안 단건 승인",
-            description = "라벨 제안을 수정하여 confirmed=true로 전환합니다. 요청 바디로 이름·색상·순서·알림정책·규칙을 원하는 값으로 변경한 뒤 승인할 수 있습니다. rule이 있는 라벨은 승인 후 과거 메일 재분류 작업이 비동기로 발행됩니다.",
+            description = "라벨 제안을 수정하여 confirmed=true로 전환합니다. 요청 바디로 이름·색상·순서·알림정책·민감 라벨 여부·규칙을 원하는 값으로 변경한 뒤 승인할 수 있습니다. rule이 있는 라벨은 승인 후 과거 메일 재분류 작업이 비동기로 발행됩니다.",
             security = @SecurityRequirement(name = "cookieAuth")
     )
     @ApiResponses({

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadDetailResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadDetailResponse.java
@@ -32,7 +32,8 @@ public record ThreadDetailResponse(
     public record LabelSummary(
             @Schema(description = "라벨 ID") UUID labelId,
             @Schema(description = "라벨 이름") String name,
-            @Schema(description = "라벨 색상 코드", example = "#FF5733") String colorCode
+            @Schema(description = "라벨 색상 코드", example = "#FF5733") String colorCode,
+            @Schema(description = "AI 기능에서 제외할 민감 라벨 여부", example = "false") boolean isSensitive
     ) {}
 
     public static ThreadDetailResponse from(
@@ -51,7 +52,7 @@ public record ThreadDetailResponse(
                 .toList();
 
         List<LabelSummary> labels = labelViews.stream()
-                .map(v -> new LabelSummary(v.labelId(), v.labelName(), v.colorCode()))
+                .map(v -> new LabelSummary(v.labelId(), v.labelName(), v.colorCode(), v.isSensitive()))
                 .toList();
 
         return new ThreadDetailResponse(

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponse.java
@@ -38,7 +38,8 @@ public record ThreadSummaryResponse(
     public record LabelSummary(
             @Schema(description = "라벨 ID") UUID labelId,
             @Schema(description = "라벨 이름") String name,
-            @Schema(description = "라벨 색상 코드", example = "#FF5733") String colorCode
+            @Schema(description = "라벨 색상 코드", example = "#FF5733") String colorCode,
+            @Schema(description = "AI 기능에서 제외할 민감 라벨 여부", example = "false") boolean isSensitive
     ) {}
 
     public static ThreadSummaryResponse from(
@@ -59,7 +60,7 @@ public record ThreadSummaryResponse(
                 attachments.stream().map(AttachmentResponse::from).toList(),
                 thread.getMessageCount(),
                 labelViews.stream()
-                        .map(v -> new LabelSummary(v.labelId(), v.labelName(), v.colorCode()))
+                        .map(v -> new LabelSummary(v.labelId(), v.labelName(), v.colorCode(), v.isSensitive()))
                         .toList()
         );
     }

--- a/core/src/main/java/com/mailsangja/core/dto/label/LabelCreateRequest.java
+++ b/core/src/main/java/com/mailsangja/core/dto/label/LabelCreateRequest.java
@@ -21,6 +21,9 @@ public record LabelCreateRequest(
         @Schema(description = "표시 순서", example = "0")
         int order,
 
+        @Schema(description = "AI 기능에서 제외할 민감 라벨 여부", example = "false")
+        Boolean isSensitive,
+
         @Schema(description = "라벨 자동 분류 규칙")
         LabelRule rule
 ) {

--- a/core/src/main/java/com/mailsangja/core/dto/label/LabelDetailResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/label/LabelDetailResponse.java
@@ -24,6 +24,9 @@ public record LabelDetailResponse(
         @Schema(description = "알림 정책 (URGENT/INHERIT/SILENT)", example = "INHERIT")
         NotificationPolicy notificationPolicy,
 
+        @Schema(description = "AI 기능에서 제외할 민감 라벨 여부", example = "false")
+        boolean isSensitive,
+
         @Schema(description = "라벨 자동 분류 규칙")
         LabelRule rule
 ) {
@@ -35,6 +38,7 @@ public record LabelDetailResponse(
                 label.getColorCode(),
                 label.getDisplayOrder(),
                 label.getNotificationPolicy(),
+                label.isSensitive(),
                 rule
         );
     }

--- a/core/src/main/java/com/mailsangja/core/dto/label/LabelListResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/label/LabelListResponse.java
@@ -19,6 +19,9 @@ public record LabelListResponse(
         @Schema(description = "표시 순서", example = "0")
         int order,
 
+        @Schema(description = "AI 기능에서 제외할 민감 라벨 여부", example = "false")
+        boolean isSensitive,
+
         @Schema(description = "읽지 않은 스레드 수", example = "12")
         long unreadThreadCount
 ) {
@@ -29,6 +32,7 @@ public record LabelListResponse(
                 label.getName(),
                 label.getColorCode(),
                 label.getDisplayOrder(),
+                label.isSensitive(),
                 unreadThreadCount
         );
     }

--- a/core/src/main/java/com/mailsangja/core/dto/label/LabelUpdateRequest.java
+++ b/core/src/main/java/com/mailsangja/core/dto/label/LabelUpdateRequest.java
@@ -15,6 +15,9 @@ public record LabelUpdateRequest(
         NotificationPolicy notificationPolicy,
 
         @Schema(description = "표시 순서", example = "1")
-        Integer order
+        Integer order,
+
+        @Schema(description = "AI 기능에서 제외할 민감 라벨 여부", example = "true")
+        Boolean isSensitive
 ) {
 }

--- a/core/src/main/java/com/mailsangja/core/facade/LabelFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/LabelFacade.java
@@ -94,7 +94,7 @@ public class LabelFacade {
         List<Label> existingLabels = labelQueryService.findAllActiveByUserId(user.getId());
         LlmLabelSuggestionResult result = labelSuggestionAiService.suggest(user.getId(), existingLabels);
         return result.suggestions().stream()
-                .map(item -> new LabelCreateRequest(item.name(), item.colorCode(), item.notificationPolicy(), item.order(), item.rule()))
+                .map(item -> new LabelCreateRequest(item.name(), item.colorCode(), item.notificationPolicy(), item.order(), false, item.rule()))
                 .filter(request -> !labelQueryService.existsByUserIdAndName(user.getId(), request.name().trim()))
                 .map(request -> {
                     Label suggestion = labelCommandService.createSuggestion(user, request);

--- a/core/src/main/java/com/mailsangja/core/service/label/LabelCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/label/LabelCommandService.java
@@ -39,6 +39,7 @@ public class LabelCommandService {
                 .displayOrder(request.order())
                 .rule(request.rule())
                 .confirmed(true)
+                .isSensitive(Boolean.TRUE.equals(request.isSensitive()))
                 .build();
         return labelRepositoryPort.save(label);
     }
@@ -56,6 +57,7 @@ public class LabelCommandService {
                 .displayOrder(request.order())
                 .rule(request.rule())
                 .confirmed(false)
+                .isSensitive(Boolean.TRUE.equals(request.isSensitive()))
                 .build();
         return labelRepositoryPort.save(label);
     }
@@ -69,6 +71,7 @@ public class LabelCommandService {
         );
         suggestion.updateDisplayOrder(request.order());
         suggestion.updateRule(request.rule());
+        suggestion.updateSensitive(Boolean.TRUE.equals(request.isSensitive()));
         suggestion.confirm();
         return labelRepositoryPort.save(suggestion);
     }
@@ -86,6 +89,9 @@ public class LabelCommandService {
         }
         if (request.order() != null) {
             label.updateDisplayOrder(request.order());
+        }
+        if (request.isSensitive() != null) {
+            label.updateSensitive(request.isSensitive());
         }
         return labelRepositoryPort.save(label);
     }

--- a/core/src/test/java/com/mailsangja/core/facade/InboxFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/InboxFacadeTest.java
@@ -11,6 +11,7 @@ import com.mailsangja.core.service.mail.GoogleAccessTokenEnsureService;
 import com.mailsangja.core.service.mail.InlineImageService;
 import com.mailsangja.core.service.mail.MailAccountQueryService;
 import com.mailsangja.core.service.search.MailSearchQueryService;
+import com.mailsangja.db.dto.ThreadMessageLabelView;
 import com.mailsangja.db.entity.mail.Direction;
 import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.MailProvider;
@@ -58,8 +59,9 @@ class InboxFacadeTest {
         // given
         User user = user();
         Thread thread = thread(mailAccount(user, MailProvider.GMAIL), Direction.INBOUND);
+        ThreadMessageLabelView label = new ThreadMessageLabelView(thread.getId(), UUID.randomUUID(), "민감", "#123456", true);
         when(inboxQueryService.findInboxThreadsResult(user.getId(), null, null, null, PageRequest.of(0, 50)))
-                .thenReturn(threadListResult(List.of(thread), false));
+                .thenReturn(threadListResult(List.of(thread), Map.of(thread.getId(), List.of(label)), false));
         when(inboxQueryService.countUnreadInbox(user.getId(), null, null)).thenReturn(3L);
         when(inboxQueryService.countInbox(user.getId(), null, null)).thenReturn(7L);
 
@@ -69,6 +71,7 @@ class InboxFacadeTest {
 
         // then
         assertEquals(1, result.content().size());
+        assertEquals(label.isSensitive(), result.content().getFirst().labels().getFirst().isSensitive());
         assertEquals(3L, result.unreadCount());
         assertEquals(7L, result.totalCount());
         verify(mailSearchQueryService, never()).searchInboxThreadsResult(any(), any(), anyList(), any(), any(), any());
@@ -194,6 +197,14 @@ class InboxFacadeTest {
 
     private ThreadListResult threadListResult(List<Thread> threads, boolean hasNext) {
         return new ThreadListResult(new SliceImpl<>(threads, PageRequest.of(0, 50), hasNext), Map.of(), Map.of(), Map.of());
+    }
+
+    private ThreadListResult threadListResult(
+            List<Thread> threads,
+            Map<UUID, List<ThreadMessageLabelView>> labelsByThreadId,
+            boolean hasNext
+    ) {
+        return new ThreadListResult(new SliceImpl<>(threads, PageRequest.of(0, 50), hasNext), Map.of(), Map.of(), labelsByThreadId);
     }
 
     private User user() {

--- a/core/src/test/java/com/mailsangja/core/facade/LabelFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/LabelFacadeTest.java
@@ -67,8 +67,10 @@ class LabelFacadeTest {
 
         assertEquals(2, responses.size());
         assertEquals(first.getId(), responses.get(0).id());
+        assertEquals(first.isSensitive(), responses.get(0).isSensitive());
         assertEquals(7L, responses.get(0).unreadThreadCount());
         assertEquals(second.getId(), responses.get(1).id());
+        assertEquals(second.isSensitive(), responses.get(1).isSensitive());
         assertEquals(0L, responses.get(1).unreadThreadCount());
     }
 
@@ -82,13 +84,14 @@ class LabelFacadeTest {
         LabelDetailResponse response = labelFacade.getLabelDetail(user, label.getId());
 
         assertEquals(label.getId(), response.id());
+        assertEquals(label.isSensitive(), response.isSensitive());
         assertSame(rule, response.rule());
     }
 
     @Test
     void 라벨생성_생성전이름중복시_예외발생하고생성안됨() {
         User user = user();
-        LabelCreateRequest request = new LabelCreateRequest("  업무  ", "#3366FF", NotificationPolicy.INHERIT, 1, null);
+        LabelCreateRequest request = new LabelCreateRequest("  업무  ", "#3366FF", NotificationPolicy.INHERIT, 1, false, null);
         when(labelQueryService.existsByUserIdAndName(user.getId(), "업무")).thenReturn(true);
 
         LabelException exception = assertThrows(LabelException.class, () -> labelFacade.createLabel(user, request));
@@ -101,7 +104,7 @@ class LabelFacadeTest {
     void 라벨생성_규칙있을때_규칙검증및PendingJob병합() {
         User user = user();
         LabelRule rule = rule("invoice");
-        LabelCreateRequest request = new LabelCreateRequest("업무", "#3366FF", NotificationPolicy.URGENT, 1, rule);
+        LabelCreateRequest request = new LabelCreateRequest("업무", "#3366FF", NotificationPolicy.URGENT, 1, true, rule);
         Label saved = label("업무", 1, rule);
         when(labelQueryService.existsByUserIdAndName(user.getId(), "업무")).thenReturn(false);
         when(labelCommandService.create(user, request)).thenReturn(saved);
@@ -112,13 +115,14 @@ class LabelFacadeTest {
         verify(pendingJobStore).checkRateLimit(user.getId());
         verify(pendingJobStore).mergePendingJob(user.getId(), saved.getId());
         assertEquals(saved.getId(), response.id());
+        assertEquals(saved.isSensitive(), response.isSensitive());
         assertSame(rule, response.rule());
     }
 
     @Test
     void 라벨생성_규칙없을때_PendingJob생성안됨() {
         User user = user();
-        LabelCreateRequest request = new LabelCreateRequest("업무", "#3366FF", NotificationPolicy.INHERIT, 1, null);
+        LabelCreateRequest request = new LabelCreateRequest("업무", "#3366FF", NotificationPolicy.INHERIT, 1, false, null);
         Label saved = label("업무", 1, null);
         when(labelCommandService.create(user, request)).thenReturn(saved);
 
@@ -132,7 +136,7 @@ class LabelFacadeTest {
     @Test
     void 라벨생성_DB중복시_이름중복예외발생() {
         User user = user();
-        LabelCreateRequest request = new LabelCreateRequest("업무", "#3366FF", NotificationPolicy.INHERIT, 1, null);
+        LabelCreateRequest request = new LabelCreateRequest("업무", "#3366FF", NotificationPolicy.INHERIT, 1, false, null);
         when(labelCommandService.create(user, request)).thenThrow(new DataIntegrityViolationException("duplicate"));
 
         LabelException exception = assertThrows(LabelException.class, () -> labelFacade.createLabel(user, request));
@@ -144,7 +148,7 @@ class LabelFacadeTest {
     void 라벨수정_이름이공백이면_이름공백예외발생() {
         User user = user();
         Label label = label("기존", 1);
-        LabelUpdateRequest request = new LabelUpdateRequest("  ", null, null, null);
+        LabelUpdateRequest request = new LabelUpdateRequest("  ", null, null, null, null);
         when(labelQueryService.findActiveByIdAndUserId(label.getId(), user.getId())).thenReturn(label);
 
         LabelException exception = assertThrows(LabelException.class, () -> labelFacade.updateLabel(user, label.getId(), request));
@@ -157,7 +161,7 @@ class LabelFacadeTest {
     void 라벨생성_RateLimit초과시_예외전파되고PendingJob병합안됨() {
         User user = user();
         LabelRule rule = rule("invoice");
-        LabelCreateRequest request = new LabelCreateRequest("업무", "#3366FF", NotificationPolicy.URGENT, 1, rule);
+        LabelCreateRequest request = new LabelCreateRequest("업무", "#3366FF", NotificationPolicy.URGENT, 1, true, rule);
         Label saved = label("업무", 1, rule);
         when(labelQueryService.existsByUserIdAndName(user.getId(), "업무")).thenReturn(false);
         when(labelCommandService.create(user, request)).thenReturn(saved);

--- a/core/src/test/java/com/mailsangja/core/facade/TrashFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/TrashFacadeTest.java
@@ -267,7 +267,7 @@ class TrashFacadeTest {
         Thread inbound = thread(account, "gmail-thread-1", Direction.INBOUND);
         Message message = message(inbound);
         Attachment attachment = attachment(message);
-        ThreadMessageLabelView label = new ThreadMessageLabelView(inbound.getId(), UUID.randomUUID(), "업무", "#123456");
+        ThreadMessageLabelView label = new ThreadMessageLabelView(inbound.getId(), UUID.randomUUID(), "업무", "#123456", false);
         stubTrashCounts(user.getId());
         when(trashQueryService.findDeletedMessagesByUserId(any(), any(), anyInt(), any(), any()))
                 .thenReturn(sliceOf(message));
@@ -386,7 +386,7 @@ class TrashFacadeTest {
                 List.of("cc@example.com")
         );
         Message second = detailedMessage(thread, "from@example.com", List.of("to@example.com"), null);
-        ThreadMessageLabelView label = new ThreadMessageLabelView(thread.getId(), UUID.randomUUID(), "중요", "#ff0000");
+        ThreadMessageLabelView label = new ThreadMessageLabelView(thread.getId(), UUID.randomUUID(), "중요", "#ff0000", false);
         when(trashQueryService.findThreadByIdIncludingDeleted(thread.getId())).thenReturn(thread);
         when(mailAccountQueryService.findAllActiveByUserId(user.getId())).thenReturn(List.of(account));
         when(trashQueryService.findDeletedMessagesByMailAccountIdAndGmailThreadId(account.getId(), thread.getGmailThreadId()))

--- a/core/src/test/java/com/mailsangja/core/service/inbox/InboxQueryServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/inbox/InboxQueryServiceTest.java
@@ -57,7 +57,7 @@ class InboxQueryServiceTest {
         message.replaceAttachments(List.of(attachment));
         UUID labelId = UUID.randomUUID();
         List<UUID> labelIds = Arrays.asList(labelId, null, labelId);
-        ThreadMessageLabelView label = new ThreadMessageLabelView(thread.getId(), labelId, "업무", "#123456");
+        ThreadMessageLabelView label = new ThreadMessageLabelView(thread.getId(), labelId, "업무", "#123456", true);
         when(threadRepositoryPort.findInboxByUserIdAndFilters(
                 user.getId(), List.of(labelId), false, null, PageRequest.of(0, 20)))
                 .thenReturn(new SliceImpl<>(List.of(thread), PageRequest.of(0, 20), false));
@@ -113,7 +113,7 @@ class InboxQueryServiceTest {
                 .toAddresses(List.of("to@example.com"))
                 .ccAddresses(List.of("cc@example.com"))
                 .build();
-        ThreadMessageLabelView label = new ThreadMessageLabelView(thread.getId(), UUID.randomUUID(), "중요", "#ff0000");
+        ThreadMessageLabelView label = new ThreadMessageLabelView(thread.getId(), UUID.randomUUID(), "중요", "#ff0000", true);
         when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
                 account.getId(), thread.getGmailThreadId()))
                 .thenReturn(List.of(message));

--- a/core/src/test/java/com/mailsangja/core/service/label/LabelCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/label/LabelCommandServiceTest.java
@@ -47,7 +47,7 @@ class LabelCommandServiceTest {
     void create_notificationPolicyIsNull_defaultsToInheritAndTrimsName() {
         User user = User.builder().id(UUID.randomUUID()).build();
         LabelRule rule = rule("invoice");
-        LabelCreateRequest request = new LabelCreateRequest("  업무  ", "#3366FF", null, 3, rule);
+        LabelCreateRequest request = new LabelCreateRequest("  업무  ", "#3366FF", null, 3, true, rule);
         when(labelRepositoryPort.save(any(Label.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         Label saved = labelCommandService.create(user, request);
@@ -57,6 +57,7 @@ class LabelCommandServiceTest {
         assertEquals("#3366FF", saved.getColorCode());
         assertEquals(NotificationPolicy.INHERIT, saved.getNotificationPolicy());
         assertEquals(3, saved.getDisplayOrder());
+        assertTrue(saved.isSensitive());
         assertSame(rule, saved.getRule());
     }
 
@@ -68,8 +69,9 @@ class LabelCommandServiceTest {
                 .colorCode("#111111")
                 .notificationPolicy(NotificationPolicy.INHERIT)
                 .displayOrder(1)
+                .isSensitive(false)
                 .build();
-        LabelUpdateRequest request = new LabelUpdateRequest("  새 이름  ", null, NotificationPolicy.SILENT, null);
+        LabelUpdateRequest request = new LabelUpdateRequest("  새 이름  ", null, NotificationPolicy.SILENT, null, true);
         when(labelRepositoryPort.save(label)).thenReturn(label);
 
         Label updated = labelCommandService.update(label, request);
@@ -79,6 +81,7 @@ class LabelCommandServiceTest {
         assertEquals("#111111", label.getColorCode());
         assertEquals(NotificationPolicy.SILENT, label.getNotificationPolicy());
         assertEquals(1, label.getDisplayOrder());
+        assertTrue(label.isSensitive());
     }
 
     @Test

--- a/core/src/test/java/com/mailsangja/core/service/search/MailSearchQueryServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/search/MailSearchQueryServiceTest.java
@@ -51,7 +51,7 @@ class MailSearchQueryServiceTest {
         Message message = message(thread);
         Attachment attachment = attachment(message);
         message.replaceAttachments(List.of(attachment));
-        ThreadMessageLabelView label = new ThreadMessageLabelView(thread.getId(), UUID.randomUUID(), "업무", "#123456");
+        ThreadMessageLabelView label = new ThreadMessageLabelView(thread.getId(), UUID.randomUUID(), "업무", "#123456", false);
         when(mailSearchRepositoryPort.searchInboxThreads(
                 user.getId(), "프로젝트", List.of(), null, null, PageRequest.of(0, 20)))
                 .thenReturn(new SliceImpl<>(List.of(thread), PageRequest.of(0, 20), false));
@@ -147,7 +147,7 @@ class MailSearchQueryServiceTest {
         Message message = message(thread);
         Attachment attachment = attachment(message);
         message.replaceAttachments(List.of(attachment));
-        ThreadMessageLabelView label = new ThreadMessageLabelView(thread.getId(), UUID.randomUUID(), "채용", "#0077B5");
+        ThreadMessageLabelView label = new ThreadMessageLabelView(thread.getId(), UUID.randomUUID(), "채용", "#0077B5", false);
         when(mailSearchRepositoryPort.searchInboxThreads(
                 user.getId(), "LinkedIn", null, null, null, PageRequest.of(0, 20)))
                 .thenReturn(new SliceImpl<>(List.of(thread), PageRequest.of(0, 20), false));

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
@@ -207,7 +207,13 @@ public class MessageRepositoryAdapter implements MessageRepositoryPort {
         }
         return messageJpaRepositoryModule.findLabelsByThreadIdIn(threadIds)
                 .stream()
-                .map(p -> new ThreadMessageLabelView(p.getThreadId(), p.getLabelId(), p.getLabelName(), p.getLabelColorCode()))
+                .map(p -> new ThreadMessageLabelView(
+                        p.getThreadId(),
+                        p.getLabelId(),
+                        p.getLabelName(),
+                        p.getLabelColorCode(),
+                        p.getLabelIsSensitive()
+                ))
                 .toList();
     }
 

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/MessageRepositoryAdapter.java
@@ -43,6 +43,11 @@ public class MessageRepositoryAdapter implements MessageRepositoryPort {
     }
 
     @Override
+    public Optional<Message> findByIdIncludingDeletedAndSensitiveLabelsExcluded(UUID messageId) {
+        return messageJpaRepositoryModule.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId);
+    }
+
+    @Override
     public Optional<Message> findByMailAccountIdAndGmailThreadIdAndGmailMessageIdAndDeletedAtIsNull(
             UUID mailAccountId,
             String gmailThreadId,
@@ -112,6 +117,17 @@ public class MessageRepositoryAdapter implements MessageRepositoryPort {
     @Override
     public List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId) {
         return messageJpaRepositoryModule.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, gmailThreadId);
+    }
+
+    @Override
+    public List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullAndSensitiveLabelsExcluded(
+            UUID mailAccountId,
+            String gmailThreadId
+    ) {
+        return messageJpaRepositoryModule.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullAndSensitiveLabelsExcluded(
+                mailAccountId,
+                gmailThreadId
+        );
     }
 
     @Override

--- a/db/src/main/java/com/mailsangja/db/dto/ThreadMessageLabelProjection.java
+++ b/db/src/main/java/com/mailsangja/db/dto/ThreadMessageLabelProjection.java
@@ -7,4 +7,5 @@ public interface ThreadMessageLabelProjection {
     UUID getLabelId();
     String getLabelName();
     String getLabelColorCode();
+    boolean getLabelIsSensitive();
 }

--- a/db/src/main/java/com/mailsangja/db/dto/ThreadMessageLabelView.java
+++ b/db/src/main/java/com/mailsangja/db/dto/ThreadMessageLabelView.java
@@ -6,5 +6,6 @@ public record ThreadMessageLabelView(
         UUID threadId,
         UUID labelId,
         String labelName,
-        String colorCode
+        String colorCode,
+        boolean isSensitive
 ) {}

--- a/db/src/main/java/com/mailsangja/db/entity/label/Label.java
+++ b/db/src/main/java/com/mailsangja/db/entity/label/Label.java
@@ -50,6 +50,10 @@ public class Label extends BaseEntity {
     @Column(name = "confirmed", nullable = false)
     private boolean confirmed = true;
 
+    @Builder.Default
+    @Column(name = "is_sensitive", nullable = false)
+    private boolean isSensitive = false;
+
     public void confirm() {
         this.confirmed = true;
     }
@@ -72,5 +76,9 @@ public class Label extends BaseEntity {
 
     public void updateRule(LabelRule rule) {
         this.rule = rule;
+    }
+
+    public void updateSensitive(boolean isSensitive) {
+        this.isSensitive = isSensitive;
     }
 }

--- a/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
@@ -310,7 +310,8 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
             SELECT DISTINCT ml.message.thread.id AS threadId,
                             ml.label.id  AS labelId,
                             ml.label.name AS labelName,
-                            ml.label.colorCode AS labelColorCode
+                            ml.label.colorCode AS labelColorCode,
+                            ml.label.isSensitive AS labelIsSensitive
             FROM MessageLabel ml
             WHERE ml.message.thread.id IN :threadIds
               AND ml.deletedAt IS NULL

--- a/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
@@ -96,8 +96,46 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
             @Param("gmailThreadId") String gmailThreadId
     );
 
+    @EntityGraph(attributePaths = {"attachments"})
+    @Query("""
+            SELECT m
+            FROM Message m
+            WHERE m.thread.mailAccount.id = :mailAccountId
+              AND m.thread.gmailThreadId = :gmailThreadId
+              AND m.deletedAt IS NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM MessageLabel ml
+                  WHERE ml.message.id = m.id
+                    AND ml.deletedAt IS NULL
+                    AND ml.label.deletedAt IS NULL
+                    AND ml.label.isSensitive = true
+              )
+            ORDER BY m.sentAt ASC
+            """)
+    List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullAndSensitiveLabelsExcluded(
+            @Param("mailAccountId") UUID mailAccountId,
+            @Param("gmailThreadId") String gmailThreadId
+    );
+
     @EntityGraph(attributePaths = {"thread", "thread.mailAccount", "thread.mailAccount.user"})
     Optional<Message> findById(UUID id);
+
+    @EntityGraph(attributePaths = {"thread", "thread.mailAccount", "thread.mailAccount.user"})
+    @Query("""
+            SELECT m
+            FROM Message m
+            WHERE m.id = :messageId
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM MessageLabel ml
+                  WHERE ml.message.id = m.id
+                    AND ml.deletedAt IS NULL
+                    AND ml.label.deletedAt IS NULL
+                    AND ml.label.isSensitive = true
+              )
+            """)
+    Optional<Message> findByIdIncludingDeletedAndSensitiveLabelsExcluded(@Param("messageId") UUID messageId);
 
     @EntityGraph(attributePaths = {"attachments"})
     @Query("SELECT m FROM Message m WHERE m.thread.mailAccount.id = :mailAccountId AND m.thread.gmailThreadId = :gmailThreadId ORDER BY m.sentAt ASC")

--- a/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
@@ -371,6 +371,14 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
               AND m.deletedAt IS NULL
               AND m.thread.deletedAt IS NULL
               AND m.thread.mailAccount.deletedAt IS NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM MessageLabel ml
+                  WHERE ml.message.id = m.id
+                    AND ml.deletedAt IS NULL
+                    AND ml.label.deletedAt IS NULL
+                    AND ml.label.isSensitive = true
+              )
             ORDER BY m.sentAt DESC, m.id DESC
             """)
     List<Message> findRecentByUserIdAndMailAccountIdAndDirection(
@@ -391,6 +399,15 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
               AND m.deleted_at IS NULL
               AND t.deleted_at IS NULL
               AND ma.deleted_at IS NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM message_labels ml
+                  JOIN labels l ON l.id = ml.label_id
+                  WHERE ml.message_id = m.id
+                    AND ml.deleted_at IS NULL
+                    AND l.deleted_at IS NULL
+                    AND l.is_sensitive = true
+              )
               AND (
                   LOWER(COALESCE(m.subject, '')) LIKE LOWER(CONCAT('%', :hint, '%'))
                   OR LOWER(COALESCE(m.body_text, '')) LIKE LOWER(CONCAT('%', :hint, '%'))
@@ -416,6 +433,14 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
               AND m.deletedAt IS NULL
               AND m.thread.deletedAt IS NULL
               AND m.thread.mailAccount.deletedAt IS NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM MessageLabel ml
+                  WHERE ml.message.id = m.id
+                    AND ml.deletedAt IS NULL
+                    AND ml.label.deletedAt IS NULL
+                    AND ml.label.isSensitive = true
+              )
             ORDER BY m.sentAt DESC, m.id DESC
             """)
     List<Message> findRecentByUserIdAndDirection(
@@ -434,6 +459,15 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
               AND m.deleted_at IS NULL
               AND t.deleted_at IS NULL
               AND ma.deleted_at IS NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM message_labels ml
+                  JOIN labels l ON l.id = ml.label_id
+                  WHERE ml.message_id = m.id
+                    AND ml.deleted_at IS NULL
+                    AND l.deleted_at IS NULL
+                    AND l.is_sensitive = true
+              )
               AND (
                   (
                       m.direction = 'OUTBOUND'
@@ -475,6 +509,14 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
               AND m.deletedAt IS NULL
               AND m.thread.deletedAt IS NULL
               AND m.thread.mailAccount.deletedAt IS NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM MessageLabel ml
+                  WHERE ml.message.id = m.id
+                    AND ml.deletedAt IS NULL
+                    AND ml.label.deletedAt IS NULL
+                    AND ml.label.isSensitive = true
+              )
             """)
     List<Message> findActiveByIdIn(@Param("messageIds") List<UUID> messageIds);
 
@@ -491,6 +533,14 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
               AND m.deletedAt IS NULL
               AND m.thread.deletedAt IS NULL
               AND m.thread.mailAccount.deletedAt IS NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM MessageLabel ml
+                  WHERE ml.message.id = m.id
+                    AND ml.deletedAt IS NULL
+                    AND ml.label.deletedAt IS NULL
+                    AND ml.label.isSensitive = true
+              )
             ORDER BY m.sentAt ASC, m.id ASC
             """)
     List<Message> findThreadContextByReplyMessageId(@Param("replyMessageId") UUID replyMessageId);

--- a/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/MessageRepositoryPort.java
@@ -37,10 +37,12 @@ public interface MessageRepositoryPort {
             Direction direction
     );
     Optional<Message> findByIdIncludingDeleted(UUID messageId);
+    Optional<Message> findByIdIncludingDeletedAndSensitiveLabelsExcluded(UUID messageId);
     List<Message> findAllByThreadIdAndDeletedAtIsNull(UUID threadId);
     List<Message> findAllByThreadIdIncludingDeleted(UUID threadId);
     List<Message> findAllByThreadIdInAndDeletedAtIsNull(List<UUID> threadIds);
     List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(UUID mailAccountId, String gmailThreadId);
+    List<Message> findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullAndSensitiveLabelsExcluded(UUID mailAccountId, String gmailThreadId);
     List<Message> findAllByMailAccountIdAndGmailThreadId(UUID mailAccountId, String gmailThreadId);
     Slice<Message> findDeletedByUserId(UUID userId, UUID markerId, Pageable pageable);
     Slice<Message> findDeletedByUserIdAndFilters(UUID userId, UUID markerId, List<UUID> labelIds, Boolean read, Pageable pageable);

--- a/db/src/main/resources/init.sql
+++ b/db/src/main/resources/init.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;;
+
 CREATE UNIQUE INDEX IF NOT EXISTS uq_mail_accounts_user_provider_email_active
     ON mail_accounts (user_id, provider, email_address)
     WHERE deleted_at IS NULL;;
@@ -103,7 +105,7 @@ CREATE INDEX IF NOT EXISTS idx_threads_last_message_at ON threads(last_message_a
 -- WHERE filename_vector IS NULL;
 
 -- ── Full-Text Search (English, pg_trgm) ──────────────────────────────────────
--- pg_trgm 확장은 extensions.sql(docker-entrypoint-initdb.d)에서 superuser로 설치됨
+-- pg_trgm 확장은 이 스크립트 상단에서 보장됨
 
 -- messages.search_text: 영어 부분/대소문자 무시 검색을 위한 소문자 정규화 텍스트
 -- body_text는 인덱스 크기 제한을 위해 앞 5000자만 포함

--- a/db/src/main/resources/init.sql
+++ b/db/src/main/resources/init.sql
@@ -23,6 +23,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_labels_user_name_active
     ON labels (user_id, lower(name))
     WHERE deleted_at IS NULL;;
 
+ALTER TABLE labels ADD COLUMN IF NOT EXISTS is_sensitive BOOLEAN NOT NULL DEFAULT FALSE;;
+
 CREATE UNIQUE INDEX IF NOT EXISTS uq_orders_webhook_id
     ON orders (webhook_id);;
 

--- a/db/src/main/resources/schema.sql
+++ b/db/src/main/resources/schema.sql
@@ -167,6 +167,7 @@ CREATE TABLE IF NOT EXISTS labels (
     display_order        INT          NOT NULL DEFAULT 0,
     rule                 JSONB        NULL,
     confirmed            BOOLEAN      NOT NULL DEFAULT TRUE,
+    is_sensitive         BOOLEAN      NOT NULL DEFAULT FALSE,
     created_at           TIMESTAMP    NOT NULL,
     modified_at          TIMESTAMP    NOT NULL,
     deleted_at           TIMESTAMP    NULL,

--- a/db/src/test/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModuleTest.java
+++ b/db/src/test/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModuleTest.java
@@ -1,0 +1,81 @@
+package com.mailsangja.db.module.mail;
+
+import com.mailsangja.db.entity.mail.Direction;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MessageJpaRepositoryModuleTest {
+
+    @Test
+    void sensitiveLabelsExcludedJpqlQueriesContainNotExistsFilter() throws NoSuchMethodException {
+        assertAll(
+                () -> assertJpqlSensitiveLabelFilter("findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullAndSensitiveLabelsExcluded", UUID.class, String.class),
+                () -> assertJpqlSensitiveLabelFilter("findByIdIncludingDeletedAndSensitiveLabelsExcluded", UUID.class),
+                () -> assertJpqlSensitiveLabelFilter("findRecentByUserIdAndMailAccountIdAndDirection", UUID.class, UUID.class, Direction.class, Pageable.class),
+                () -> assertJpqlSensitiveLabelFilter("findRecentByUserIdAndDirection", UUID.class, Direction.class, Pageable.class),
+                () -> assertJpqlSensitiveLabelFilter("findActiveByIdIn", List.class),
+                () -> assertJpqlSensitiveLabelFilter("findThreadContextByReplyMessageId", UUID.class)
+        );
+    }
+
+    @Test
+    void sensitiveLabelsExcludedNativeQueriesContainNotExistsFilter() throws NoSuchMethodException {
+        assertAll(
+                () -> assertNativeSensitiveLabelFilter("findWrittenByUserIdAndMailAccountIdAndHint", String.class, String.class, String.class, Pageable.class),
+                () -> assertNativeSensitiveLabelFilter("findRecipientHistoryByUserIdAndMailAccountIdAndHint", String.class, String.class, String.class, Pageable.class)
+        );
+    }
+
+    private void assertJpqlSensitiveLabelFilter(String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
+        String query = queryOf(methodName, parameterTypes);
+        String normalized = normalize(query);
+
+        assertAll(
+                () -> assertTrue(normalized.contains("not exists"), methodName + " must exclude sensitive labels with NOT EXISTS"),
+                () -> assertTrue(normalized.contains("from messagelabel ml"), methodName + " must inspect MessageLabel"),
+                () -> assertTrue(normalized.contains("ml.message.id = m.id"), methodName + " must correlate MessageLabel to Message"),
+                () -> assertTrue(normalized.contains("ml.deletedat is null"), methodName + " must ignore deleted MessageLabel rows"),
+                () -> assertTrue(normalized.contains("ml.label.deletedat is null"), methodName + " must ignore deleted Label rows"),
+                () -> assertTrue(normalized.contains("ml.label.issensitive = true"), methodName + " must exclude sensitive labels")
+        );
+    }
+
+    private void assertNativeSensitiveLabelFilter(String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
+        String query = queryOf(methodName, parameterTypes);
+        String normalized = normalize(query);
+
+        assertAll(
+                () -> assertTrue(normalized.contains("not exists"), methodName + " must exclude sensitive labels with NOT EXISTS"),
+                () -> assertTrue(normalized.contains("from message_labels ml"), methodName + " must inspect message_labels"),
+                () -> assertTrue(normalized.contains("join labels l on l.id = ml.label_id"), methodName + " must join labels"),
+                () -> assertTrue(normalized.contains("ml.message_id = m.id"), methodName + " must correlate message_labels to messages"),
+                () -> assertTrue(normalized.contains("ml.deleted_at is null"), methodName + " must ignore deleted message_labels rows"),
+                () -> assertTrue(normalized.contains("l.deleted_at is null"), methodName + " must ignore deleted labels rows"),
+                () -> assertTrue(normalized.contains("l.is_sensitive = true"), methodName + " must exclude sensitive labels")
+        );
+    }
+
+    private String queryOf(String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
+        Method method = MessageJpaRepositoryModule.class.getDeclaredMethod(methodName, parameterTypes);
+        Query query = method.getAnnotation(Query.class);
+
+        assertNotNull(query, methodName + " must declare @Query");
+        return query.value();
+    }
+
+    private String normalize(String query) {
+        return query.replaceAll("\\s+", " ")
+                .trim()
+                .toLowerCase(Locale.ROOT);
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
+++ b/worker/src/main/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandler.java
@@ -46,22 +46,21 @@ public class MessageAddedHistoryEventHandler {
     public void handle(MailAccount mailAccount, GmailHistoryEvent event) {
         gmailNewMessageSyncCommandService.syncNewMessage(mailAccount, event).ifPresent(context -> {
             mailEmbeddingPublisher.publish(new MailEmbeddingMessage(context.messageId()));
-            publishReplyDraftSuggestionIfEligible(mailAccount, event, context);
 
             List<Label> activeLabels = labelQueryService.findAllActiveByUserId(mailAccount.getUser().getId());
 
             boolean isOutbound = context.direction() == Direction.OUTBOUND;
+            LabelApplyResult labelApplyResult = LabelApplyResult.empty();
 
-            if (activeLabels.isEmpty()) {
-                if (!isOutbound) {
-                    sendFcmPush(context);
-                }
-                return;
+            if (!activeLabels.isEmpty()) {
+                labelApplyResult = applyLabelsAndResolveResult(context, activeLabels);
             }
 
-            boolean notificationShouldSend = applyLabelsAndCheckNotification(context, activeLabels);
+            if (!labelApplyResult.hasSensitiveLabel()) {
+                publishReplyDraftSuggestionIfEligible(mailAccount, event, context);
+            }
 
-            if (!isOutbound && notificationShouldSend) {
+            if (!isOutbound && labelApplyResult.notificationShouldSend()) {
                 sendFcmPush(context);
             }
         });
@@ -94,14 +93,14 @@ public class MessageAddedHistoryEventHandler {
                 .anyMatch(address -> connectedEmail.equalsIgnoreCase(address.trim()));
     }
 
-    private boolean applyLabelsAndCheckNotification(NewMailPushContext context, List<Label> activeLabels) {
+    private LabelApplyResult applyLabelsAndResolveResult(NewMailPushContext context, List<Label> activeLabels) {
         try {
             Message message = labelQueryService.findActiveMessageWithLabelsById(context.messageId())
                     .orElse(null);
 
             if (message == null) {
                 log.warn("Message not found for labeling: messageId={}", context.messageId());
-                return true;
+                return LabelApplyResult.empty();
             }
 
             Set<UUID> messageIdsWithAttachments = Set.of();
@@ -120,13 +119,17 @@ public class MessageAddedHistoryEventHandler {
             messageLabelCommandService.applyLabels(List.of(message), labelsByMessageId, activeLabelIds);
 
             List<Label> matchedLabels = labelsByMessageId.getOrDefault(context.messageId(), List.of());
-            return resolveNotification(matchedLabels);
+            return new LabelApplyResult(resolveNotification(matchedLabels), hasSensitiveLabel(matchedLabels));
 
         } catch (Exception e) {
             log.warn("Label apply failed for messageId={} — falling back to send FCM push. error={}",
                     context.messageId(), e.getMessage());
-            return true;
+            return new LabelApplyResult(true, true);
         }
+    }
+
+    private boolean hasSensitiveLabel(List<Label> matchedLabels) {
+        return matchedLabels.stream().anyMatch(Label::isSensitive);
     }
 
     private boolean resolveNotification(List<Label> matchedLabels) {
@@ -144,6 +147,13 @@ public class MessageAddedHistoryEventHandler {
             fcmPushCommandService.sendNewMailPush(context);
         } catch (Exception e) {
             log.warn("FCM push skipped due to unexpected error: mailAccountId={} error={}", context.mailAccountId(), e.getMessage());
+        }
+    }
+
+    private record LabelApplyResult(boolean notificationShouldSend, boolean hasSensitiveLabel) {
+
+        private static LabelApplyResult empty() {
+            return new LabelApplyResult(true, false);
         }
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionCommandService.java
@@ -57,7 +57,7 @@ public class ReplyDraftSuggestionCommandService {
         if (messageId == null) {
             throw new MqException(MqErrorCode.INVALID_REPLY_DRAFT_SUGGESTION_MESSAGE);
         }
-        com.mailsangja.db.entity.mail.Message message = messageRepositoryPort.findByIdIncludingDeleted(messageId)
+        com.mailsangja.db.entity.mail.Message message = messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId)
                 .orElseThrow(() -> new MqException(MqErrorCode.INVALID_REPLY_DRAFT_SUGGESTION_MESSAGE));
         if (message.isDeleted()) {
             throw new MqException(MqErrorCode.INVALID_REPLY_DRAFT_SUGGESTION_MESSAGE);

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionQueryService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionQueryService.java
@@ -119,7 +119,7 @@ public class ReplyDraftSuggestionQueryService {
         if (messageId == null) {
             throw new MqException(MqErrorCode.INVALID_REPLY_DRAFT_SUGGESTION_MESSAGE);
         }
-        Message message = messageRepositoryPort.findByIdIncludingDeleted(messageId)
+        Message message = messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId)
                 .orElseThrow(() -> new MqException(MqErrorCode.INVALID_REPLY_DRAFT_SUGGESTION_MESSAGE));
         if (message.isDeleted()) {
             throw new MqException(MqErrorCode.INVALID_REPLY_DRAFT_SUGGESTION_MESSAGE);
@@ -128,7 +128,7 @@ public class ReplyDraftSuggestionQueryService {
     }
 
     private List<ReplyDraftSuggestionContextResult> findThread(Message latestMessage) {
-        List<Message> messages = messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
+        List<Message> messages = messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullAndSensitiveLabelsExcluded(
                 latestMessage.getThread().getMailAccount().getId(),
                 latestMessage.getThread().getGmailThreadId()
         );

--- a/worker/src/test/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandlerTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/handler/mail/MessageAddedHistoryEventHandlerTest.java
@@ -387,6 +387,49 @@ class MessageAddedHistoryEventHandlerTest {
         verify(fcmPushCommandService).sendNewMailPush(context);
     }
 
+    @Test
+    void handle_민감라벨이매칭되면답장추천메시지를발행하지않는다() {
+        UUID userId = UUID.randomUUID();
+        UUID mailAccountId = UUID.randomUUID();
+        UUID messageId = UUID.randomUUID();
+        MailAccount mailAccount = createMailAccount(userId, mailAccountId);
+        GmailHistoryEvent event = createEvent(mailAccountId);
+        NewMailPushContext context = new NewMailPushContext(
+                mailAccountId,
+                "Alice",
+                "subject",
+                "snippet",
+                UUID.randomUUID(),
+                messageId,
+                Direction.INBOUND,
+                List.of("alice@example.com"),
+                1
+        );
+        Label sensitiveLabel = createLabel(NotificationPolicy.INHERIT, true);
+        Message message = Message.builder()
+                .id(messageId)
+                .gmailMessageId("gmail-message-1")
+                .build();
+
+        when(gmailNewMessageSyncCommandService.syncNewMessage(mailAccount, event)).thenReturn(Optional.of(context));
+        when(labelQueryService.findAllActiveByUserId(userId)).thenReturn(List.of(sensitiveLabel));
+        when(labelQueryService.findActiveMessageWithLabelsById(messageId)).thenReturn(Optional.of(message));
+        when(attachmentRepositoryPort.findAllByMessageIdAndDeletedAtIsNull(messageId)).thenReturn(List.of());
+        when(labelRuleCompiler.compile(List.of(sensitiveLabel), new MessageBatch(List.of(message), Set.of())))
+                .thenReturn(Map.of(messageId, List.of(sensitiveLabel)));
+
+        handler.handle(mailAccount, event);
+
+        verify(messageLabelCommandService).applyLabels(
+                List.of(message),
+                Map.of(messageId, List.of(sensitiveLabel)),
+                Set.of(sensitiveLabel.getId())
+        );
+        verifyNoInteractions(replyDraftSuggestionQueryService);
+        verifyNoInteractions(replyDraftSuggestionPublisher);
+        verify(fcmPushCommandService).sendNewMailPush(context);
+    }
+
     private MailAccount createMailAccount(UUID userId, UUID mailAccountId) {
         User user = User.builder()
                 .id(userId)
@@ -418,12 +461,17 @@ class MessageAddedHistoryEventHandlerTest {
     }
 
     private Label createLabel(NotificationPolicy notificationPolicy) {
+        return createLabel(notificationPolicy, false);
+    }
+
+    private Label createLabel(NotificationPolicy notificationPolicy, boolean isSensitive) {
         return Label.builder()
                 .id(UUID.randomUUID())
                 .name("label")
                 .colorCode("#111111")
                 .notificationPolicy(notificationPolicy)
                 .displayOrder(1)
+                .isSensitive(isSensitive)
                 .build();
     }
 }

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionCommandServiceTest.java
@@ -61,7 +61,8 @@ class ReplyDraftSuggestionCommandServiceTest {
                 queryService,
                 transactionTemplate
         );
-        when(messageRepositoryPort.findByIdIncludingDeleted(messageId)).thenReturn(Optional.of(message));
+        when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId))
+                .thenReturn(Optional.of(message));
         when(queryService.existsByMessageId(messageId)).thenReturn(true);
 
         // when
@@ -106,7 +107,8 @@ class ReplyDraftSuggestionCommandServiceTest {
                 queryService,
                 transactionTemplate
         );
-        when(messageRepositoryPort.findByIdIncludingDeleted(messageId)).thenReturn(Optional.of(message));
+        when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId))
+                .thenReturn(Optional.of(message));
         when(queryService.existsByMessageId(messageId)).thenReturn(false);
         when(queryService.createPrompt(eq(messageId), contains("suggestions")))
                 .thenReturn(new ReplyDraftSuggestionPromptResult("system", "user"));
@@ -159,7 +161,8 @@ class ReplyDraftSuggestionCommandServiceTest {
                 queryService,
                 transactionTemplate
         );
-        when(messageRepositoryPort.findByIdIncludingDeleted(messageId)).thenReturn(Optional.of(message));
+        when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId))
+                .thenReturn(Optional.of(message));
         when(queryService.existsByMessageId(messageId)).thenReturn(false);
         when(queryService.createPrompt(eq(messageId), contains("suggestions")))
                 .thenReturn(new ReplyDraftSuggestionPromptResult("system", "user"));
@@ -199,7 +202,8 @@ class ReplyDraftSuggestionCommandServiceTest {
                 queryService,
                 transactionTemplate
         );
-        when(messageRepositoryPort.findByIdIncludingDeleted(messageId)).thenReturn(Optional.of(message));
+        when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId))
+                .thenReturn(Optional.of(message));
         when(queryService.existsByMessageId(messageId)).thenReturn(false);
         when(queryService.createPrompt(eq(messageId), contains("suggestions")))
                 .thenReturn(new ReplyDraftSuggestionPromptResult("system", "user"));
@@ -227,7 +231,8 @@ class ReplyDraftSuggestionCommandServiceTest {
                 queryService,
                 transactionTemplate()
         );
-        when(messageRepositoryPort.findByIdIncludingDeleted(messageId)).thenReturn(Optional.empty());
+        when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId))
+                .thenReturn(Optional.empty());
 
         // when
         MqException exception = assertThrows(MqException.class, () -> service.generate(messageId));
@@ -252,7 +257,8 @@ class ReplyDraftSuggestionCommandServiceTest {
                 queryService,
                 transactionTemplate()
         );
-        when(messageRepositoryPort.findByIdIncludingDeleted(messageId)).thenReturn(Optional.of(message));
+        when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId))
+                .thenReturn(Optional.of(message));
         when(queryService.existsByMessageId(messageId)).thenReturn(false);
         when(queryService.createPrompt(eq(messageId), contains("suggestions")))
                 .thenReturn(new ReplyDraftSuggestionPromptResult("system", "user"));

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionQueryServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionQueryServiceTest.java
@@ -138,8 +138,12 @@ class ReplyDraftSuggestionQueryServiceTest {
         );
 
         ReplyDraftSuggestionQueryService service = createService();
-        when(messageRepositoryPort.findByIdIncludingDeleted(latestMessageId)).thenReturn(Optional.of(latestMessage));
-        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, "gmail-thread-1"))
+        when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(latestMessageId))
+                .thenReturn(Optional.of(latestMessage));
+        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullAndSensitiveLabelsExcluded(
+                mailAccountId,
+                "gmail-thread-1"
+        ))
                 .thenReturn(threadMessages);
         when(referenceQueryPort.findWrittenMessagesByHints(any(), any(), any(), any(Integer.class)))
                 .thenReturn(List.of(sameRecipientSent));
@@ -185,8 +189,12 @@ class ReplyDraftSuggestionQueryServiceTest {
                 LocalDateTime.now()
         );
         ReplyDraftSuggestionQueryService service = createService();
-        when(messageRepositoryPort.findByIdIncludingDeleted(latestMessageId)).thenReturn(Optional.of(latestMessage));
-        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, "gmail-thread-1"))
+        when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(latestMessageId))
+                .thenReturn(Optional.of(latestMessage));
+        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullAndSensitiveLabelsExcluded(
+                mailAccountId,
+                "gmail-thread-1"
+        ))
                 .thenReturn(List.of(latestMessage));
         when(referenceQueryPort.findWrittenMessagesByHints(any(), any(), any(), any(Integer.class))).thenReturn(List.of());
         when(referenceQueryPort.findRecentWrittenMessages(userId, mailAccountId, 10)).thenReturn(List.of());
@@ -233,8 +241,12 @@ class ReplyDraftSuggestionQueryServiceTest {
                 LocalDateTime.now()
         );
         ReplyDraftSuggestionQueryService service = createService();
-        when(messageRepositoryPort.findByIdIncludingDeleted(latestMessageId)).thenReturn(Optional.of(latestMessage));
-        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, "gmail-thread-1"))
+        when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(latestMessageId))
+                .thenReturn(Optional.of(latestMessage));
+        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullAndSensitiveLabelsExcluded(
+                mailAccountId,
+                "gmail-thread-1"
+        ))
                 .thenReturn(List.of(latestMessage));
         when(referenceQueryPort.findWrittenMessagesByHints(any(), any(), any(), any(Integer.class))).thenReturn(List.of());
         when(referenceQueryPort.findRecentWrittenMessages(userId, mailAccountId, 10)).thenReturn(List.of());


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#17

### 📌 Task
- Closes #140


## 💡 작업 내용

- 라벨에 `isSensitive` 필드를 추가해 사용자가 라벨 생성/수정 시 AI 기능 제외 여부를 지정할 수 있도록 했습니다.
- 라벨 목록/상세/제안 승인/인박스 조회 응답에 민감 라벨 여부를 포함하도록 API 응답을 확장했습니다.
- 메일 초안 생성, 라벨 AI 제안, 답장 초안 추천에서 `isSensitive = true` 라벨이 하나라도 붙은 메일을 AI 전달 대상에서 제외했습니다.
- 새 INBOUND 메일 수신 직후 답장 초안 추천 MQ 발행 전에 라벨을 먼저 적용하고, 매칭된 라벨 중 민감 라벨이 있으면 추천 생성 메시지를 발행하지 않도록 했습니다.


## 📝 추가 설명

### 1. 민감 라벨 모델 및 API 확장

- `labels.is_sensitive` 컬럼과 `Label.isSensitive` 필드를 추가했습니다.
- 라벨 생성 요청에서 `isSensitive`가 없으면 기본값은 `false`입니다.
- 라벨 수정 요청에서 `isSensitive`가 `null`이면 기존 값을 유지하고, `true`/`false`가 들어오면 해당 값으로 변경합니다.
- 라벨 목록/상세 응답과 인박스 thread/message 라벨 요약 응답에 `isSensitive`를 포함했습니다.

| API | 변경 내용 |
| --- | --- |
| `POST /api/v1/labels` | `isSensitive` 지정 가능 |
| `PATCH /api/v1/labels/{labelId}` | `isSensitive` 변경 가능 |
| `GET /api/v1/labels` | 라벨별 `isSensitive` 반환 |
| `GET /api/v1/labels/{labelId}` | 라벨 상세 `isSensitive` 반환 |
| 인박스 목록/상세 조회 | 라벨 요약에 `isSensitive` 포함 |

### 2. AI 메일 조회 제외 정책

민감 처리 기준은 메일 단위입니다.

메일에 여러 라벨이 붙어 있을 수 있으므로, 그 중 하나라도 `isSensitive = true`이면 해당 메일은 AI 기능에서 제외합니다.

```mermaid
flowchart LR
    A[AI 기능에서 메일 조회] --> B[message_labels 조회]
    B --> C{민감 라벨 존재?}
    C -- 있음 --> D[AI 전달 대상에서 제외]
    C -- 없음 --> E[마스킹/본문 가공 후 AI 전달]
```

적용된 AI 기능은 다음과 같습니다.

| AI 기능 | 제외 방식 |
| --- | --- |
| 메일 초안 생성 | RAG 후보 ID를 DB에서 다시 조회할 때 민감 라벨 메일 제외 |
| 라벨 AI 제안 | 최근 INBOUND 메일 조회 시 민감 라벨 메일 제외 |
| 답장 초안 추천 | 대상 메일, thread 문맥, 과거 작성 메일 조회 시 민감 라벨 메일 제외 |

### 3. 답장 초안 추천 생성 순서 변경

기존에는 새 메일 수신 후 답장 초안 추천 MQ를 먼저 발행하고, 그 다음 라벨을 적용했습니다.

이 경우 자동 라벨 규칙으로 민감 라벨이 붙을 메일도, MQ consumer가 먼저 실행되면 라벨 적용 전에 AI 생성 흐름으로 들어갈 수 있었습니다.

변경 후에는 다음 순서로 처리합니다.

```mermaid
sequenceDiagram
    participant Gmail as Gmail History
    participant Worker as MessageAddedHistoryEventHandler
    participant Label as Label Rule
    participant MQ as ReplyDraftSuggestion MQ
    participant AI as Reply Draft Worker

    Gmail->>Worker: 새 INBOUND 메일 이벤트
    Worker->>Worker: 메일 동기화 및 저장
    Worker->>Label: 활성 라벨 조회 및 규칙 적용
    Label-->>Worker: 매칭 라벨 반환
    alt 민감 라벨 매칭
        Worker-->>MQ: 발행하지 않음
    else 민감 라벨 없음
        Worker->>MQ: 답장 초안 추천 메시지 발행
        MQ->>AI: 추천 생성
    end
```

라벨 적용 중 예외가 발생하면 FCM 알림은 기존처럼 fallback으로 발송하지만, AI 큐 발행은 보수적으로 막습니다.

### 4. Vector Search 필터링 방식

메일 초안 생성의 vector search는 먼저 vector store에서 유사도 기반 후보 message ID를 가져온 뒤, 해당 ID 목록을 DB에서 다시 조회하면서 민감 라벨 메일을 제외합니다.

DB 재조회 단계에서 `message_labels -> labels.is_sensitive`를 기준으로 확인하는 이유는 DB가 최신 라벨 상태의 source of truth이기 때문입니다.

vector metadata로 민감 여부를 필터링하지 않은 이유는 라벨 상태가 이후에도 계속 바뀔 수 있기 때문입니다.

- 메일에 라벨이 추가/삭제될 수 있습니다.
- 라벨의 `isSensitive` 값이 `false -> true` 또는 `true -> false`로 바뀔 수 있습니다.
- 이 변화를 vector metadata에도 매번 동기화하려면 라벨 수정, 라벨 적용, 라벨 제거, 재분류 흐름마다 vector store 갱신 처리가 필요합니다.
- 동기화 누락 시 DB와 vector metadata가 달라져 민감 메일 차단 정책이 깨질 수 있습니다.

따라서 현재 구현은 DB 기준 필터링을 선택했습니다.

단, vector search 이후 DB 필터링을 수행하므로 민감 메일이 후보에 많이 포함되면 최종 컨텍스트 수가 최초 top-k보다 줄어들 수 있습니다. 이 부분은 필요하면 추후 over-fetch 또는 재검색 방식으로 보완할 수 있습니다.

### 5. 라벨 AI 제안 응답 처리

LLM이 반환하는 라벨 제안 DTO에는 `isSensitive` 필드가 없습니다.

민감 라벨은 사용자가 직접 지정해야 하는 값이므로, 프롬프트에는 민감 라벨 생성을 요구하지 않고 기본 제안은 일반 라벨로 저장됩니다. 사용자가 제안을 승인하거나 라벨을 수정할 때 `isSensitive`를 직접 지정할 수 있습니다.


## ⚡️ Test 결과

| 라벨/인박스/API 응답 | AI 조회 제외 | 답장 초안 추천 |
| -- | -- | -- |
| `core` label/inbox 관련 테스트 | `core` AI 관련 테스트 | `worker` reply draft/handler 테스트 |
| `./gradlew :core:test --tests "com.mailsangja.core.service.label.*" --tests "com.mailsangja.core.facade.LabelFacadeTest" --tests "com.mailsangja.core.service.inbox.*" --tests "com.mailsangja.core.dto.inbox.*" --tests "com.mailsangja.core.service.ai.*"` | 동일 명령 내 `com.mailsangja.core.service.ai.*` | `./gradlew :worker:test --tests "com.mailsangja.worker.service.mail.ReplyDraftSuggestionQueryServiceTest" --tests "com.mailsangja.worker.service.mail.ReplyDraftSuggestionCommandServiceTest" --tests "com.mailsangja.worker.handler.mail.MessageAddedHistoryEventHandlerTest"` |
| `BUILD SUCCESSFUL` | `BUILD SUCCESSFUL` | `BUILD SUCCESSFUL` |
