### PR TITLE
[STORY-803] PRO 플랜 무제한 한도

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ out/
 /worker/src/main/resources/firebase-key.json
 /fcm-test-frontend/
 /docs/
+/architecture/

--- a/core/src/main/java/com/mailsangja/core/common/exception/label/LabelErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/label/LabelErrorCode.java
@@ -32,7 +32,7 @@ public enum LabelErrorCode implements ErrorCode {
     LABEL_SUGGESTION_NOT_FOUND(404, "MS-LABEL-SUGGESTION-NOT-FOUND", "라벨 제안을 찾을 수 없습니다."),
     LABEL_SUGGESTION_APPROVE_EMPTY(400, "MS-LABEL-SUGGESTION-APPROVE-EMPTY", "승인할 라벨 제안 ID 목록이 비어 있습니다."),
     LABEL_SUGGESTION_AI_FAILED(500, "MS-LABEL-SUGGESTION-AI-FAILED", "AI 라벨 제안 생성에 실패했습니다."),
-    LABEL_SUGGESTION_RATE_LIMIT_EXCEEDED(429, "MS-LABEL-SUGGESTION-RATE-LIMIT-EXCEEDED", "이번 달 라벨 제안 요청 횟수를 초과했습니다.");
+    LABEL_SUGGESTION_RATE_LIMIT_EXCEEDED(429, "MS-LABEL-SUGGESTION-RATE-LIMIT-EXCEEDED", "이번 주 라벨 제안 요청 횟수를 초과했습니다.");
 
     private final int status;
     private final String code;

--- a/core/src/main/java/com/mailsangja/core/common/exception/mail/MailDraftErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/mail/MailDraftErrorCode.java
@@ -13,7 +13,7 @@ public enum MailDraftErrorCode implements ErrorCode {
     REPLY_DRAFT_SUGGESTION_NOT_FOUND(404, "MS-MAIL-DRAFT-REPLY-DRAFT-SUGGESTION-NOT-FOUND", "답장 추천 초안을 찾을 수 없습니다."),
     PROMPT_INJECTION_DETECTED(400, "MS-MAIL-DRAFT-PROMPT-INJECTION-DETECTED", "메일 초안 요청에 허용되지 않은 지시가 포함되어 있습니다."),
     UNRESOLVED_PLACEHOLDER(500, "MS-MAIL-DRAFT-UNRESOLVED-PLACEHOLDER", "AI 초안 응답에 복원할 수 없는 placeholder가 포함되어 있습니다."),
-    RATE_LIMIT_EXCEEDED(429, "MS-MAIL-DRAFT-RATE-LIMIT-EXCEEDED", "메일 초안 생성 월간 한도를 초과했습니다."),
+    RATE_LIMIT_EXCEEDED(429, "MS-MAIL-DRAFT-RATE-LIMIT-EXCEEDED", "메일 초안 생성 주간 한도를 초과했습니다."),
     CHAT_MODEL_NOT_AVAILABLE(503, "MS-MAIL-DRAFT-CHAT-MODEL-NOT-AVAILABLE", "AI 초안 생성 모델을 사용할 수 없습니다.");
 
     private final int status;

--- a/core/src/main/java/com/mailsangja/core/common/exception/mail/MailReviewErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/mail/MailReviewErrorCode.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 public enum MailReviewErrorCode implements ErrorCode {
 
     INVALID_REQUEST(400, "MS-MAIL-REVIEW-INVALID-REQUEST", "메일 검토 요청 형식이 올바르지 않습니다."),
-    RATE_LIMIT_EXCEEDED(429, "MS-MAIL-REVIEW-RATE-LIMIT-EXCEEDED", "메일 검토 월간 한도를 초과했습니다."),
+    RATE_LIMIT_EXCEEDED(429, "MS-MAIL-REVIEW-RATE-LIMIT-EXCEEDED", "메일 검토 주간 한도를 초과했습니다."),
     CHAT_MODEL_NOT_AVAILABLE(503, "MS-MAIL-REVIEW-CHAT-MODEL-NOT-AVAILABLE", "메일 검토 모델을 사용할 수 없습니다."),
     AI_RESPONSE_INVALID(502, "MS-MAIL-REVIEW-AI-RESPONSE-INVALID", "메일 검토 AI 응답 형식이 올바르지 않습니다.");
 

--- a/core/src/main/java/com/mailsangja/core/controller/docs/LabelControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/LabelControllerDocs.java
@@ -137,14 +137,14 @@ public interface LabelControllerDocs {
 
     @Operation(
             summary = "라벨 제안 생성",
-            description = "최근 수신 메일의 제목·발신자 정보를 AI로 분석하여 라벨 규칙 제안을 생성합니다. confirmed=false 상태로 저장되며, 동일 이름의 제안이 이미 존재하면 중복 저장하지 않습니다. 월간 사용 횟수 제한이 적용됩니다.",
+            description = "최근 수신 메일의 제목·발신자 정보를 AI로 분석하여 라벨 규칙 제안을 생성합니다. confirmed=false 상태로 저장되며, 동일 이름의 제안이 이미 존재하면 중복 저장하지 않습니다. 주간 사용 횟수 제한이 적용됩니다.",
             security = @SecurityRequirement(name = "cookieAuth")
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "라벨 제안 생성 성공 (새로 저장된 제안 목록만 반환)"),
             @ApiResponse(responseCode = "401", description = "인증 필요",
                     content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "429", description = "이번 달 라벨 제안 요청 횟수 초과",
+            @ApiResponse(responseCode = "429", description = "이번 주 라벨 제안 요청 횟수 초과",
                     content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "500", description = "AI 라벨 제안 생성 실패",
                     content = @Content(schema = @Schema(hidden = true)))

--- a/core/src/main/java/com/mailsangja/core/controller/docs/MailControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/MailControllerDocs.java
@@ -99,7 +99,7 @@ public interface MailControllerDocs {
             ),
             @ApiResponse(
                     responseCode = "429",
-                    description = "월간 AI 사용 한도 초과",
+                    description = "주간 AI 사용 한도 초과",
                     content = @Content(schema = @Schema(hidden = true))
             ),
             @ApiResponse(

--- a/core/src/main/java/com/mailsangja/core/facade/AiFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/AiFacade.java
@@ -34,7 +34,7 @@ public class AiFacade {
     public AiPlaygroundChatResponse chat(User user, AiPlaygroundChatRequest request) {
         validateAdmin(user);
         validateRegisteredMailAccount(user);
-        return AiPlaygroundChatResponse.from(aiPlaygroundCommandService.chat(user.getId(), request));
+        return AiPlaygroundChatResponse.from(aiPlaygroundCommandService.chat(user.getId(), request, user.getPlan()));
     }
 
     public AiModelListResponse getModels() {

--- a/core/src/main/java/com/mailsangja/core/facade/LabelFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/LabelFacade.java
@@ -14,6 +14,7 @@ import com.mailsangja.core.service.label.LabelCommandService;
 import com.mailsangja.core.service.label.LabelQueryService;
 import com.mailsangja.core.service.label.LabelReclassifyPendingJobStore;
 import com.mailsangja.db.entity.label.Label;
+import com.mailsangja.db.entity.user.Plan;
 import com.mailsangja.db.entity.user.User;
 import com.mailsangja.db.port.LabelSuggestionRateLimitCachePort;
 import lombok.RequiredArgsConstructor;
@@ -90,7 +91,7 @@ public class LabelFacade {
     }
 
     public List<LabelListResponse> createSuggestions(User user) {
-        validateSuggestionRateLimit(user.getId());
+        validateSuggestionRateLimit(user.getId(), user.getPlan());
         List<Label> existingLabels = labelQueryService.findAllActiveByUserId(user.getId());
         LlmLabelSuggestionResult result = labelSuggestionAiService.suggest(user.getId(), existingLabels);
         return result.suggestions().stream()
@@ -103,8 +104,9 @@ public class LabelFacade {
                 .toList();
     }
 
-    private void validateSuggestionRateLimit(UUID userId) {
-        if (!suggestionRateLimitCachePort.tryConsumeWeeklyLimit(userId)) {
+    private void validateSuggestionRateLimit(UUID userId, Plan plan) {
+        boolean allowed = suggestionRateLimitCachePort.tryConsumeWeeklyLimit(userId);
+        if (plan != Plan.PRO && !allowed) {
             throw new LabelException(LabelErrorCode.LABEL_SUGGESTION_RATE_LIMIT_EXCEEDED);
         }
     }

--- a/core/src/main/java/com/mailsangja/core/facade/MailDraftFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/MailDraftFacade.java
@@ -45,7 +45,7 @@ public class MailDraftFacade {
 
     private void streamByPurpose(User user, SseEmitter emitter, MailDraftCommand command) {
         if (command.purpose() == com.mailsangja.core.dto.mail.MailDraftPurpose.GENERAL) {
-            mailDraftAsyncService.streamGeneral(emitter, command);
+            mailDraftAsyncService.streamGeneral(emitter, command, user.getPlan());
             return;
         }
         streamReply(user, emitter, command);
@@ -54,7 +54,7 @@ public class MailDraftFacade {
     private void streamReply(User user, SseEmitter emitter, MailDraftCommand command) {
         Message replyTarget = mailQueryService.findReplyTargetMessage(command.replyMessageId());
         validateReplyTarget(user, replyTarget);
-        mailDraftAsyncService.streamReply(emitter, command);
+        mailDraftAsyncService.streamReply(emitter, command, user.getPlan());
     }
 
     private void validateReplyTarget(User user, Message replyTarget) {

--- a/core/src/main/java/com/mailsangja/core/facade/MailReviewFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/MailReviewFacade.java
@@ -16,7 +16,7 @@ public class MailReviewFacade {
     private final MailReviewCommandService mailReviewCommandService;
 
     public MailReviewResponse review(User user, MailReviewRequest request) {
-        MailReviewResult result = mailReviewCommandService.review(MailReviewCommand.of(user.getId(), request));
+        MailReviewResult result = mailReviewCommandService.review(MailReviewCommand.of(user.getId(), request), user.getPlan());
         return MailReviewResponse.from(result);
     }
 }

--- a/core/src/main/java/com/mailsangja/core/service/ai/AiPlaygroundCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/ai/AiPlaygroundCommandService.java
@@ -9,6 +9,7 @@ import com.mailsangja.core.dto.ai.AiPlaygroundChatResult;
 import com.mailsangja.core.dto.ai.AiPlaygroundMessageRequest;
 import com.mailsangja.core.dto.ai.AiPlaygroundOptionsRequest;
 import com.mailsangja.core.dto.ai.AiPlaygroundUsageResult;
+import com.mailsangja.db.entity.user.Plan;
 import com.mailsangja.db.port.AiPlaygroundRateLimitCachePort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,10 +44,14 @@ public class AiPlaygroundCommandService {
     private final ObjectMapper objectMapper;
 
     public AiPlaygroundChatResult chat(UUID userId, AiPlaygroundChatRequest request) {
+        return chat(userId, request, Plan.FREE);
+    }
+
+    public AiPlaygroundChatResult chat(UUID userId, AiPlaygroundChatRequest request, Plan plan) {
         if (request == null) {
             throw new AiPlaygroundException(AiPlaygroundErrorCode.INVALID_REQUEST);
         }
-        validateWeeklyRateLimit(userId);
+        validateWeeklyRateLimit(userId, plan);
         Prompt prompt = createPrompt(request);
         try {
             ChatResponse response = chatModel().call(prompt);
@@ -59,8 +64,9 @@ public class AiPlaygroundCommandService {
         }
     }
 
-    private void validateWeeklyRateLimit(UUID userId) {
-        if (!rateLimitCachePort.tryConsumeWeeklyLimit(userId)) {
+    private void validateWeeklyRateLimit(UUID userId, Plan plan) {
+        boolean allowed = rateLimitCachePort.tryConsumeWeeklyLimit(userId);
+        if (plan != Plan.PRO && !allowed) {
             throw new AiPlaygroundException(AiPlaygroundErrorCode.RATE_LIMIT_EXCEEDED);
         }
     }

--- a/core/src/main/java/com/mailsangja/core/service/ai/draft/MailDraftAsyncService.java
+++ b/core/src/main/java/com/mailsangja/core/service/ai/draft/MailDraftAsyncService.java
@@ -5,6 +5,7 @@ import com.mailsangja.core.dto.mail.MailDraftPromptResult;
 import com.mailsangja.core.dto.mail.MailDraftRagContextResult;
 import com.mailsangja.core.dto.mail.MailDraftRestoreContextResult;
 import com.mailsangja.core.dto.mail.MailDraftUsageResult;
+import com.mailsangja.db.entity.user.Plan;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -22,26 +23,26 @@ public class MailDraftAsyncService {
     private final MailDraftCommandService mailDraftCommandService;
 
     @Async
-    public void streamGeneral(SseEmitter emitter, MailDraftCommand command) {
+    public void streamGeneral(SseEmitter emitter, MailDraftCommand command, Plan plan) {
         MailDraftCommandService.StreamCancellation cancellation = mailDraftCommandService.createCancellation();
         registerCancel(emitter, cancellation);
         try {
             MailDraftRagContextResult context = mailDraftQueryService.generalRagContext(command);
             MailDraftPromptResult prompt = mailDraftQueryService.generalPrompt(command, context);
-            stream(emitter, command, prompt, cancellation);
+            stream(emitter, command, prompt, cancellation, plan);
         } catch (Exception exception) {
             handleFailure(emitter, command, exception);
         }
     }
 
     @Async
-    public void streamReply(SseEmitter emitter, MailDraftCommand command) {
+    public void streamReply(SseEmitter emitter, MailDraftCommand command, Plan plan) {
         MailDraftCommandService.StreamCancellation cancellation = mailDraftCommandService.createCancellation();
         registerCancel(emitter, cancellation);
         try {
             MailDraftRagContextResult context = mailDraftQueryService.replyRagContext(command);
             MailDraftPromptResult prompt = mailDraftQueryService.replyPrompt(command, context);
-            streamReplyBody(emitter, command, prompt, cancellation);
+            streamReplyBody(emitter, command, prompt, cancellation, plan);
         } catch (Exception exception) {
             handleFailure(emitter, command, exception);
         }
@@ -78,9 +79,9 @@ public class MailDraftAsyncService {
     }
 
     private void stream(SseEmitter emitter, MailDraftCommand command, MailDraftPromptResult prompt,
-                        MailDraftCommandService.StreamCancellation cancellation) {
+                        MailDraftCommandService.StreamCancellation cancellation, Plan plan) {
         try {
-            streamAfterRateLimit(emitter, command, prompt, cancellation);
+            streamAfterRateLimit(emitter, command, prompt, cancellation, plan);
         } catch (Exception exception) {
             handleFailure(emitter, command, exception);
         }
@@ -99,9 +100,9 @@ public class MailDraftAsyncService {
     }
 
     private void streamAfterRateLimit(SseEmitter emitter, MailDraftCommand command, MailDraftPromptResult prompt,
-                                      MailDraftCommandService.StreamCancellation cancellation) {
+                                      MailDraftCommandService.StreamCancellation cancellation, Plan plan) {
         String model = mailDraftCommandService.resolveModel(command.model());
-        mailDraftCommandService.validateWeeklyRateLimit(command.userId());
+        mailDraftCommandService.validateWeeklyRateLimit(command.userId(), plan);
         MailDraftRestoreContextResult restoreContext = MailDraftRestoreContextResult.from(command);
         try {
             MailDraftUsageResult usage = mailDraftCommandService.streamCombined(emitter, prompt, restoreContext, cancellation, model);
@@ -129,10 +130,10 @@ public class MailDraftAsyncService {
     }
 
     private void streamReplyBody(SseEmitter emitter, MailDraftCommand command, MailDraftPromptResult prompt,
-                                 MailDraftCommandService.StreamCancellation cancellation) {
+                                 MailDraftCommandService.StreamCancellation cancellation, Plan plan) {
         try {
             String model = mailDraftCommandService.resolveModel(command.model());
-            mailDraftCommandService.validateWeeklyRateLimit(command.userId());
+            mailDraftCommandService.validateWeeklyRateLimit(command.userId(), plan);
             MailDraftRestoreContextResult restoreContext = MailDraftRestoreContextResult.from(command);
             MailDraftUsageResult bodyUsage = mailDraftCommandService.streamBody(emitter, prompt, restoreContext, cancellation, model);
             if (cancellation.isCancelled()) {

--- a/core/src/main/java/com/mailsangja/core/service/ai/draft/MailDraftCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/ai/draft/MailDraftCommandService.java
@@ -11,6 +11,7 @@ import com.mailsangja.core.dto.mail.MailDraftPromptResult;
 import com.mailsangja.core.dto.mail.MailDraftRestoreContextResult;
 import com.mailsangja.core.dto.mail.MailDraftUsageEvent;
 import com.mailsangja.core.dto.mail.MailDraftUsageResult;
+import com.mailsangja.db.entity.user.Plan;
 import com.mailsangja.db.port.MailDraftRateLimitCachePort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -71,7 +72,12 @@ public class MailDraftCommandService {
     private final AiModelProperties modelProperties;
 
     public void validateWeeklyRateLimit(UUID userId) {
-        if (!rateLimitCachePort.tryConsumeWeeklyLimit(userId)) {
+        validateWeeklyRateLimit(userId, Plan.FREE);
+    }
+
+    public void validateWeeklyRateLimit(UUID userId, Plan plan) {
+        boolean allowed = rateLimitCachePort.tryConsumeWeeklyLimit(userId);
+        if (plan != Plan.PRO && !allowed) {
             throw new MailDraftException(MailDraftErrorCode.RATE_LIMIT_EXCEEDED);
         }
     }

--- a/core/src/main/java/com/mailsangja/core/service/ai/review/MailReviewCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/ai/review/MailReviewCommandService.java
@@ -11,6 +11,7 @@ import com.mailsangja.core.dto.mail.MailReviewIssueResult;
 import com.mailsangja.core.dto.mail.MailReviewIssueType;
 import com.mailsangja.core.dto.mail.MailReviewResult;
 import com.mailsangja.core.dto.mail.MailReviewSegment;
+import com.mailsangja.db.entity.user.Plan;
 import com.mailsangja.db.port.MailReviewRateLimitCachePort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -59,7 +60,11 @@ public class MailReviewCommandService {
     private final MailReviewQueryService mailReviewQueryService;
 
     public MailReviewResult review(MailReviewCommand command) {
-        validateWeeklyRateLimit(command);
+        return review(command, Plan.FREE);
+    }
+
+    public MailReviewResult review(MailReviewCommand command, Plan plan) {
+        validateWeeklyRateLimit(command, plan);
         List<MailReviewSegment> segments = mailReviewQueryService.createSegments(command);
         if (segments.isEmpty()) {
             return new MailReviewResult(List.of());
@@ -72,8 +77,9 @@ public class MailReviewCommandService {
         return new MailReviewResult(filterAttachmentIssues(command, issues));
     }
 
-    private void validateWeeklyRateLimit(MailReviewCommand command) {
-        if (!rateLimitCachePort.tryConsumeWeeklyLimit(command.userId())) {
+    private void validateWeeklyRateLimit(MailReviewCommand command, Plan plan) {
+        boolean allowed = rateLimitCachePort.tryConsumeWeeklyLimit(command.userId());
+        if (plan != Plan.PRO && !allowed) {
             throw new MailReviewException(MailReviewErrorCode.RATE_LIMIT_EXCEEDED);
         }
     }

--- a/core/src/test/java/com/mailsangja/core/facade/AiFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/AiFacadeTest.java
@@ -13,6 +13,7 @@ import com.mailsangja.core.service.ai.AiQueryService;
 import com.mailsangja.core.service.ai.AiUsageQueryService;
 import com.mailsangja.core.service.mail.MailAccountQueryService;
 import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.user.Plan;
 import com.mailsangja.db.entity.user.Role;
 import com.mailsangja.db.entity.user.User;
 import org.junit.jupiter.api.Test;
@@ -67,7 +68,7 @@ class AiFacadeTest {
 
         when(mailAccountQueryService.findAllActiveByUserId(user.getId()))
                 .thenReturn(List.of(mock(MailAccount.class)));
-        when(playgroundCommandService.chat(user.getId(), request))
+        when(playgroundCommandService.chat(user.getId(), request, user.getPlan()))
                 .thenReturn(new AiPlaygroundChatResult(
                         "OPENROUTER",
                         "google/gemini-3.5-flash",
@@ -86,7 +87,7 @@ class AiFacadeTest {
         assertEquals(10, response.usage().inputTokens());
         assertEquals(20, response.usage().outputTokens());
         assertEquals(30, response.usage().totalTokens());
-        verify(playgroundCommandService).chat(user.getId(), request);
+        verify(playgroundCommandService).chat(user.getId(), request, user.getPlan());
     }
 
     @Test
@@ -151,6 +152,7 @@ class AiFacadeTest {
                 .name("테스트 사용자")
                 .username("tester@example.com")
                 .password("encoded")
+                .plan(Plan.FREE)
                 .role(Role.USER)
                 .build();
     }
@@ -161,6 +163,7 @@ class AiFacadeTest {
                 .name("관리자")
                 .username("admin@example.com")
                 .password("encoded")
+                .plan(Plan.PRO)
                 .role(Role.ADMIN)
                 .build();
     }

--- a/core/src/test/java/com/mailsangja/core/facade/LabelFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/LabelFacadeTest.java
@@ -8,13 +8,17 @@ import com.mailsangja.core.dto.label.LabelDetailResponse;
 import com.mailsangja.core.dto.label.LabelListResponse;
 import com.mailsangja.core.dto.label.LabelRuleUpdateRequest;
 import com.mailsangja.core.dto.label.LabelUpdateRequest;
+import com.mailsangja.core.dto.label.LlmLabelSuggestionResult;
+import com.mailsangja.core.service.ai.label.LabelSuggestionAiService;
 import com.mailsangja.core.service.label.LabelCommandService;
 import com.mailsangja.core.service.label.LabelQueryService;
 import com.mailsangja.core.service.label.LabelReclassifyPendingJobStore;
 import com.mailsangja.db.common.label.LabelRule;
 import com.mailsangja.db.common.label.NotificationPolicy;
 import com.mailsangja.db.entity.label.Label;
+import com.mailsangja.db.entity.user.Plan;
 import com.mailsangja.db.entity.user.User;
+import com.mailsangja.db.port.LabelSuggestionRateLimitCachePort;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -51,6 +55,12 @@ class LabelFacadeTest {
 
     @Mock
     private LabelRuleValidator labelRuleValidator;
+
+    @Mock
+    private LabelSuggestionAiService labelSuggestionAiService;
+
+    @Mock
+    private LabelSuggestionRateLimitCachePort suggestionRateLimitCachePort;
 
     @InjectMocks
     private LabelFacade labelFacade;
@@ -194,6 +204,38 @@ class LabelFacadeTest {
     }
 
     @Test
+    void 라벨제안_pro사용자는한도초과여도카운트만소모하고허용한다() {
+        User user = user(Plan.PRO);
+        LabelRule rule = rule("invoice");
+        LlmLabelSuggestionResult result = new LlmLabelSuggestionResult(List.of(
+                new LlmLabelSuggestionResult.LabelSuggestionItem("청구서", "#3366FF", NotificationPolicy.INHERIT, 1, rule)
+        ));
+        Label saved = label("청구서", 1, rule);
+        when(suggestionRateLimitCachePort.tryConsumeWeeklyLimit(user.getId())).thenReturn(false);
+        when(labelQueryService.findAllActiveByUserId(user.getId())).thenReturn(List.of());
+        when(labelSuggestionAiService.suggest(user.getId(), List.of())).thenReturn(result);
+        when(labelQueryService.existsByUserIdAndName(user.getId(), "청구서")).thenReturn(false);
+        when(labelCommandService.createSuggestion(any(), any())).thenReturn(saved);
+
+        List<LabelListResponse> responses = labelFacade.createSuggestions(user);
+
+        assertEquals(1, responses.size());
+        verify(suggestionRateLimitCachePort).tryConsumeWeeklyLimit(user.getId());
+        verify(labelSuggestionAiService).suggest(user.getId(), List.of());
+    }
+
+    @Test
+    void 라벨제안_free사용자는한도초과시예외를던지고LLM을호출하지않는다() {
+        User user = user();
+        when(suggestionRateLimitCachePort.tryConsumeWeeklyLimit(user.getId())).thenReturn(false);
+
+        LabelException exception = assertThrows(LabelException.class, () -> labelFacade.createSuggestions(user));
+
+        assertEquals(LabelErrorCode.LABEL_SUGGESTION_RATE_LIMIT_EXCEEDED, exception.getErrorCode());
+        verify(labelSuggestionAiService, never()).suggest(any(), any());
+    }
+
+    @Test
     void updateLabelRule_rateLimit초과_예외전파되고PendingJob병합안됨() {
         User user = user();
         LabelRule rule = rule("invoice");
@@ -250,8 +292,13 @@ class LabelFacadeTest {
     }
 
     private User user() {
+        return user(Plan.FREE);
+    }
+
+    private User user(Plan plan) {
         return User.builder()
                 .id(UUID.randomUUID())
+                .plan(plan)
                 .build();
     }
 

--- a/core/src/test/java/com/mailsangja/core/facade/MailDraftFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/MailDraftFacadeTest.java
@@ -15,6 +15,7 @@ import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.MailProvider;
 import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.Thread;
+import com.mailsangja.db.entity.user.Plan;
 import com.mailsangja.db.entity.user.User;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -51,7 +52,7 @@ class MailDraftFacadeTest {
 
         // then
         assertNotNull(emitter);
-        verify(fixture.draftAsyncService()).streamGeneral(eq(emitter), any(MailDraftCommand.class));
+        verify(fixture.draftAsyncService()).streamGeneral(eq(emitter), any(MailDraftCommand.class), eq(user.getPlan()));
     }
 
     @Test
@@ -66,8 +67,8 @@ class MailDraftFacadeTest {
         assertThrows(MailAccountException.class, () -> fixture.facade().streamDraft(user, createRequest(account, null)));
 
         // then
-        verify(fixture.draftAsyncService(), never()).streamGeneral(any(), any());
-        verify(fixture.draftAsyncService(), never()).streamReply(any(), any());
+        verify(fixture.draftAsyncService(), never()).streamGeneral(any(), any(), any());
+        verify(fixture.draftAsyncService(), never()).streamReply(any(), any(), any());
     }
 
     @Test
@@ -82,8 +83,8 @@ class MailDraftFacadeTest {
 
         // then
         verify(fixture.mailQueryService(), never()).findReplyTargetMessage(any());
-        verify(fixture.draftAsyncService()).streamGeneral(any(), any(MailDraftCommand.class));
-        verify(fixture.draftAsyncService(), never()).streamReply(any(), any());
+        verify(fixture.draftAsyncService()).streamGeneral(any(), any(MailDraftCommand.class), eq(user.getPlan()));
+        verify(fixture.draftAsyncService(), never()).streamReply(any(), any(), any());
     }
 
     @Test
@@ -100,8 +101,8 @@ class MailDraftFacadeTest {
 
         // then
         verify(fixture.mailQueryService()).findReplyTargetMessage(replyMessageId);
-        verify(fixture.draftAsyncService()).streamReply(any(), any(MailDraftCommand.class));
-        verify(fixture.draftAsyncService(), never()).streamGeneral(any(), any());
+        verify(fixture.draftAsyncService()).streamReply(any(), any(MailDraftCommand.class), eq(user.getPlan()));
+        verify(fixture.draftAsyncService(), never()).streamGeneral(any(), any(), any());
     }
 
     @Test
@@ -117,8 +118,8 @@ class MailDraftFacadeTest {
         assertThrows(MailDraftException.class, () -> fixture.facade().streamDraft(user, createRequest(account, UUID.randomUUID())));
 
         // then
-        verify(fixture.draftAsyncService(), never()).streamGeneral(any(), any());
-        verify(fixture.draftAsyncService(), never()).streamReply(any(), any());
+        verify(fixture.draftAsyncService(), never()).streamGeneral(any(), any(), any());
+        verify(fixture.draftAsyncService(), never()).streamReply(any(), any(), any());
     }
 
     @Test
@@ -134,8 +135,8 @@ class MailDraftFacadeTest {
         fixture.facade().streamDraft(user, createRequest(requestAccount, UUID.randomUUID()));
 
         // then
-        verify(fixture.draftAsyncService()).streamReply(any(), captor.capture());
-        verify(fixture.draftAsyncService(), never()).streamGeneral(any(), any());
+        verify(fixture.draftAsyncService()).streamReply(any(), captor.capture(), eq(user.getPlan()));
+        verify(fixture.draftAsyncService(), never()).streamGeneral(any(), any(), any());
         assertEquals(requestAccount.getId(), captor.getValue().mailAccountId());
     }
 
@@ -152,7 +153,7 @@ class MailDraftFacadeTest {
 
         // then
         verify(fixture.draftQueryService(), atLeastOnce()).validatePromptInjection(any());
-        verify(fixture.draftAsyncService(), never()).streamGeneral(any(), any());
+        verify(fixture.draftAsyncService(), never()).streamGeneral(any(), any(), any());
     }
 
     private FacadeFixture createFacade(MailAccount account, Message replyTarget) {
@@ -204,7 +205,7 @@ class MailDraftFacadeTest {
     }
 
     private User createUser(UUID id) {
-        return User.builder().id(id).build();
+        return User.builder().id(id).plan(Plan.FREE).build();
     }
 
     private MailAccount createMailAccount(User user, UUID id) {

--- a/core/src/test/java/com/mailsangja/core/service/ai/AiPlaygroundCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/ai/AiPlaygroundCommandServiceTest.java
@@ -1,0 +1,110 @@
+package com.mailsangja.core.service.ai;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mailsangja.core.common.exception.ai.AiPlaygroundErrorCode;
+import com.mailsangja.core.common.exception.ai.AiPlaygroundException;
+import com.mailsangja.core.dto.ai.AiPlaygroundChatRequest;
+import com.mailsangja.db.entity.user.Plan;
+import com.mailsangja.db.port.AiPlaygroundRateLimitCachePort;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AiPlaygroundCommandServiceTest {
+
+    @Test
+    void free사용자는한도초과시예외를던진다() {
+        UUID userId = UUID.randomUUID();
+        AiPlaygroundRateLimitCachePort cachePort = mock(AiPlaygroundRateLimitCachePort.class);
+        when(cachePort.tryConsumeWeeklyLimit(userId)).thenReturn(false);
+        AiPlaygroundCommandService service = new AiPlaygroundCommandService(
+                cachePort,
+                chatModelProvider(chatModel("응답")),
+                new ObjectMapper()
+        );
+
+        AiPlaygroundException exception = assertThrows(
+                AiPlaygroundException.class,
+                () -> service.chat(userId, request(), Plan.FREE)
+        );
+
+        assertEquals(AiPlaygroundErrorCode.RATE_LIMIT_EXCEEDED, exception.getErrorCode());
+        verify(cachePort).tryConsumeWeeklyLimit(userId);
+    }
+
+    @Test
+    void pro사용자는한도초과여도카운트만소모하고허용한다() {
+        UUID userId = UUID.randomUUID();
+        AiPlaygroundRateLimitCachePort cachePort = mock(AiPlaygroundRateLimitCachePort.class);
+        when(cachePort.tryConsumeWeeklyLimit(userId)).thenReturn(false);
+        AiPlaygroundCommandService service = new AiPlaygroundCommandService(
+                cachePort,
+                chatModelProvider(chatModel("응답")),
+                new ObjectMapper()
+        );
+
+        assertDoesNotThrow(() -> service.chat(userId, request(), Plan.PRO));
+
+        verify(cachePort).tryConsumeWeeklyLimit(userId);
+    }
+
+    @SuppressWarnings("unchecked")
+    private ObjectProvider<ChatModel> chatModelProvider(ChatModel chatModel) {
+        ObjectProvider<ChatModel> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(chatModel);
+        return provider;
+    }
+
+    private AiPlaygroundChatRequest request() {
+        return new AiPlaygroundChatRequest(
+                "OPENROUTER",
+                "gpt-test",
+                null,
+                "메일을 작성해줘.",
+                List.of(),
+                Map.of(),
+                null,
+                Map.of()
+        );
+    }
+
+    private ChatModel chatModel(String text) {
+        return new StubChatModel(response(text));
+    }
+
+    private ChatResponse response(String text) {
+        Generation generation = new Generation(AssistantMessage.builder().content(text).build());
+        ChatResponseMetadata metadata = ChatResponseMetadata.builder().model("gpt-test").build();
+        return new ChatResponse(List.of(generation), metadata);
+    }
+
+    private record StubChatModel(ChatResponse response) implements ChatModel {
+
+        @Override
+        public ChatResponse call(Prompt prompt) {
+            return response;
+        }
+
+        @Override
+        public ChatOptions getDefaultOptions() {
+            return ChatOptions.builder().model("gpt-test").build();
+        }
+    }
+}

--- a/core/src/test/java/com/mailsangja/core/service/ai/draft/MailDraftAsyncServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/ai/draft/MailDraftAsyncServiceTest.java
@@ -5,6 +5,7 @@ import com.mailsangja.core.dto.mail.MailDraftCommand;
 import com.mailsangja.core.dto.mail.MailDraftPromptResult;
 import com.mailsangja.core.dto.mail.MailDraftRagContextResult;
 import com.mailsangja.core.dto.mail.MailDraftUsageResult;
+import com.mailsangja.db.entity.user.Plan;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -34,7 +35,7 @@ class MailDraftAsyncServiceTest {
         MailDraftCommand command = createCommand();
 
         // when
-        fixture.asyncService().streamGeneral(emitter, command);
+        fixture.asyncService().streamGeneral(emitter, command, Plan.FREE);
         emitter.disconnect();
 
         // then
@@ -49,7 +50,7 @@ class MailDraftAsyncServiceTest {
         MailDraftCommand command = createCommand();
 
         // when
-        fixture.asyncService().streamGeneral(emitter, command);
+        fixture.asyncService().streamGeneral(emitter, command, Plan.FREE);
         emitter.timeout();
 
         // then
@@ -64,7 +65,7 @@ class MailDraftAsyncServiceTest {
         MailDraftCommand command = createCommand();
 
         // when
-        fixture.asyncService().streamGeneral(emitter, command);
+        fixture.asyncService().streamGeneral(emitter, command, Plan.FREE);
         emitter.fail();
 
         // then
@@ -82,7 +83,7 @@ class MailDraftAsyncServiceTest {
         doThrow(new RuntimeException("body failed")).when(fixture.commandService()).streamBody(eq(emitter), any(), any(), any(), any());
 
         // when
-        fixture.asyncService().streamGeneral(emitter, command);
+        fixture.asyncService().streamGeneral(emitter, command, Plan.FREE);
 
         // then
         verify(fixture.commandService()).sendError(eq(emitter), any());
@@ -100,7 +101,7 @@ class MailDraftAsyncServiceTest {
         doThrow(new IllegalStateException("send failed")).when(fixture.commandService()).sendError(eq(emitter), any());
 
         // when
-        fixture.asyncService().streamGeneral(emitter, command);
+        fixture.asyncService().streamGeneral(emitter, command, Plan.FREE);
 
         // then
         verify(fixture.commandService()).sendError(eq(emitter), any());
@@ -119,7 +120,7 @@ class MailDraftAsyncServiceTest {
         when(fixture.commandService().streamBody(eq(emitter), any(), any(), any(), any())).thenReturn(bodyUsage);
 
         // when
-        fixture.asyncService().streamGeneral(emitter, command);
+        fixture.asyncService().streamGeneral(emitter, command, Plan.FREE);
 
         // then
         org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(fixture.commandService());
@@ -138,7 +139,7 @@ class MailDraftAsyncServiceTest {
         org.mockito.Mockito.doReturn(usage).when(fixture.commandService()).streamCombined(eq(emitter), any(), any(), any(), any());
 
         // when
-        fixture.asyncService().streamGeneral(emitter, command);
+        fixture.asyncService().streamGeneral(emitter, command, Plan.FREE);
 
         // then
         org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(fixture.commandService());
@@ -164,7 +165,7 @@ class MailDraftAsyncServiceTest {
         });
 
         // when
-        fixture.asyncService().streamGeneral(emitter, command);
+        fixture.asyncService().streamGeneral(emitter, command, Plan.FREE);
 
         // then
         verify(fixture.commandService(), org.mockito.Mockito.never()).streamBody(any(), any(), any(), any(), any());
@@ -179,13 +180,13 @@ class MailDraftAsyncServiceTest {
         MailDraftCommand command = createCommand();
 
         // when
-        fixture.asyncService().streamGeneral(emitter, command);
+        fixture.asyncService().streamGeneral(emitter, command, Plan.FREE);
 
         // then
         org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(fixture.queryService(), fixture.commandService());
         inOrder.verify(fixture.queryService()).generalPrompt(eq(command), any());
         inOrder.verify(fixture.commandService()).resolveModel(command.model());
-        inOrder.verify(fixture.commandService()).validateWeeklyRateLimit(command.userId());
+        inOrder.verify(fixture.commandService()).validateWeeklyRateLimit(command.userId(), Plan.FREE);
         inOrder.verify(fixture.commandService()).streamSubject(eq(emitter), any(), any(), any(), any());
     }
 
@@ -195,10 +196,10 @@ class MailDraftAsyncServiceTest {
         Fixture fixture = createFixture();
         SseEmitter emitter = new SseEmitter();
         MailDraftCommand command = createCommand();
-        doThrow(mock(MailDraftException.class)).when(fixture.commandService()).validateWeeklyRateLimit(command.userId());
+        doThrow(mock(MailDraftException.class)).when(fixture.commandService()).validateWeeklyRateLimit(command.userId(), Plan.FREE);
 
         // when
-        fixture.asyncService().streamGeneral(emitter, command);
+        fixture.asyncService().streamGeneral(emitter, command, Plan.FREE);
 
         // then
         verify(fixture.commandService(), org.mockito.Mockito.never()).streamSubject(any(), any(), any(), any(), any());
@@ -216,7 +217,7 @@ class MailDraftAsyncServiceTest {
         when(fixture.queryService().generalPrompt(any(), any())).thenReturn(prompt);
 
         // when
-        fixture.asyncService().streamGeneral(emitter, createCommand());
+        fixture.asyncService().streamGeneral(emitter, createCommand(), Plan.FREE);
 
         // then
         var captor = forClass(MailDraftPromptResult.class);
@@ -237,7 +238,7 @@ class MailDraftAsyncServiceTest {
         when(fixture.commandService().streamBody(eq(emitter), any(), any(), any(), any())).thenReturn(bodyUsage);
 
         // when
-        fixture.asyncService().streamReply(emitter, command);
+        fixture.asyncService().streamReply(emitter, command, Plan.FREE);
 
         // then
         var captor = forClass(MailDraftPromptResult.class);

--- a/core/src/test/java/com/mailsangja/core/service/ai/draft/MailDraftCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/ai/draft/MailDraftCommandServiceTest.java
@@ -11,6 +11,7 @@ import com.mailsangja.core.dto.mail.MailDraftPromptResult;
 import com.mailsangja.core.dto.mail.MailDraftRestoreContextResult;
 import com.mailsangja.core.dto.mail.MailDraftUsageEvent;
 import com.mailsangja.core.dto.mail.MailDraftUsageResult;
+import com.mailsangja.db.entity.user.Plan;
 import com.mailsangja.db.port.MailDraftRateLimitCachePort;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -67,6 +68,21 @@ class MailDraftCommandServiceTest {
 
         // when & then
         assertThrows(MailDraftException.class, () -> service.validateWeeklyRateLimit(userId));
+    }
+
+    @Test
+    void pro사용자는한도초과여도카운트만소모하고허용한다() {
+        // given
+        UUID userId = UUID.randomUUID();
+        MailDraftRateLimitCachePort cachePort = mock(MailDraftRateLimitCachePort.class);
+        MailDraftCommandService service = new MailDraftCommandService(cachePort, chatModelProvider(), modelProperties());
+        when(cachePort.tryConsumeWeeklyLimit(userId)).thenReturn(false);
+
+        // when & then
+        assertDoesNotThrow(() -> service.validateWeeklyRateLimit(userId, Plan.PRO));
+
+        // then
+        verify(cachePort).tryConsumeWeeklyLimit(userId);
     }
 
     @Test

--- a/core/src/test/java/com/mailsangja/core/service/ai/review/MailReviewCommandServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/ai/review/MailReviewCommandServiceTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mailsangja.core.dto.mail.MailReviewCommand;
 import com.mailsangja.core.dto.mail.MailReviewIssueType;
 import com.mailsangja.core.dto.mail.MailReviewResult;
+import com.mailsangja.db.entity.user.Plan;
 import com.mailsangja.db.port.MailReviewRateLimitCachePort;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -19,10 +20,33 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MailReviewCommandServiceTest {
+
+    @Test
+    void pro사용자는한도초과여도카운트만소모하고허용한다() {
+        // given
+        UUID userId = UUID.randomUUID();
+        MailReviewRateLimitCachePort cachePort = mock(MailReviewRateLimitCachePort.class);
+        when(cachePort.tryConsumeWeeklyLimit(userId)).thenReturn(false);
+        MailReviewCommandService service = new MailReviewCommandService(
+                cachePort,
+                chatModelProvider(chatModel("{\"issues\":[]}")),
+                new ObjectMapper(),
+                new MailReviewQueryService()
+        );
+        MailReviewCommand command = new MailReviewCommand(userId, "", "검토할 본문입니다.", 0, List.of());
+
+        // when & then
+        assertDoesNotThrow(() -> service.review(command, Plan.PRO));
+
+        // then
+        verify(cachePort).tryConsumeWeeklyLimit(userId);
+    }
 
     @Test
     void llm후보를검증해서적용가능한issue만반환한다() {


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#n

### 📌 Task
- Related #130


## 💡 작업 내용

- `Plan.PRO` 사용자는 AI 기능 주간 rate limit을 초과해도 요청이 차단되지 않도록 변경했습니다.
- Redis 사용량 카운트는 `FREE`/`PRO` 모두 동일하게 계속 증가하도록 유지했습니다.
- 메일 초안, 메일 검토, 라벨 제안, AI Playground 호출 흐름에 사용자 플랜을 전달하도록 수정했습니다.
- 사용량 응답 DTO와 프론트 노출용 `limit` 값은 기존 계약을 유지했습니다.
- PR diff에서 잘못 포함되었던 `architecture/` 산출물을 제거하고, 재포함 방지를 위해 `.gitignore`에 `/architecture/`를 추가했습니다.


## 📝 추가 설명

### 1. Rate limit 정책 변경

기존에는 Redis rate limit cache의 `tryConsumeWeeklyLimit(userId)` 결과가 `false`이면 모든 사용자가 동일하게 429 예외를 받았습니다.

이번 변경에서는 `tryConsumeWeeklyLimit(userId)` 호출 자체는 그대로 유지하고, 초과 시 차단 여부만 플랜에 따라 분기합니다.

| 플랜 | Redis 카운트 증가 | 한도 초과 시 처리 |
| --- | --- | --- |
| `FREE` | 증가 | 기존처럼 429 예외 |
| `PRO` | 증가 | 예외 없이 요청 계속 처리 |

```mermaid
flowchart TD
    A[AI 기능 요청] --> B[Facade에서 user.plan 전달]
    B --> C[RateLimitCache.tryConsumeWeeklyLimit userId]
    C --> D{한도 내인가?}
    D -- 예 --> E[요청 처리]
    D -- 아니오 --> F{Plan.PRO 인가?}
    F -- 예 --> E
    F -- 아니오 --> G[429 RATE_LIMIT_EXCEEDED]
```

이 방식은 사용량 집계를 계속 유지하면서도 `PRO` 사용자의 기능 사용을 제한하지 않습니다.

### 2. 적용된 기능 범위

| 기능 | 변경 흐름 |
| --- | --- |
| 메일 초안 생성 | `MailDraftFacade` → `MailDraftAsyncService` → `MailDraftCommandService` |
| 메일 검토 | `MailReviewFacade` → `MailReviewCommandService` |
| 라벨 제안 | `LabelFacade` 내부 rate limit 검증 |
| AI Playground | `AiFacade` → `AiPlaygroundCommandService` |

각 기능의 실제 차단 분기는 아래와 같은 동일한 형태로 맞췄습니다.

```java
boolean allowed = rateLimitCachePort.tryConsumeWeeklyLimit(userId);
if (plan != Plan.PRO && !allowed) {
    throw new ...RateLimitExceededException(...);
}
```

### 3. 사용량 응답 계약 유지

프론트에서 사용하는 AI 사용량 응답은 변경하지 않았습니다.

| 항목 | 변경 여부 |
| --- | --- |
| `AiUsageItemResponse.used` | 유지 |
| `AiUsageItemResponse.limit` | 유지 |
| `limit=10` 등 기존 표시 | 유지 |
| `unlimited` 같은 신규 필드 | 추가하지 않음 |

따라서 `PRO` 사용자는 화면상 `limit=10`, `used=37`처럼 표시될 수 있지만, 서버에서는 차단되지 않습니다.

### 4. 주요 변경 파일

| 파일 | 변경 내용 |
| --- | --- |
| `core/facade/MailDraftFacade` | 메일 초안 스트리밍 진입 시 `user.getPlan()` 전달 |
| `core/service/ai/draft/MailDraftAsyncService` | async 스트리밍 내부 rate limit 검증까지 플랜 전달 |
| `core/service/ai/draft/MailDraftCommandService` | `PRO` 초과 요청 허용, Redis 카운트 호출 유지 |
| `core/facade/MailReviewFacade` | 메일 검토 서비스 호출 시 플랜 전달 |
| `core/service/ai/review/MailReviewCommandService` | `PRO` 초과 요청 허용, Redis 카운트 호출 유지 |
| `core/facade/LabelFacade` | 라벨 제안 rate limit 검증에 플랜 분기 추가 |
| `core/facade/AiFacade` | AI Playground 호출 시 플랜 전달 |
| `core/service/ai/AiPlaygroundCommandService` | `PRO` 초과 요청 허용, Redis 카운트 호출 유지 |
| `.gitignore` | `/architecture/` 제외 규칙 추가 |

### 5. 테스트 보강

- `FREE` 사용자는 한도 초과 시 기존 예외가 유지되는지 검증했습니다.
- `PRO` 사용자는 한도 초과 결과가 와도 예외 없이 통과하는지 검증했습니다.
- `PRO` 사용자 요청에서도 `tryConsumeWeeklyLimit(userId)`가 호출되어 Redis 카운트가 증가하는지 검증했습니다.
- Facade에서 서비스로 `user.getPlan()`이 전달되는지 검증했습니다.


## ⚡️ Test 결과

| 메일 초안 | 메일 검토 | 라벨 제안 | AI Playground |
| -- | -- | -- | -- |
| Unit Test | Unit Test | Unit Test | Unit Test |
| `MailDraftCommandServiceTest`, `MailDraftAsyncServiceTest`, `MailDraftFacadeTest` | `MailReviewCommandServiceTest` | `LabelFacadeTest` | `AiFacadeTest`, `AiPlaygroundCommandServiceTest` |
| `BUILD SUCCESSFUL` | `BUILD SUCCESSFUL` | `BUILD SUCCESSFUL` | `BUILD SUCCESSFUL` |

실행한 테스트:

```bash
./gradlew :test -x :db:test
```

결과:

```text
BUILD SUCCESSFUL
```
