### PR TITLE
[STORY-402] Database Index 구성

### DIFF
--- a/db/src/main/resources/init.sql
+++ b/db/src/main/resources/init.sql
@@ -1,3 +1,5 @@
+-- ── Unique Indexes ────────────────────────────────────────────────────────────
+
 CREATE UNIQUE INDEX IF NOT EXISTS uq_mail_accounts_user_provider_email_active
     ON mail_accounts (user_id, provider, email_address)
     WHERE deleted_at IS NULL;;
@@ -29,6 +31,115 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_orders_webhook_id
 CREATE UNIQUE INDEX IF NOT EXISTS uq_label_groups_user_name_active
     ON label_groups (user_id, lower(name))
     WHERE deleted_at IS NULL;;
+
+-- ── Users ─────────────────────────────────────────────────────────────────────
+
+-- 로그인 시 username 단건 조회
+CREATE INDEX IF NOT EXISTS idx_users_username
+    ON users (username)
+    WHERE deleted_at IS NULL;;
+
+-- ── Mail Accounts ─────────────────────────────────────────────────────────────
+
+-- user_id 기반 계정 목록 (가장 빈번한 패턴)
+CREATE INDEX IF NOT EXISTS idx_mail_accounts_user_id_active
+    ON mail_accounts (user_id)
+    WHERE deleted_at IS NULL;;
+
+-- Pub/Sub webhook 수신 시 email_address로 계정 탐색
+CREATE INDEX IF NOT EXISTS idx_mail_accounts_email_address_active
+    ON mail_accounts (email_address)
+    WHERE deleted_at IS NULL;;
+
+-- user_id + active 조합 조회 (활성 계정 필터링)
+CREATE INDEX IF NOT EXISTS idx_mail_accounts_user_id_active_flag
+    ON mail_accounts (user_id, active)
+    WHERE deleted_at IS NULL;;
+
+-- Gmail watch 갱신 배치: provider + watch_expires_at 범위 스캔
+CREATE INDEX IF NOT EXISTS idx_mail_accounts_renewal_target
+    ON mail_accounts (provider, watch_expires_at)
+    WHERE deleted_at IS NULL;;
+
+-- ── Threads ───────────────────────────────────────────────────────────────────
+
+-- 받은편지함/보낸편지함 목록 + 정렬 핵심 쿼리
+-- (mail_account_id, direction) 필터 후 last_message_at DESC 정렬
+CREATE INDEX IF NOT EXISTS idx_threads_mail_account_direction_last_msg
+    ON threads (mail_account_id, direction, last_message_at DESC)
+    WHERE deleted_at IS NULL;;
+
+-- 읽지 않은 스레드 카운트 (mail_account_id + read 필터)
+CREATE INDEX IF NOT EXISTS idx_threads_mail_account_read
+    ON threads (mail_account_id, read)
+    WHERE deleted_at IS NULL;;
+
+-- ── Messages ──────────────────────────────────────────────────────────────────
+
+-- thread_id 기반 메시지 목록 (핵심 FK 조회)
+CREATE INDEX IF NOT EXISTS idx_messages_thread_id_active
+    ON messages (thread_id)
+    WHERE deleted_at IS NULL;;
+
+-- ── Attachments ───────────────────────────────────────────────────────────────
+
+-- message_id 기반 첨부파일 목록
+CREATE INDEX IF NOT EXISTS idx_attachments_message_id_active
+    ON attachments (message_id)
+    WHERE deleted_at IS NULL;;
+
+-- ── Message Labels ────────────────────────────────────────────────────────────
+
+-- label_id 역방향 조회 (레이블별 메시지·스레드 필터링)
+-- 복합 PK가 (message_id, label_id) 순서이므로 label_id 단독 인덱스 필요
+CREATE INDEX IF NOT EXISTS idx_message_labels_label_id
+    ON message_labels (label_id);;
+
+-- ── Labels ────────────────────────────────────────────────────────────────────
+
+-- user_id 기반 레이블 목록
+CREATE INDEX IF NOT EXISTS idx_labels_user_id_active
+    ON labels (user_id)
+    WHERE deleted_at IS NULL;;
+
+-- ── Label Groups ──────────────────────────────────────────────────────────────
+
+-- user_id 기반 그룹 목록
+CREATE INDEX IF NOT EXISTS idx_label_groups_user_id_active
+    ON label_groups (user_id)
+    WHERE deleted_at IS NULL;;
+
+-- label_id 역방향 조회 (레이블이 속한 그룹 탐색)
+-- 복합 PK가 (label_group_id, label_id) 순서이므로 label_id 단독 인덱스 필요
+CREATE INDEX IF NOT EXISTS idx_label_group_labels_label_id
+    ON label_group_labels (label_id);;
+
+-- ── Contacts ──────────────────────────────────────────────────────────────────
+
+-- user_id 기반 연락처 목록
+CREATE INDEX IF NOT EXISTS idx_contacts_user_id_active
+    ON contacts (user_id)
+    WHERE deleted_at IS NULL;;
+
+-- ── Reply Draft Suggestions ───────────────────────────────────────────────────
+
+-- message_id 기반 AI 답장 초안 조회 및 삽입 잠금
+CREATE INDEX IF NOT EXISTS idx_reply_draft_suggestions_message_id_active
+    ON reply_draft_suggestions (message_id)
+    WHERE deleted_at IS NULL;;
+
+-- ── User Devices ──────────────────────────────────────────────────────────────
+
+-- user_id 기반 FCM 디바이스 목록 (푸시 알림 발송)
+CREATE INDEX IF NOT EXISTS idx_user_devices_user_id_active
+    ON user_devices (user_id)
+    WHERE deleted_at IS NULL;;
+
+-- ── Orders ────────────────────────────────────────────────────────────────────
+
+-- user_id 기반 주문 이력 조회
+CREATE INDEX IF NOT EXISTS idx_orders_user_id
+    ON orders (user_id);;
 
 -- ── Full-Text Search (Korean) ────────────────────────────────────────────────
 

