### PR TITLE
[STORY-201] 스레드 내 메세지 개수 버그 수정

### DIFF
--- a/core/src/main/java/com/mailsangja/core/service/google/GoogleMailMessageQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/google/GoogleMailMessageQueryService.java
@@ -311,7 +311,16 @@ public class GoogleMailMessageQueryService {
 
     private AttachmentDisposition resolveDisposition(GoogleMailMessageResponse.GoogleMailPayloadResponse part) {
         String disposition = extractPartHeaderValue(part, "Content-Disposition");
-        if (!isBlank(disposition) && disposition.trim().toLowerCase().startsWith("inline")) {
+        String normalizedDisposition = disposition == null ? null : disposition.trim().toLowerCase();
+        if (!isBlank(normalizedDisposition) && normalizedDisposition.startsWith("attachment")) {
+            return AttachmentDisposition.ATTACHMENT;
+        }
+
+        if (!isInlineImage(part)) {
+            return AttachmentDisposition.ATTACHMENT;
+        }
+
+        if (!isBlank(normalizedDisposition) && normalizedDisposition.startsWith("inline")) {
             return AttachmentDisposition.INLINE;
         }
 
@@ -320,6 +329,12 @@ public class GoogleMailMessageQueryService {
         }
 
         return AttachmentDisposition.ATTACHMENT;
+    }
+
+    private boolean isInlineImage(GoogleMailMessageResponse.GoogleMailPayloadResponse part) {
+        return part != null
+                && part.mimeType() != null
+                && part.mimeType().trim().toLowerCase().startsWith("image/");
     }
 
     private String normalizeContentId(String contentId) {

--- a/core/src/main/java/com/mailsangja/core/service/mail/MailCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/mail/MailCommandService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -45,7 +46,10 @@ public class MailCommandService {
         );
 
         if (inserted) {
-            thread.updateMessageCount(thread.getMessageCount() + 1);
+            synchronizeThreadMessageCount(
+                    command.mailAccount().getId(),
+                    command.messageResult().gmailThreadId()
+            );
         }
     }
 
@@ -93,6 +97,17 @@ public class MailCommandService {
         message.replaceAttachments(createAttachments(message, command.messageResult().attachments()));
         messageRepositoryPort.save(message);
         return false;
+    }
+
+    private void synchronizeThreadMessageCount(UUID mailAccountId, String gmailThreadId) {
+        int activeCount = messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
+                mailAccountId,
+                gmailThreadId
+        ).size();
+        threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
+                mailAccountId,
+                gmailThreadId
+        ).forEach(thread -> thread.updateMessageCount(activeCount));
     }
 
     private List<Attachment> createAttachments(

--- a/core/src/test/java/com/mailsangja/core/service/google/GoogleMailMessageQueryServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/google/GoogleMailMessageQueryServiceTest.java
@@ -72,6 +72,56 @@ class GoogleMailMessageQueryServiceTest {
         assertEquals(AttachmentDisposition.INLINE, result.attachments().getFirst().disposition());
     }
 
+    @Test
+    void getMessage_contentId가있어도첨부파일Disposition이면Attachment로분류한다() {
+        GoogleMailProperties properties = new GoogleMailProperties();
+        properties.setMessagesUri("https://gmail.googleapis.com/gmail/v1/users/me/messages");
+
+        RestClient restClient = RestClient.builder()
+                .requestFactory(new StubClientHttpRequestFactory("""
+                        {
+                          "id": "message-1",
+                          "threadId": "thread-1",
+                          "snippet": "snippet",
+                          "historyId": "history-1",
+                          "internalDate": "1712822400000",
+                          "payload": {
+                            "mimeType": "multipart/mixed",
+                            "headers": [
+                              {"name": "Subject", "value": "subject"},
+                              {"name": "From", "value": "Alice <alice@example.com>"},
+                              {"name": "To", "value": "Bob <bob@example.com>"},
+                              {"name": "Message-ID", "value": "<message-id@example.com>"}
+                            ],
+                            "parts": [
+                              {
+                                "mimeType": "text/plain",
+                                "body": {"data": "aGVsbG8"}
+                              },
+                              {
+                                "mimeType": "application/haansofthwp",
+                                "filename": "document.hwp",
+                                "headers": [
+                                  {"name": "Content-ID", "value": "<f_mpmdzs8f0>"},
+                                  {"name": "Content-Disposition", "value": "attachment; filename=document.hwp"}
+                                ],
+                                "body": {"attachmentId": "gmail-attachment-id", "size": 100}
+                              }
+                            ]
+                          }
+                        }
+                        """))
+                .build();
+
+        GoogleMailMessageQueryService service = new GoogleMailMessageQueryService(properties, restClient);
+
+        GoogleMailMessageResult result = service.getMessage("token", "message-1");
+
+        assertEquals(1, result.attachments().size());
+        assertEquals("f_mpmdzs8f0", result.attachments().getFirst().contentId());
+        assertEquals(AttachmentDisposition.ATTACHMENT, result.attachments().getFirst().disposition());
+    }
+
     private static final class StubClientHttpRequestFactory extends SimpleClientHttpRequestFactory {
         private final String responseBody;
 

--- a/core/src/test/java/com/mailsangja/core/service/mail/MailCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/mail/MailCommandServiceTest.java
@@ -1,0 +1,149 @@
+package com.mailsangja.core.service.mail;
+
+import com.mailsangja.core.dto.mail.GoogleMailMessageResult;
+import com.mailsangja.core.dto.mail.MailAddressCommand;
+import com.mailsangja.core.dto.mail.MailSendCommand;
+import com.mailsangja.core.dto.mail.MailSendPersistCommand;
+import com.mailsangja.db.entity.mail.Direction;
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.entity.mail.Thread;
+import com.mailsangja.db.port.GmailThreadLockRepositoryPort;
+import com.mailsangja.db.port.MessageRepositoryPort;
+import com.mailsangja.db.port.ThreadRepositoryPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MailCommandServiceTest {
+
+    @Mock
+    private ThreadRepositoryPort threadRepositoryPort;
+
+    @Mock
+    private MessageRepositoryPort messageRepositoryPort;
+
+    @Mock
+    private GmailThreadLockRepositoryPort gmailThreadLockRepositoryPort;
+
+    private MailCommandService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MailCommandService(threadRepositoryPort, messageRepositoryPort, gmailThreadLockRepositoryPort);
+    }
+
+    @Test
+    void saveSentMail_updatesAllDirectionThreadCountsWithFullConversationCount() {
+        MailAccount mailAccount = MailAccount.builder()
+                .id(UUID.randomUUID())
+                .emailAddress("me@example.com")
+                .build();
+        Thread inboundThread = createThread(mailAccount, Direction.INBOUND, 1);
+        Thread outboundThread = createThread(mailAccount, Direction.OUTBOUND, 0);
+        List<Message> activeMessages = new ArrayList<>();
+        activeMessages.add(Message.from(inboundThread, new Message.CreateValues(
+                "message-inbound",
+                null,
+                null,
+                null,
+                null,
+                null,
+                Direction.INBOUND,
+                "inbound subject",
+                "alice@example.com",
+                "Alice",
+                List.of("me@example.com"),
+                List.of("Me"),
+                List.of(),
+                List.of(),
+                "inbound snippet",
+                false,
+                LocalDateTime.of(2026, 4, 11, 10, 0),
+                null,
+                null
+        )));
+
+        when(threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccount.getId(), "gmail-thread-1", Direction.OUTBOUND
+        )).thenReturn(Optional.of(outboundThread));
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageIdAndDeletedAtIsNull(
+                outboundThread.getId(), "message-outbound"
+        )).thenReturn(Optional.empty());
+        when(messageRepositoryPort.save(any(Message.class))).thenAnswer(invocation -> {
+            Message message = invocation.getArgument(0);
+            activeMessages.add(message);
+            return message;
+        });
+        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
+                mailAccount.getId(), "gmail-thread-1"
+        )).thenAnswer(invocation -> List.copyOf(activeMessages));
+        when(threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
+                mailAccount.getId(), "gmail-thread-1"
+        )).thenReturn(List.of(inboundThread, outboundThread));
+
+        service.saveSentMail(new MailSendPersistCommand(
+                mailAccount,
+                new GoogleMailMessageResult(
+                        "message-outbound",
+                        "gmail-thread-1",
+                        "history-1",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        "outbound subject",
+                        "me@example.com",
+                        "Me",
+                        List.of("alice@example.com"),
+                        List.of("Alice"),
+                        List.of(),
+                        List.of(),
+                        "outbound snippet",
+                        LocalDateTime.of(2026, 4, 11, 11, 0),
+                        "body",
+                        null,
+                        List.of()
+                ),
+                new MailSendCommand(
+                        UUID.randomUUID(),
+                        new MailAddressCommand("Me", "me@example.com"),
+                        null,
+                        List.of(new MailAddressCommand("Alice", "alice@example.com")),
+                        List.of(),
+                        List.of(),
+                        "outbound subject",
+                        "body",
+                        List.of()
+                )
+        ));
+
+        assertEquals(2, inboundThread.getMessageCount());
+        assertEquals(2, outboundThread.getMessageCount());
+    }
+
+    private Thread createThread(MailAccount mailAccount, Direction direction, int messageCount) {
+        return Thread.builder()
+                .id(UUID.randomUUID())
+                .mailAccount(mailAccount)
+                .gmailThreadId("gmail-thread-1")
+                .direction(direction)
+                .read(true)
+                .messageCount(messageCount)
+                .build();
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/service/google/GmailMessageApiService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/google/GmailMessageApiService.java
@@ -412,7 +412,16 @@ public class GmailMessageApiService {
 
     private AttachmentDisposition resolveDisposition(GoogleMailThreadResponse.GoogleMailThreadPayloadResponse part) {
         String disposition = extractPartHeaderValue(part, "Content-Disposition");
-        if (!isBlank(disposition) && disposition.trim().toLowerCase().startsWith("inline")) {
+        String normalizedDisposition = disposition == null ? null : disposition.trim().toLowerCase();
+        if (!isBlank(normalizedDisposition) && normalizedDisposition.startsWith("attachment")) {
+            return AttachmentDisposition.ATTACHMENT;
+        }
+
+        if (!isInlineImage(part)) {
+            return AttachmentDisposition.ATTACHMENT;
+        }
+
+        if (!isBlank(normalizedDisposition) && normalizedDisposition.startsWith("inline")) {
             return AttachmentDisposition.INLINE;
         }
 
@@ -421,6 +430,12 @@ public class GmailMessageApiService {
         }
 
         return AttachmentDisposition.ATTACHMENT;
+    }
+
+    private boolean isInlineImage(GoogleMailThreadResponse.GoogleMailThreadPayloadResponse part) {
+        return part != null
+                && part.mimeType() != null
+                && part.mimeType().trim().toLowerCase().startsWith("image/");
     }
 
     private String normalizeContentId(String contentId) {

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
@@ -78,7 +78,7 @@ public class InitialMailSyncCommandService {
         return new InitialMailSyncSaveResult(
                 results.stream().map(ThreadDirectionSaveResult::threadId).toList(),
                 results.stream().flatMap(result -> result.messageIds().stream()).toList(),
-                results.stream().mapToInt(ThreadDirectionSaveResult::messageCount).sum()
+                synchronizeThreadMessageCount(mailAccount.getId(), command.gmailThreadId())
         );
     }
 
@@ -111,7 +111,7 @@ public class InitialMailSyncCommandService {
                 aggregate.read()
         );
         thread.updateMessageCount(aggregate.messageCount());
-        return new ThreadDirectionSaveResult(thread.getId(), savedMessageIds, thread.getMessageCount());
+        return new ThreadDirectionSaveResult(thread.getId(), savedMessageIds);
     }
 
     private void saveMissingMessagesByDirection(
@@ -150,8 +150,22 @@ public class InitialMailSyncCommandService {
         }
 
         if (insertedCount > 0) {
-            thread.updateMessageCount(thread.getMessageCount() + insertedCount);
+            synchronizeThreadMessageCount(mailAccount.getId(), gmailThreadId);
         }
+    }
+
+    private int synchronizeThreadMessageCount(UUID mailAccountId, String gmailThreadId) {
+        List<Message> activeMessages = messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
+                mailAccountId,
+                gmailThreadId
+        );
+        int activeCount = activeMessages.size();
+        List<Thread> threads = threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(
+                mailAccountId,
+                gmailThreadId
+        );
+        threads.forEach(thread -> thread.updateMessageCount(activeCount));
+        return activeCount;
     }
 
     private Optional<UUID> saveMessage(
@@ -238,8 +252,7 @@ public class InitialMailSyncCommandService {
 
     private record ThreadDirectionSaveResult(
             UUID threadId,
-            List<UUID> messageIds,
-            int messageCount
+            List<UUID> messageIds
     ) {
         private ThreadDirectionSaveResult {
             messageIds = messageIds == null ? List.of() : List.copyOf(messageIds);

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
@@ -110,7 +110,6 @@ public class InitialMailSyncCommandService {
                 aggregate.lastMessageAt(),
                 aggregate.read()
         );
-        thread.updateMessageCount(aggregate.messageCount());
         return new ThreadDirectionSaveResult(thread.getId(), savedMessageIds);
     }
 

--- a/worker/src/test/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryServiceTest.java
@@ -101,6 +101,64 @@ class GoogleMailMessageQueryServiceTest {
         assertEquals(AttachmentDisposition.INLINE, results.getFirst().messages().getFirst().attachments().getFirst().disposition());
     }
 
+    @Test
+    void getThreads_contentId가있어도첨부파일Disposition이면Attachment로분류한다() {
+        GoogleMailInitialSyncProperties properties = new GoogleMailInitialSyncProperties();
+        properties.setThreadsUri("https://gmail.googleapis.com/gmail/v1/users/me/threads");
+
+        RestClient restClient = RestClient.builder()
+                .requestFactory(new StubClientHttpRequestFactory("""
+                        {
+                          "id": "thread-1",
+                          "historyId": "history-1",
+                          "messages": [
+                            {
+                              "id": "message-1",
+                              "threadId": "thread-1",
+                              "labelIds": ["INBOX"],
+                              "snippet": "snippet",
+                              "historyId": "history-1",
+                              "internalDate": "1712822400000",
+                              "payload": {
+                                "mimeType": "multipart/mixed",
+                                "headers": [
+                                  {"name": "Subject", "value": "subject"},
+                                  {"name": "From", "value": "Alice <alice@example.com>"},
+                                  {"name": "To", "value": "Bob <bob@example.com>"},
+                                  {"name": "Message-ID", "value": "<message-id@example.com>"}
+                                ],
+                                "parts": [
+                                  {
+                                    "mimeType": "text/plain",
+                                    "body": {"data": "aGVsbG8"}
+                                  },
+                                  {
+                                    "mimeType": "application/haansofthwp",
+                                    "filename": "document.hwp",
+                                    "headers": [
+                                      {"name": "Content-ID", "value": "<f_mpmdzs8f0>"},
+                                      {"name": "Content-Disposition", "value": "attachment; filename=document.hwp"}
+                                    ],
+                                    "body": {"attachmentId": "gmail-attachment-id", "size": 100}
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                        """))
+                .build();
+
+        GmailMessageApiService service = new GmailMessageApiService(properties, restClient);
+
+        List<InitialMailSyncThreadResult> results = service.getThreads("token", List.of("thread-1"));
+
+        assertEquals(1, results.size());
+        assertEquals(1, results.getFirst().messages().getFirst().attachments().size());
+        assertEquals("f_mpmdzs8f0", results.getFirst().messages().getFirst().attachments().getFirst().contentId());
+        assertEquals(AttachmentDisposition.ATTACHMENT, results.getFirst().messages().getFirst().attachments().getFirst().disposition());
+    }
+
     private static final class StubClientHttpRequestFactory extends SimpleClientHttpRequestFactory {
         private final String responseBody;
 

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
@@ -18,7 +18,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -449,6 +451,91 @@ class InitialMailSyncCommandServiceTest {
         // then
         assertEquals(java.util.List.of(thread.getId()), result.threadIds());
         assertEquals(java.util.List.of(messageId), result.messageIds());
+    }
+
+    @Test
+    void saveThreadBatch_updatesAllDirectionThreadCountsWithFullConversationCount() {
+        MailAccount mailAccount = createMailAccount();
+        Thread inboundThread = createThread(mailAccount, "thread-1", Direction.INBOUND);
+        Thread outboundThread = createThread(mailAccount, "thread-1", Direction.OUTBOUND);
+        List<Message> activeMessages = new ArrayList<>();
+
+        when(threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccount.getId(), "thread-1", Direction.INBOUND
+        )).thenReturn(Optional.of(inboundThread));
+        when(threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccount.getId(), "thread-1", Direction.OUTBOUND
+        )).thenReturn(Optional.of(outboundThread));
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageId(inboundThread.getId(), "message-inbound"))
+                .thenReturn(Optional.empty());
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageId(outboundThread.getId(), "message-outbound"))
+                .thenReturn(Optional.empty());
+        when(messageRepositoryPort.save(any(Message.class))).thenAnswer(invocation -> {
+            Message message = invocation.getArgument(0);
+            activeMessages.add(message);
+            return message;
+        });
+        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccount.getId(), "thread-1"))
+                .thenAnswer(invocation -> List.copyOf(activeMessages));
+        when(threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccount.getId(), "thread-1"))
+                .thenReturn(List.of(inboundThread, outboundThread));
+
+        InitialMailSyncSaveResult result = service.saveThreadBatch(mailAccount, List.of(new InitialMailSyncThreadSaveCommand(
+                "thread-1",
+                "history-1",
+                List.of(
+                        new InitialMailSyncMessageSaveCommand(
+                                "message-inbound",
+                                "history-1",
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                Direction.INBOUND,
+                                "inbound subject",
+                                "alice@example.com",
+                                "Alice",
+                                List.of("me@example.com"),
+                                List.of("Me"),
+                                List.of(),
+                                List.of(),
+                                "inbound snippet",
+                                false,
+                                LocalDateTime.of(2026, 4, 11, 10, 0),
+                                "body",
+                                null,
+                                List.of()
+                        ),
+                        new InitialMailSyncMessageSaveCommand(
+                                "message-outbound",
+                                "history-1",
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                Direction.OUTBOUND,
+                                "outbound subject",
+                                "me@example.com",
+                                "Me",
+                                List.of("alice@example.com"),
+                                List.of("Alice"),
+                                List.of(),
+                                List.of(),
+                                "outbound snippet",
+                                true,
+                                LocalDateTime.of(2026, 4, 11, 11, 0),
+                                "body",
+                                null,
+                                List.of()
+                        )
+                )
+        )));
+
+        assertEquals(2, result.threadMessageCount());
+        assertEquals(2, inboundThread.getMessageCount());
+        assertEquals(2, outboundThread.getMessageCount());
     }
 
     private MailAccount createMailAccount() {


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#4
- mailsangja/docs4capstone#11

### 📌 Task
- Related #23
- Related #43


## 💡 작업 내용

- INBOUND/OUTBOUND로 분리 저장되는 `Thread.messageCount`를 같은 Gmail 대화 전체 메시지 수 기준으로 통일했습니다.
- 초기 동기화, 신규 메일 수신, 직접 발신 저장 경로에서 `mailAccountId + gmailThreadId` 기준 active 메시지 수를 재계산하도록 변경했습니다.
- Gmail 첨부파일의 `Content-ID`가 존재해도 `Content-Disposition: attachment`이면 일반 첨부파일로 분류하도록 수정했습니다.
- inline 첨부파일은 `image/*` MIME 타입일 때만 허용하도록 제한했습니다.
- hwp 등 문서 첨부파일에 `Content-ID`가 붙어 inline으로 오분류되는 회귀 케이스를 core/worker 테스트에 추가했습니다.


## 📝 추가 설명

### 1. Thread messageCount 기준 통일

현재 DB 구조는 같은 Gmail thread라도 받은편지함/보낸편지함 표현을 위해 `threads` row를 direction별로 나눕니다.

```sql
UNIQUE (mail_account_id, gmail_thread_id, direction)
```

기존 저장 경로에서는 다음처럼 `message_count`의 의미가 달라질 수 있었습니다.

| 처리 경로 | 기존 기준 |
| --- | --- |
| 초기 동기화 | direction별 메시지 수 |
| 신규 메일 수신 | direction별 메시지 수 |
| 직접 발신 저장 | OUTBOUND row만 +1 |
| 삭제/복원 | 전체 Gmail thread active 메시지 수 |

이로 인해 같은 `message_count` 필드가 상황에 따라 direction별 개수 또는 전체 대화 개수로 해석될 수 있었습니다.

이번 변경에서는 모든 저장 경로에서 아래 기준으로 통일했습니다.

```text
Thread.messageCount = 같은 mailAccountId + gmailThreadId를 가진 active Message 전체 개수
```

```mermaid
flowchart TD
    A[메일 저장/동기화] --> B[Message 저장 또는 갱신]
    B --> C[mailAccountId + gmailThreadId 기준 active Message 조회]
    C --> D[전체 active 메시지 수 계산]
    D --> E[같은 Gmail thread의 active Thread row 조회]
    E --> F[INBOUND/OUTBOUND Thread row에 동일 messageCount 반영]
```

적용된 경로:

| 경로 | 변경 내용 |
| --- | --- |
| `InitialMailSyncCommandService.saveThreadBatch` | direction별 저장 후 전체 active 메시지 수로 모든 Thread row count 동기화 |
| `InitialMailSyncCommandService.saveMissingMessagesFromThreadSnapshot` | 누락 메시지 보강 후 전체 active 메시지 수로 count 동기화 |
| `MailCommandService.saveSentMail` | OUTBOUND row만 증가시키지 않고 전체 active 메시지 수로 count 동기화 |

삭제/복원 경로는 이미 전체 active 메시지 수를 사용하고 있어 별도 변경하지 않았습니다.

### 2. Gmail inline/attachment 분류 기준 강화

기존 분류 로직은 `Content-ID`가 있으면 일반 첨부파일도 `INLINE`으로 처리했습니다.

```text
Content-Disposition: attachment
Content-Type: application/haansofthwp
Content-ID: <f_mpmdzs8f0>
```

위와 같은 hwp 첨부파일도 `Content-ID` 조건 때문에 inline으로 저장될 수 있었습니다.

변경 후 분류 기준:

| 조건 | 결과 |
| --- | --- |
| `Content-Disposition`이 `attachment`로 시작 | `ATTACHMENT` |
| MIME 타입이 `image/*`가 아님 | `ATTACHMENT` |
| `Content-Disposition`이 `inline`이고 MIME 타입이 `image/*` | `INLINE` |
| `Content-ID`가 있고 MIME 타입이 `image/*` | `INLINE` |
| 그 외 | `ATTACHMENT` |

```mermaid
flowchart TD
    A[Gmail payload part] --> B{Content-Disposition startsWith attachment?}
    B -- 예 --> C[ATTACHMENT]
    B -- 아니오 --> D{MIME type image/* ?}
    D -- 아니오 --> C
    D -- 예 --> E{Disposition inline 또는 Content-ID 존재?}
    E -- 예 --> F[INLINE]
    E -- 아니오 --> C
```

이 정책은 `core`의 발신 후 Gmail 메시지 재조회 경로와 `worker`의 Gmail 수신/초기 동기화 경로에 동일하게 적용했습니다.

### 3. 영향 범위

| 영역 | 영향 |
| --- | --- |
| 수신함/보낸함 목록 `messageCount` | direction별 수가 아니라 전체 대화 메시지 수로 반환 |
| 스레드 상세 메시지 목록 | 기존처럼 같은 Gmail thread의 INBOUND/OUTBOUND 메시지를 모두 반환 |
| 답장 초안 추천 eligibility | `threadMessageCount`가 전체 대화 수 기준으로 전달됨 |
| 삭제/복원 처리 | 기존 전체 active 메시지 수 기준과 일치 |
| 첨부파일 표시 | hwp 등 문서 파일이 `Content-ID`만으로 inline 처리되지 않음 |

기존 DB에 저장된 `threads.message_count`는 코드 변경만으로 자동 보정되지 않습니다. 운영/개발 DB에 이미 direction별 count가 저장된 데이터가 있으면 별도 backfill이 필요합니다.

### 4. 주요 변경 파일

| 파일 | 변경 내용 |
| --- | --- |
| `worker/service/mail/InitialMailSyncCommandService` | Gmail thread 전체 active 메시지 수 기준으로 Thread count 동기화 |
| `core/service/mail/MailCommandService` | 직접 발신 저장 후 전체 active 메시지 수 기준으로 Thread count 동기화 |
| `worker/service/google/GmailMessageApiService` | Gmail 수신/초기 동기화 첨부파일 disposition 분류 기준 강화 |
| `core/service/google/GoogleMailMessageQueryService` | 발신 후 Gmail 메시지 재조회 첨부파일 disposition 분류 기준 강화 |
| `worker/service/mail/InitialMailSyncCommandServiceTest` | INBOUND/OUTBOUND 혼합 thread count 통합 테스트 추가 |
| `core/service/mail/MailCommandServiceTest` | 직접 발신 후 양쪽 Thread row count 동기화 테스트 추가 |
| `worker/service/google/GoogleMailMessageQueryServiceTest` | hwp attachment + Content-ID 오분류 회귀 테스트 추가 |
| `core/service/google/GoogleMailMessageQueryServiceTest` | hwp attachment + Content-ID 오분류 회귀 테스트 추가 |


## ⚡️ Test 결과

| Thread count 통합 - worker | Thread count 통합 - core | 첨부파일 분류 - worker | 첨부파일 분류 - core |
| -- | -- | -- | -- |
| Unit Test | Unit Test | Unit Test | Unit Test |
| `InitialMailSyncCommandServiceTest`, `GmailNewMessageApplyCommandServiceTest` | `MailCommandServiceTest`, `MailFacadeTest` | `GoogleMailMessageQueryServiceTest` | `GoogleMailMessageQueryServiceTest` |
| `BUILD SUCCESSFUL` | `BUILD SUCCESSFUL` | `BUILD SUCCESSFUL` | `BUILD SUCCESSFUL` |

실행한 테스트:

```bash
./gradlew :test --rerun-tasks \
  --tests "com.mailsangja.worker.service.mail.InitialMailSyncCommandServiceTest" \
  --tests "com.mailsangja.worker.service.mail.GmailNewMessageApplyCommandServiceTest"
```

```bash
./gradlew :test --rerun-tasks \
  --tests "com.mailsangja.core.service.mail.MailCommandServiceTest" \
  --tests "com.mailsangja.core.facade.MailFacadeTest"
```

```bash
./gradlew :test --rerun-tasks \
  --tests "com.mailsangja.core.service.google.GoogleMailMessageQueryServiceTest"
```

```bash
./gradlew :test --rerun-tasks \
  --tests "com.mailsangja.worker.service.google.GoogleMailMessageQueryServiceTest"
```

추가 검증:

```bash
git diff --check
```

결과:

```text
BUILD SUCCESSFUL
```
