### PR TITLE
[STORY-102] OAuth Scope 축소

### DIFF
--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -159,7 +159,7 @@ mailsangja:
       scopes:
         - openid
         - email
-        - https://mail.google.com/
+        - https://www.googleapis.com/auth/gmail.modify
         - https://www.googleapis.com/auth/contacts.readonly
         - https://www.googleapis.com/auth/contacts.other.readonly
   google:


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
-  mailsangja/docs4capstone#2

### 📌 Task
- Closes #10


## 💡 작업 내용

- Google OAuth에서 요청하던 Gmail 전체 접근 scope를 `gmail.modify` scope로 축소했습니다.
- 기존 연락처 조회 scope와 기타 연락처 조회 scope는 유지했습니다.
- Gmail 메일 조회, 동기화, 발송, 읽음/안읽음 처리, 라벨/상태 변경, 휴지통 이동/복구 기능은 `gmail.modify` 권한 범위에서 계속 사용할 수 있도록 정리했습니다.


## 📝 추가 설명

### 1. Gmail OAuth scope 축소

기존 설정은 Gmail 전체 접근 권한인 `https://mail.google.com/`을 요청했습니다.

이번 변경에서는 실제 서비스 기능에 필요한 범위에 맞춰 아래 scope로 변경했습니다.

```yaml
- https://www.googleapis.com/auth/gmail.modify
```

변경 전후는 다음과 같습니다.

| 구분 | Scope |
| --- | --- |
| 변경 전 | `https://mail.google.com/` |
| 변경 후 | `https://www.googleapis.com/auth/gmail.modify` |

`https://mail.google.com/`은 Gmail 전체 접근 권한이며 영구 삭제 등 더 넓은 권한을 포함합니다.

현재 서비스는 Gmail API를 통해 메일 조회, 스레드 동기화, 발송, 읽음/안읽음 처리, 라벨/상태 변경, 휴지통 이동/복구를 수행하므로 `gmail.modify`로 권한 범위를 줄였습니다.

### 2. 유지한 Google OAuth scope

메일 계정 연동과 주소록 기반 기능을 위해 아래 scope는 유지합니다.

| Scope | 사용 목적 |
| --- | --- |
| `openid` | Google 계정 연동 과정에서 사용자 식별 |
| `email` | 연동된 Google 계정 이메일 확인 |
| `https://www.googleapis.com/auth/contacts.readonly` | Google 주소록 연락처 조회 |
| `https://www.googleapis.com/auth/contacts.other.readonly` | Google 기타 연락처 조회 |

`contacts.readonly`와 `contacts.other.readonly`는 포함 관계가 아니므로, 기타 연락처까지 조회하기 위해 둘 다 유지합니다.

### 3. 적용 파일

| 파일 | 변경 내용 |
| --- | --- |
| `core/src/main/resources/application.yaml` | Google OAuth Gmail scope를 `https://mail.google.com/`에서 `https://www.googleapis.com/auth/gmail.modify`로 변경 |