--- a/db/src/main/resources/init.sql
+++ b/db/src/main/resources/init.sql
@@ -51,9 +51,9 @@ CREATE INDEX IF NOT EXISTS idx_mail_accounts_email_address_active
     ON mail_accounts (email_address)
     WHERE deleted_at IS NULL;;
 
--- user_id + active 조합 조회 (활성 계정 필터링)
+-- user_id + is_active 조합 조회 (활성 계정 필터링)
 CREATE INDEX IF NOT EXISTS idx_mail_accounts_user_id_active_flag
-    ON mail_accounts (user_id, active)
+    ON mail_accounts (user_id, is_active)
     WHERE deleted_at IS NULL;;
 
 -- Gmail watch 갱신 배치: provider + watch_expires_at 범위 스캔
@@ -69,9 +69,9 @@ CREATE INDEX IF NOT EXISTS idx_threads_mail_account_direction_last_msg
     ON threads (mail_account_id, direction, last_message_at DESC)
     WHERE deleted_at IS NULL;;
 
--- 읽지 않은 스레드 카운트 (mail_account_id + read 필터)
+-- 읽지 않은 스레드 카운트 (mail_account_id + is_read 필터)
 CREATE INDEX IF NOT EXISTS idx_threads_mail_account_read
-    ON threads (mail_account_id, read)
+    ON threads (mail_account_id, is_read)
     WHERE deleted_at IS NULL;;
 
 -- ── Messages ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#17

### 📌 Task
- Closes #76


## 💡 작업 내용

- Database Index 구성

## 📝 추가 설명


## Unique Indexes

### `uq_mail_accounts_user_provider_email_active`
```sql
ON mail_accounts (user_id, provider, email_address) WHERE deleted_at IS NULL
```
같은 사용자가 동일 벤더의 동일 이메일 계정을 중복 등록하는 것을 방지합니다.
소프트 딜리트된 계정은 제약에서 제외해, 삭제 후 재등록이 가능합니다.

### `uq_user_devices_fcm_token_active`
```sql
ON user_devices (fcm_token) WHERE deleted_at IS NULL
```
FCM 토큰은 디바이스 고유 식별자입니다. 동일 토큰이 여러 사용자에게 중복 등록되면 다른 사용자에게 푸시 알림이 전송되는 버그가 발생합니다.

### `uq_threads_account_gmail_direction`
```sql
ON threads (mail_account_id, gmail_thread_id, direction)
```
Gmail 스레드 ID는 계정 내에서 유일하지만, 동일 스레드를 받은편지함(INBOUND)·보낸편지함(OUTBOUND) 양쪽에서 표현할 수 있어 `direction`을 포함합니다.
소프트 딜리트 없이 전체 행에 적용해 복원(restore) 시에도 중복을 방지합니다.

### `uq_gmail_thread_locks_account_thread`
```sql
ON gmail_thread_locks (mail_account_id, gmail_thread_id)
```
동일 Gmail 스레드에 대한 동시 동기화 작업 충돌을 막기 위한 비관적 잠금 테이블의 유니크 제약입니다.

### `uq_messages_thread_gmail`
```sql
ON messages (thread_id, gmail_message_id)
```
Gmail 메시지 ID는 전역 고유값이지만, 스레드 컨텍스트 내에서 중복 삽입되는 것을 방지하기 위해 `thread_id`와 조합합니다.

### `uq_contacts_user_email_active`
```sql
ON contacts (user_id, lower(email)) WHERE deleted_at IS NULL
```
같은 사용자가 동일 이메일의 연락처를 중복 등록하지 못하도록 합니다.
`lower(email)`로 대소문자를 정규화해 `A@b.com`과 `a@B.com`을 동일 이메일로 처리합니다.

### `uq_labels_user_name_active`
```sql
ON labels (user_id, lower(name)) WHERE deleted_at IS NULL
```
같은 사용자 내에서 레이블 이름 중복을 방지합니다.
`lower(name)`으로 대소문자 무시 비교를 적용합니다.

### `uq_orders_webhook_id`
```sql
ON orders (webhook_id)
```
결제 webhook의 멱등성을 보장합니다. 동일 `webhook_id`로 중복 결제 처리가 발생하지 않도록 DB 레벨에서 차단합니다.

### `uq_label_groups_user_name_active`
```sql
ON label_groups (user_id, lower(name)) WHERE deleted_at IS NULL
```
`uq_labels_user_name_active`와 동일한 이유로, 레이블 그룹 이름의 사용자 내 중복을 방지합니다.

---

## 일반 인덱스 — 테이블별

### users

#### `idx_users_username`
```sql
ON users (username) WHERE deleted_at IS NULL
```
사용자 로그인 시 `username`으로 단건 조회(`findByUsername`)하는 쿼리가 모든 API 요청의 인증 과정에서 실행됩니다.
인덱스 없이는 전체 테이블 스캔이 발생합니다.

---

### mail_accounts

#### `idx_mail_accounts_user_id_active`
```sql
ON mail_accounts (user_id) WHERE deleted_at IS NULL
```
사용자의 연동 계정 목록을 가져오는 `findAllByUserIdAndDeletedAtIsNull`이 거의 모든 API에서 호출됩니다.
가장 기본적이고 빈번한 조회 패턴입니다.

#### `idx_mail_accounts_email_address_active`
```sql
ON mail_accounts (email_address) WHERE deleted_at IS NULL
```
Gmail Pub/Sub webhook 수신 시, 이메일 주소로 해당 `MailAccount`를 찾는 `findByEmailAddressAndDeletedAtIsNull`에 사용됩니다.
메일 동기화의 진입점이므로 응답 속도가 중요합니다.

#### `idx_mail_accounts_user_id_active_flag`
```sql
ON mail_accounts (user_id, active) WHERE deleted_at IS NULL
```
`findAllByUserIdAndActiveAndDeletedAtIsNull`처럼 활성 계정만 필터링하는 쿼리에 사용됩니다.
`idx_mail_accounts_user_id_active`와 컬럼이 겹치지만, `active` 조건이 추가되어 선택도가 더 높습니다.

#### `idx_mail_accounts_renewal_target`
```sql
ON mail_accounts (provider, watch_expires_at) WHERE deleted_at IS NULL
```
Gmail watch를 갱신하는 백그라운드 배치 작업(`findRenewalTargetGmailAccounts`)이 `provider = GMAIL AND watch_expires_at < now() + interval` 조건으로 범위 스캔을 수행합니다.
이 인덱스가 없으면 배치 실행마다 전체 계정 테이블을 스캔합니다.

---

### threads

#### `idx_threads_mail_account_direction_last_msg`
```sql
ON threads (mail_account_id, direction, last_message_at DESC) WHERE deleted_at IS NULL
```
받은편지함·보낸편지함 목록 조회의 핵심 인덱스입니다.

쿼리 패턴:
```sql
WHERE mail_account_id = ? AND direction = ? AND deleted_at IS NULL
ORDER BY last_message_at DESC
```

컬럼 순서 설명:
- `mail_account_id`: 계정 필터 (등호, 선두 배치)
- `direction`: INBOUND/OUTBOUND 필터 (등호)
- `last_message_at DESC`: 최신순 정렬을 인덱스 스캔 순서로 처리해 filesort 회피

`WHERE deleted_at IS NULL` partial index로 삭제된 스레드를 인덱스에서 제외합니다.

#### `idx_threads_mail_account_read`
```sql
ON threads (mail_account_id, read) WHERE deleted_at IS NULL
```
읽지 않은 스레드 수를 카운트하는 `countUnreadInboxByUserId` 등의 쿼리에 사용됩니다.
`mail_account_id`로 계정을 특정한 후 `read = false`만 카운트하므로, 정렬 컬럼 없이 `(mail_account_id, read)` 조합으로 충분합니다.

---

### messages

#### `idx_messages_thread_id_active`
```sql
ON messages (thread_id) WHERE deleted_at IS NULL
```
스레드 상세 조회 시 해당 스레드의 메시지 목록을 가져오는 `findAllByThreadIdAndDeletedAtIsNull`이 가장 빈번하게 실행됩니다.
`thread_id`는 `messages` 테이블의 FK이며, JPA는 FK 인덱스를 자동 생성하지 않습니다.

---

### attachments

#### `idx_attachments_message_id_active`
```sql
ON attachments (message_id) WHERE deleted_at IS NULL
```
메시지 조회 시 첨부파일 목록을 함께 로딩하는 `findAllByMessageIdAndDeletedAtIsNull`에 사용됩니다.
`message_id`도 FK이므로 명시적 인덱스가 필요합니다.

---

### message_labels

#### `idx_message_labels_label_id`
```sql
ON message_labels (label_id)
```
`message_labels` 테이블의 복합 PK는 `(message_id, label_id)` 순서입니다.
PostgreSQL은 복합 PK로 `message_id` 선두 인덱스만 생성하므로, `label_id`만으로 조회하는 쿼리(레이블별 메시지 필터링)는 전체 테이블 스캔이 됩니다.
레이블 기반 스레드 목록 조회(`findInboxByUserIdAndLabelIdsAndDeletedAtIsNull` 등)가 이 인덱스를 사용합니다.

---

### labels

#### `idx_labels_user_id_active`
```sql
ON labels (user_id) WHERE deleted_at IS NULL
```
레이블 목록 조회(`findAllByUserIdAndDeletedAtIsNull`), 읽지 않은 스레드 수 집계(`findUnreadThreadCountsByUserId`) 등 레이블 관련 쿼리가 모두 `user_id`를 기준으로 조회합니다.

---

### label_groups

#### `idx_label_groups_user_id_active`
```sql
ON label_groups (user_id) WHERE deleted_at IS NULL
```
레이블 그룹 목록 조회(`findAllByUserIdAndDeletedAtIsNullOrderByDisplayOrder`)에 사용됩니다.

---

### label_group_labels

#### `idx_label_group_labels_label_id`
```sql
ON label_group_labels (label_id)
```
`label_group_labels`의 복합 PK는 `(label_group_id, label_id)` 순서입니다.
`findActiveGroupsByLabelId`처럼 특정 레이블이 속한 그룹을 역방향으로 탐색할 때 `label_id` 단독 인덱스가 필요합니다.
레이블 삭제 시 관련 그룹을 연쇄 처리하는 경우에도 사용됩니다.

---

### contacts

#### `idx_contacts_user_id_active`
```sql
ON contacts (user_id) WHERE deleted_at IS NULL
```
연락처 목록 조회, 수신자 자동완성 검색 모두 `user_id`를 기준으로 시작합니다.

---

### reply_draft_suggestions

#### `idx_reply_draft_suggestions_message_id_active`
```sql
ON reply_draft_suggestions (message_id) WHERE deleted_at IS NULL
```
AI 답장 초안을 조회하는 `findAllByMessageIdAndDeletedAtIsNull`과, 중복 삽입을 막는 `insertIfActiveCountBelowLimit`(내부적으로 `FOR UPDATE` 잠금 사용)이 모두 `message_id`를 기준으로 합니다.
잠금 대상 행을 빠르게 찾지 못하면 불필요한 테이블 잠금이 발생할 수 있습니다.

---

### user_devices

#### `idx_user_devices_user_id_active`
```sql
ON user_devices (user_id) WHERE deleted_at IS NULL
```
`findAllByMailAccountIdAndDeletedAtIsNull`은 내부적으로 `mail_accounts`와 JOIN해 `user_id`로 디바이스를 조회합니다.
푸시 알림 발송 경로에 있으므로 지연이 발생하면 실시간성이 저하됩니다.

---

### orders

#### `idx_orders_user_id`
```sql
ON orders (user_id)
```
사용자의 결제 이력 조회에 사용됩니다.
`orders`는 소프트 딜리트보다 상태(`status: PENDING/COMPLETED`)로 관리되므로 partial index를 적용하지 않습니다.

---

## Full-Text Search 인덱스

### 한국어 (tsvector / GIN)

#### `idx_messages_search_vector`
```sql
ON messages USING GIN(search_vector)
```
`messages.search_vector` 컬럼은 `subject`, `from_name`, `body_text`, `to_names`, `cc_names`를 한국어 형태소 분석기(`korean` 사전)로 변환한 `tsvector`입니다.
GIN 인덱스는 `@@` 연산자(전문 검색)에 최적화되어 있습니다.
트리거(`trg_messages_search_vector`)가 INSERT/UPDATE 시 자동으로 갱신합니다.

#### `idx_attachments_filename_vector`
```sql
ON attachments USING GIN(filename_vector)
```
첨부파일명을 한국어 형태소로 분석한 `filename_vector`에 대한 GIN 인덱스입니다.
파일명 검색 쿼리에서 `@@` 연산자로 활용됩니다.

#### `idx_threads_last_message_at`
```sql
ON threads(last_message_at DESC)
```
검색 결과를 최신순으로 정렬할 때 사용됩니다.
`idx_threads_mail_account_direction_last_msg`가 받은함/보낸함 목록에서 정렬을 처리하지만, 검색 결과처럼 계정 필터 없이 날짜만으로 정렬하는 경우를 위해 단독 인덱스를 유지합니다.

---

### 영어 (pg_trgm / GIN)

> `pg_trgm` 확장은 `extensions.sql`(docker-entrypoint-initdb.d)에서 superuser 권한으로 설치됩니다.

#### `idx_messages_search_text_trgm`
```sql
ON messages USING GIN(search_text gin_trgm_ops)
```
`messages.search_text`는 `subject`, `from_name`, `to_names`, `cc_names`, `body_text` 앞 5,000자를 소문자로 정규화한 텍스트 컬럼입니다.

트라이그램 GIN 인덱스는 `ILIKE '%keyword%'` 또는 `% 'keyword' %` (similarity) 패턴의 부분 문자열 검색을 인덱스로 처리할 수 있습니다.
한국어 FTS와 달리 형태소 분석 없이 대소문자 무시 부분 일치를 지원합니다.

`body_text`를 5,000자로 제한하는 이유: 긴 본문을 그대로 인덱싱하면 GIN 인덱스 항목이 폭발적으로 증가해 인덱스 크기와 업데이트 비용이 과도하게 커집니다.

#### `idx_attachments_filename_trgm`
```sql
ON attachments USING GIN(lower(filename) gin_trgm_ops)
```
첨부파일명에 대한 대소문자 무시 부분 검색(`ILIKE`)을 인덱스로 처리합니다.
`lower(filename)`을 인덱스 표현식으로 사용해, 쿼리에서도 `lower(filename) ILIKE ?` 형태를 유지해야 인덱스가 활용됩니다.
