### PR TITLE
[STORY-501] 하이브리드 서치 구현 및 연관 메일 조회

### DIFF
--- a/core/src/main/java/com/mailsangja/core/common/exception/inbox/InboxErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/inbox/InboxErrorCode.java
@@ -15,6 +15,7 @@ public enum InboxErrorCode implements ErrorCode {
     ATTACHMENT_ACCESS_DENIED(403, "MS-INBOX-ATTACHMENT-ACCESS-DENIED", "해당 첨부파일에 접근할 권한이 없습니다."),
     ATTACHMENT_PROVIDER_NOT_SUPPORTED(501, "MS-INBOX-ATTACHMENT-PROVIDER-NOT-SUPPORTED", "해당 메일 제공자의 첨부파일 조회는 아직 지원하지 않습니다."),
     ATTACHMENT_SOURCE_INVALID(502, "MS-INBOX-ATTACHMENT-SOURCE-INVALID", "첨부파일 원본 정보가 올바르지 않습니다."),
+    INVALID_SEARCH_REQUEST(400, "MS-INBOX-INVALID-SEARCH-REQUEST", "메일 검색 요청 형식이 올바르지 않습니다."),
     ATTACHMENT_DOWNLOAD_FAILED(502, "MS-INBOX-ATTACHMENT-DOWNLOAD-FAILED", "첨부파일 다운로드에 실패했습니다.");
 
     private final int status;

--- a/core/src/main/java/com/mailsangja/core/config/properties/AiModelProperties.java
+++ b/core/src/main/java/com/mailsangja/core/config/properties/AiModelProperties.java
@@ -18,6 +18,8 @@ import java.util.List;
 public class AiModelProperties {
 
     private String defaultModel;
+    private String draftModel;
+    private String labelSuggestionModel;
     private List<String> allowedModels = List.of();
 
     public String resolve(String requestedModel) {
@@ -35,8 +37,30 @@ public class AiModelProperties {
         return resolve(null);
     }
 
+    public String resolveDraft(String requestedModel) {
+        String model = normalize(requestedModel);
+        if (model == null) {
+            model = normalize(draftModel);
+        }
+        return resolveDefaulted(model);
+    }
+
+    public String labelSuggestionModel() {
+        return resolveDefaulted(normalize(labelSuggestionModel));
+    }
+
     public List<String> allowedModels() {
         return normalizedAllowedModels();
+    }
+
+    private String resolveDefaulted(String model) {
+        if (model == null) {
+            model = normalize(defaultModel);
+        }
+        if (model == null || !normalizedAllowedModels().contains(model)) {
+            throw new AiModelException(AiModelErrorCode.INVALID_MODEL);
+        }
+        return model;
     }
 
     private List<String> normalizedAllowedModels() {

--- a/core/src/main/java/com/mailsangja/core/controller/MailSearchController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/MailSearchController.java
@@ -1,0 +1,37 @@
+package com.mailsangja.core.controller;
+
+import com.mailsangja.core.common.auth.AuthUser;
+import com.mailsangja.core.controller.docs.MailSearchControllerDocs;
+import com.mailsangja.core.dto.search.HybridMailSearchResponse;
+import com.mailsangja.core.dto.search.HybridMailSearchScope;
+import com.mailsangja.core.facade.HybridMailSearchFacade;
+import com.mailsangja.db.entity.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+public class MailSearchController implements MailSearchControllerDocs {
+
+    private final HybridMailSearchFacade hybridMailSearchFacade;
+
+    @Override
+    @GetMapping("/api/v1/mail/search/hybrid")
+    public ResponseEntity<HybridMailSearchResponse> searchHybrid(
+            @AuthUser User user,
+            @RequestParam String q,
+            @RequestParam(required = false) HybridMailSearchScope scope,
+            @RequestParam(required = false) UUID mailAccountId,
+            @RequestParam(required = false, name = "labelId") List<UUID> labelIds,
+            @RequestParam(required = false) Boolean read,
+            @RequestParam(required = false) Integer size
+    ) {
+        return ResponseEntity.ok(hybridMailSearchFacade.search(user, q, scope, mailAccountId, labelIds, read, size));
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/controller/docs/MailSearchControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/MailSearchControllerDocs.java
@@ -1,0 +1,51 @@
+package com.mailsangja.core.controller.docs;
+
+import com.mailsangja.core.common.auth.AuthUser;
+import com.mailsangja.core.dto.search.HybridMailSearchResponse;
+import com.mailsangja.core.dto.search.HybridMailSearchScope;
+import com.mailsangja.db.entity.user.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag(name = "Mail Search", description = "메일 검색 API")
+public interface MailSearchControllerDocs {
+
+    @Operation(
+            summary = "하이브리드 메일 검색",
+            description = "VectorStore 유사도 검색과 PostgreSQL FTS 검색 결과를 RRF로 병합해 message 단위 결과를 반환합니다.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "하이브리드 메일 검색 성공"),
+            @ApiResponse(responseCode = "400", description = "검색 요청 형식 오류",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    ResponseEntity<HybridMailSearchResponse> searchHybrid(
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(description = "검색어", required = true, example = "프로젝트 일정 조율")
+            @RequestParam String q,
+            @Parameter(description = "검색 범위", example = "ALL")
+            @RequestParam(required = false) HybridMailSearchScope scope,
+            @Parameter(description = "특정 메일 계정 ID")
+            @RequestParam(required = false) UUID mailAccountId,
+            @Parameter(description = "필터링할 라벨 ID 목록. 여러 labelId 중 하나라도 부착되어 있으면 포함")
+            @RequestParam(required = false, name = "labelId") List<UUID> labelIds,
+            @Parameter(description = "읽음 여부 필터. 생략 시 전체 조회", example = "false")
+            @RequestParam(required = false) Boolean read,
+            @Parameter(description = "반환할 결과 수. 최대 50", example = "20")
+            @RequestParam(required = false) Integer size
+    );
+}

--- a/core/src/main/java/com/mailsangja/core/dto/search/HybridMailSearchItemResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/search/HybridMailSearchItemResponse.java
@@ -1,0 +1,87 @@
+package com.mailsangja.core.dto.search;
+
+import com.mailsangja.core.dto.inbox.MailAddressResponse;
+import com.mailsangja.db.entity.mail.Direction;
+import com.mailsangja.db.entity.mail.Message;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Schema(description = "하이브리드 메일 검색 결과 항목")
+public record HybridMailSearchItemResponse(
+        @Schema(description = "메시지 ID")
+        UUID messageId,
+        @Schema(description = "스레드 ID")
+        UUID threadId,
+        @Schema(description = "메일 계정 ID")
+        UUID mailAccountId,
+        @Schema(description = "메시지 방향")
+        Direction direction,
+        @Schema(description = "제목")
+        String subject,
+        @Schema(description = "발신자")
+        MailAddressResponse from,
+        @Schema(description = "수신자 목록")
+        List<MailAddressResponse> to,
+        @Schema(description = "스니펫")
+        String snippet,
+        @Schema(description = "읽음 여부")
+        boolean read,
+        @Schema(description = "별표 여부")
+        boolean star,
+        @Schema(description = "발송/수신 시각")
+        LocalDateTime sentAt,
+        @Schema(description = "검색 매칭 방식")
+        List<HybridMailSearchMatchType> matchedBy,
+        @Schema(description = "RRF 기반 검색 점수")
+        double score
+) {
+    public static HybridMailSearchItemResponse from(
+            HybridMailSearchItemResult result,
+            Map<String, String> contactNameByEmail
+    ) {
+        Message message = result.message();
+        return new HybridMailSearchItemResponse(
+                message.getId(),
+                message.getThread().getId(),
+                message.getThread().getMailAccount().getId(),
+                message.getDirection(),
+                message.getSubject(),
+                MailAddressResponse.of(message.getFromName(), message.getFromAddress(), contactNameByEmail),
+                toMailAddressResponses(message.getToAddresses(), message.getToNames(), contactNameByEmail),
+                message.getSnippet(),
+                message.isRead(),
+                message.isStar(),
+                message.getSentAt(),
+                result.matchedBy(),
+                result.score()
+        );
+    }
+
+    private static List<MailAddressResponse> toMailAddressResponses(
+            List<String> emails,
+            List<String> names,
+            Map<String, String> contactNameByEmail
+    ) {
+        if (emails == null || emails.isEmpty()) {
+            return List.of();
+        }
+        return java.util.stream.IntStream.range(0, emails.size())
+                .mapToObj(index -> MailAddressResponse.of(
+                        resolveName(names, index),
+                        emails.get(index),
+                        contactNameByEmail
+                ))
+                .toList();
+    }
+
+    private static String resolveName(List<String> names, int index) {
+        if (names == null || index >= names.size()) {
+            return null;
+        }
+        return names.get(index);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/search/HybridMailSearchItemResult.java
+++ b/core/src/main/java/com/mailsangja/core/dto/search/HybridMailSearchItemResult.java
@@ -1,0 +1,15 @@
+package com.mailsangja.core.dto.search;
+
+import com.mailsangja.db.entity.mail.Message;
+
+import java.util.List;
+
+public record HybridMailSearchItemResult(
+        Message message,
+        List<HybridMailSearchMatchType> matchedBy,
+        double score
+) {
+    public HybridMailSearchItemResult {
+        matchedBy = matchedBy == null ? List.of() : List.copyOf(matchedBy);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/search/HybridMailSearchMatchType.java
+++ b/core/src/main/java/com/mailsangja/core/dto/search/HybridMailSearchMatchType.java
@@ -1,0 +1,6 @@
+package com.mailsangja.core.dto.search;
+
+public enum HybridMailSearchMatchType {
+    VECTOR,
+    LEXICAL
+}

--- a/core/src/main/java/com/mailsangja/core/dto/search/HybridMailSearchResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/search/HybridMailSearchResponse.java
@@ -1,0 +1,19 @@
+package com.mailsangja.core.dto.search;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "하이브리드 메일 검색 응답")
+public record HybridMailSearchResponse(
+        @Schema(description = "검색 결과 목록")
+        List<HybridMailSearchItemResponse> content
+) {
+    public HybridMailSearchResponse {
+        content = content == null ? List.of() : List.copyOf(content);
+    }
+
+    public static HybridMailSearchResponse of(List<HybridMailSearchItemResponse> content) {
+        return new HybridMailSearchResponse(content);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/search/HybridMailSearchResult.java
+++ b/core/src/main/java/com/mailsangja/core/dto/search/HybridMailSearchResult.java
@@ -1,0 +1,14 @@
+package com.mailsangja.core.dto.search;
+
+import java.util.List;
+import java.util.Map;
+
+public record HybridMailSearchResult(
+        List<HybridMailSearchItemResult> items,
+        Map<String, String> contactNameByEmail
+) {
+    public HybridMailSearchResult {
+        items = items == null ? List.of() : List.copyOf(items);
+        contactNameByEmail = contactNameByEmail == null ? Map.of() : Map.copyOf(contactNameByEmail);
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/dto/search/HybridMailSearchScope.java
+++ b/core/src/main/java/com/mailsangja/core/dto/search/HybridMailSearchScope.java
@@ -1,0 +1,17 @@
+package com.mailsangja.core.dto.search;
+
+import com.mailsangja.db.entity.mail.Direction;
+
+public enum HybridMailSearchScope {
+    ALL,
+    INBOX,
+    SENT;
+
+    public Direction direction() {
+        return switch (this) {
+            case ALL -> null;
+            case INBOX -> Direction.INBOUND;
+            case SENT -> Direction.OUTBOUND;
+        };
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/facade/HybridMailSearchFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/HybridMailSearchFacade.java
@@ -1,0 +1,59 @@
+package com.mailsangja.core.facade;
+
+import com.mailsangja.core.common.exception.inbox.InboxErrorCode;
+import com.mailsangja.core.common.exception.inbox.InboxException;
+import com.mailsangja.core.dto.search.HybridMailSearchItemResponse;
+import com.mailsangja.core.dto.search.HybridMailSearchResponse;
+import com.mailsangja.core.dto.search.HybridMailSearchResult;
+import com.mailsangja.core.dto.search.HybridMailSearchScope;
+import com.mailsangja.core.service.search.HybridMailSearchQueryService;
+import com.mailsangja.db.entity.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class HybridMailSearchFacade {
+
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 50;
+
+    private final HybridMailSearchQueryService hybridMailSearchQueryService;
+
+    public HybridMailSearchResponse search(
+            User user,
+            String query,
+            HybridMailSearchScope scope,
+            UUID mailAccountId,
+            List<UUID> labelIds,
+            Boolean read,
+            Integer size
+    ) {
+        validateRequest(user, query, size);
+        HybridMailSearchResult result = hybridMailSearchQueryService.search(
+                user.getId(),
+                query.trim(),
+                scope == null ? HybridMailSearchScope.ALL : scope,
+                mailAccountId,
+                labelIds,
+                read,
+                resolveSize(size)
+        );
+        return HybridMailSearchResponse.of(result.items().stream()
+                .map(item -> HybridMailSearchItemResponse.from(item, result.contactNameByEmail()))
+                .toList());
+    }
+
+    private void validateRequest(User user, String query, Integer size) {
+        if (user == null || query == null || query.isBlank() || resolveSize(size) <= 0 || resolveSize(size) > MAX_SIZE) {
+            throw new InboxException(InboxErrorCode.INVALID_SEARCH_REQUEST);
+        }
+    }
+
+    private int resolveSize(Integer size) {
+        return size == null ? DEFAULT_SIZE : size;
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/service/ai/draft/MailDraftCommandService.java
+++ b/core/src/main/java/com/mailsangja/core/service/ai/draft/MailDraftCommandService.java
@@ -191,7 +191,7 @@ public class MailDraftCommandService {
     }
 
     public String resolveModel(String requestedModel) {
-        return modelProperties.resolve(requestedModel);
+        return modelProperties.resolveDraft(requestedModel);
     }
 
     private Prompt createPrompt(MailDraftPromptResult prompt, MailDraftPhase phase, String model) {

--- a/core/src/main/java/com/mailsangja/core/service/ai/draft/MailDraftLexicalQueryBuilder.java
+++ b/core/src/main/java/com/mailsangja/core/service/ai/draft/MailDraftLexicalQueryBuilder.java
@@ -1,0 +1,59 @@
+package com.mailsangja.core.service.ai.draft;
+
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class MailDraftLexicalQueryBuilder {
+
+    private static final int MAX_TERMS = 12;
+    private static final Pattern TERM_PATTERN = Pattern.compile("[가-힣A-Za-z0-9]+");
+
+    public String build(String query, Map<String, String> restoreTokenMap) {
+        Set<String> terms = extractTerms(restoreTokens(query, restoreTokenMap));
+        return String.join(" | ", terms);
+    }
+
+    private String restoreTokens(String query, Map<String, String> restoreTokenMap) {
+        if (query == null || query.isBlank() || restoreTokenMap == null || restoreTokenMap.isEmpty()) {
+            return nullToEmpty(query);
+        }
+        String restored = query;
+        for (Map.Entry<String, String> entry : restoreTokenMap.entrySet()) {
+            restored = restored.replace(entry.getKey(), nullToEmpty(entry.getValue()));
+        }
+        return restored;
+    }
+
+    private Set<String> extractTerms(String query) {
+        Set<String> terms = new LinkedHashSet<>();
+        Matcher matcher = TERM_PATTERN.matcher(nullToEmpty(query));
+        while (matcher.find() && terms.size() < MAX_TERMS) {
+            addTerm(terms, matcher.group());
+        }
+        return terms;
+    }
+
+    private void addTerm(Set<String> terms, String value) {
+        String normalized = normalize(value);
+        if (normalized.length() >= 2) {
+            terms.add(normalized);
+        }
+    }
+
+    private String normalize(String value) {
+        return nullToEmpty(value).trim().toLowerCase();
+    }
+
+    private String nullToEmpty(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value;
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/service/ai/draft/MailDraftQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/ai/draft/MailDraftQueryService.java
@@ -44,6 +44,11 @@ public class MailDraftQueryService {
     private static final int USER_RELEVANT_WRITTEN_LIMIT = 3;
     private static final int RECIPIENT_HISTORY_LIMIT = 6;
     private static final int VECTOR_SEARCH_LIMIT = 40;
+    private static final int HYBRID_LEXICAL_SEARCH_LIMIT = 40;
+    private static final int HYBRID_RESULT_LIMIT = 40;
+    private static final int RRF_K = 60;
+    private static final double VECTOR_RRF_WEIGHT = 0.6;
+    private static final double LEXICAL_RRF_WEIGHT = 0.4;
     private static final String SOURCE_RECENT_SENT = "recent_sent";
     private static final String SOURCE_ENTITY_HINT = "entity_hint";
     private static final String SOURCE_RELEVANT_SENT = "relevant_sent";
@@ -123,6 +128,7 @@ public class MailDraftQueryService {
     private final MailDraftReferenceQueryPort referenceQueryPort;
     private final VectorStore vectorStore;
     private final PhileasMaskingService maskingService;
+    private final MailDraftLexicalQueryBuilder lexicalQueryBuilder;
 
     public void validatePromptInjection(String query) {
         if (query == null) {
@@ -373,7 +379,7 @@ public class MailDraftQueryService {
 
     private List<MailDraftSearchContextResult> findGeneralRelevant(MailDraftCommand command) {
         List<MailDraftSearchContextResult> entity = findEntityHintRelevant(command);
-        List<MailDraftReferenceMessageResult> accountMessages = findAccountVectorMessages(command);
+        List<MailDraftReferenceMessageResult> accountMessages = findAccountHybridMessages(command);
         List<MailDraftSearchContextResult> sent = findAccountRelevantWritten(command, accountMessages);
         List<MailDraftSearchContextResult> received = findAccountRelevantReceived(command, accountMessages);
         List<MailDraftSearchContextResult> user = findUserRelevantWritten(command);
@@ -468,7 +474,7 @@ public class MailDraftQueryService {
     }
 
     private List<MailDraftSearchContextResult> findUserRelevantWritten(MailDraftCommand command) {
-        List<MailDraftReferenceMessageResult> messages = findUserVectorMessages(command);
+        List<MailDraftReferenceMessageResult> messages = findUserHybridMessages(command);
         List<MailDraftReferenceMessageResult> filtered = filterByDirection(
                 messages, Direction.OUTBOUND, USER_RELEVANT_WRITTEN_LIMIT
         );
@@ -505,16 +511,88 @@ public class MailDraftQueryService {
         return toMaskedContexts(filtered, SOURCE_RELEVANT_SENT);
     }
 
-    private List<MailDraftReferenceMessageResult> findAccountVectorMessages(MailDraftCommand command) {
-        return findAccountVectorMessages(command.userId(), command.mailAccountId(), command.maskedQuery());
-    }
-
     private List<MailDraftReferenceMessageResult> findAccountVectorMessages(UUID userId, UUID mailAccountId, String query) {
         return findVectorMessages(query, accountVectorFilter(userId, mailAccountId));
     }
 
-    private List<MailDraftReferenceMessageResult> findUserVectorMessages(MailDraftCommand command) {
-        return findVectorMessages(command.maskedQuery(), userVectorFilter(command.userId()));
+    private List<MailDraftReferenceMessageResult> findAccountHybridMessages(MailDraftCommand command) {
+        if (referenceQueryPort == null) {
+            return List.of();
+        }
+        List<UUID> vectorIds = findVectorMessageIds(command.maskedQuery(), accountVectorFilter(command.userId(), command.mailAccountId()));
+        List<UUID> lexicalIds = findAccountLexicalMessageIds(command);
+        return findRankedMessages(rankHybrid(vectorIds, lexicalIds, HYBRID_RESULT_LIMIT));
+    }
+
+    private List<MailDraftReferenceMessageResult> findUserHybridMessages(MailDraftCommand command) {
+        if (referenceQueryPort == null) {
+            return List.of();
+        }
+        List<UUID> vectorIds = findVectorMessageIds(command.maskedQuery(), userVectorFilter(command.userId()));
+        List<UUID> lexicalIds = findUserLexicalMessageIds(command);
+        return findRankedMessages(rankHybrid(vectorIds, lexicalIds, HYBRID_RESULT_LIMIT));
+    }
+
+    private List<MailDraftReferenceMessageResult> findRankedMessages(List<UUID> rankedIds) {
+        if (rankedIds == null || rankedIds.isEmpty()) {
+            return List.of();
+        }
+        return orderByMessageIds(referenceQueryPort.findMessagesByIds(rankedIds), rankedIds);
+    }
+
+    private List<UUID> findAccountLexicalMessageIds(MailDraftCommand command) {
+        String tsQuery = lexicalQuery(command);
+        if (tsQuery.isBlank()) {
+            return List.of();
+        }
+        try {
+            return referenceQueryPort.findAccountLexicalRelevantMessageIds(
+                    command.userId(), command.mailAccountId(), tsQuery, HYBRID_LEXICAL_SEARCH_LIMIT
+            );
+        } catch (RuntimeException exception) {
+            log.warn("Mail draft account lexical search failed. userId={} mailAccountId={}",
+                    command.userId(), command.mailAccountId(), exception);
+            return List.of();
+        }
+    }
+
+    private List<UUID> findUserLexicalMessageIds(MailDraftCommand command) {
+        String tsQuery = lexicalQuery(command);
+        if (tsQuery.isBlank()) {
+            return List.of();
+        }
+        try {
+            return referenceQueryPort.findUserLexicalRelevantMessageIds(
+                    command.userId(), tsQuery, HYBRID_LEXICAL_SEARCH_LIMIT
+            );
+        } catch (RuntimeException exception) {
+            log.warn("Mail draft user lexical search failed. userId={}", command.userId(), exception);
+            return List.of();
+        }
+    }
+
+    private String lexicalQuery(MailDraftCommand command) {
+        return lexicalQueryBuilder.build(command.maskedQuery(), command.restoreTokenMap());
+    }
+
+    private List<UUID> rankHybrid(List<UUID> vectorIds, List<UUID> lexicalIds, int limit) {
+        Map<UUID, Double> scores = new LinkedHashMap<>();
+        addRrfScores(scores, vectorIds, VECTOR_RRF_WEIGHT);
+        addRrfScores(scores, lexicalIds, LEXICAL_RRF_WEIGHT);
+        return scores.entrySet().stream()
+                .sorted(Map.Entry.<UUID, Double>comparingByValue().reversed())
+                .limit(limit)
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
+    private void addRrfScores(Map<UUID, Double> scores, List<UUID> ids, double weight) {
+        if (ids == null || ids.isEmpty()) {
+            return;
+        }
+        for (int i = 0; i < ids.size(); i++) {
+            scores.merge(ids.get(i), weight / (RRF_K + i + 1), Double::sum);
+        }
     }
 
     private List<MailDraftReferenceMessageResult> findVectorMessages(String query, Filter.Expression filter) {
@@ -527,6 +605,18 @@ public class MailDraftQueryService {
     private List<MailDraftReferenceMessageResult> findVectorMessagesOrEmpty(String query, Filter.Expression filter) {
         try {
             return findVectorMessagesStrict(query, filter);
+        } catch (RuntimeException exception) {
+            log.warn("Mail draft vector search failed. filter={}", filter, exception);
+            return List.of();
+        }
+    }
+
+    private List<UUID> findVectorMessageIds(String query, Filter.Expression filter) {
+        if (vectorStore == null) {
+            return List.of();
+        }
+        try {
+            return messageIdsFromVectorSearch(query, filter);
         } catch (RuntimeException exception) {
             log.warn("Mail draft vector search failed. filter={}", filter, exception);
             return List.of();

--- a/core/src/main/java/com/mailsangja/core/service/ai/label/LabelSuggestionAiService.java
+++ b/core/src/main/java/com/mailsangja/core/service/ai/label/LabelSuggestionAiService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mailsangja.core.common.exception.label.LabelErrorCode;
 import com.mailsangja.core.common.exception.label.LabelException;
+import com.mailsangja.core.config.properties.AiModelProperties;
 import com.mailsangja.core.config.properties.LabelSuggestionProperties;
 import com.mailsangja.core.dto.label.LlmLabelSuggestionResult;
 import com.mailsangja.db.entity.label.Label;
@@ -20,6 +21,7 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.ai.converter.StructuredOutputConverter;
+import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -128,6 +130,7 @@ public class LabelSuggestionAiService {
     private final ObjectProvider<ChatModel> chatModelProvider;
     private final ObjectMapper objectMapper;
     private final LabelSuggestionProperties properties;
+    private final AiModelProperties modelProperties;
     private final SnippetPreprocessor snippetPreprocessor;
 
     public LlmLabelSuggestionResult suggest(UUID userId, List<Label> existingLabels) {
@@ -147,6 +150,8 @@ public class LabelSuggestionAiService {
         try {
             LlmLabelSuggestionResult result = ChatClient.create(chatModel())
                     .prompt(createPrompt(messages, existingLabels, converter))
+                    .options(OpenAiChatOptions.builder()
+                            .model(modelProperties.labelSuggestionModel()))
                     .tools(new SnippetTool(snippetMap))
                     .call()
                     .entity(converter);

--- a/core/src/main/java/com/mailsangja/core/service/search/HybridMailSearchQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/search/HybridMailSearchQueryService.java
@@ -1,0 +1,252 @@
+package com.mailsangja.core.service.search;
+
+import com.mailsangja.core.dto.search.HybridMailSearchItemResult;
+import com.mailsangja.core.dto.search.HybridMailSearchMatchType;
+import com.mailsangja.core.dto.search.HybridMailSearchResult;
+import com.mailsangja.core.dto.search.HybridMailSearchScope;
+import com.mailsangja.db.entity.contact.Contact;
+import com.mailsangja.db.entity.mail.Direction;
+import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.port.ContactRepositoryPort;
+import com.mailsangja.db.port.MailSearchRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HybridMailSearchQueryService {
+
+    private static final int CANDIDATE_MULTIPLIER = 5;
+    private static final int MIN_CANDIDATE_LIMIT = 40;
+    private static final int RRF_K = 60;
+    private static final double VECTOR_RRF_WEIGHT = 0.6;
+    private static final double LEXICAL_RRF_WEIGHT = 0.4;
+
+    private final MailSearchRepositoryPort mailSearchRepositoryPort;
+    private final ContactRepositoryPort contactRepositoryPort;
+    private final VectorStore vectorStore;
+    private final HybridSearchLexicalQueryBuilder lexicalQueryBuilder;
+
+    public HybridMailSearchResult search(
+            UUID userId,
+            String query,
+            HybridMailSearchScope scope,
+            UUID mailAccountId,
+            List<UUID> labelIds,
+            Boolean read,
+            int size
+    ) {
+        int resultLimit = Math.max(size, 1);
+        int candidateLimit = Math.max(MIN_CANDIDATE_LIMIT, resultLimit * CANDIDATE_MULTIPLIER);
+        Direction direction = scope.direction();
+        List<UUID> vectorIds = findVectorMessageIds(userId, query, direction, mailAccountId, candidateLimit);
+        List<UUID> lexicalIds = findLexicalMessageIds(userId, query, direction, mailAccountId, labelIds, read, candidateLimit);
+        Map<UUID, RankedMessage> ranked = rankHybrid(vectorIds, lexicalIds, candidateLimit);
+        List<UUID> rankedIds = ranked.keySet().stream().toList();
+        List<Message> messages = mailSearchRepositoryPort.findHybridMessagesByIds(
+                userId, rankedIds, mailAccountId, direction, labelIds, read
+        );
+        List<HybridMailSearchItemResult> items = orderByRank(messages, ranked, resultLimit);
+        return new HybridMailSearchResult(items, findContactNamesByEmails(userId, items));
+    }
+
+    private List<UUID> findVectorMessageIds(
+            UUID userId,
+            String query,
+            Direction direction,
+            UUID mailAccountId,
+            int limit
+    ) {
+        try {
+            SearchRequest request = SearchRequest.builder()
+                    .query(query)
+                    .topK(limit)
+                    .filterExpression(vectorFilter(userId, direction, mailAccountId))
+                    .build();
+            return vectorStore.similaritySearch(request).stream()
+                    .map(this::messageId)
+                    .filter(id -> id != null)
+                    .distinct()
+                    .toList();
+        } catch (RuntimeException exception) {
+            log.warn("Hybrid mail vector search failed. userId={} direction={} mailAccountId={}",
+                    userId, direction, mailAccountId, exception);
+            return List.of();
+        }
+    }
+
+    private Filter.Expression vectorFilter(UUID userId, Direction direction, UUID mailAccountId) {
+        FilterExpressionBuilder builder = new FilterExpressionBuilder();
+        if (mailAccountId == null && direction == null) {
+            return builder.eq("UserId", userId.toString()).build();
+        }
+        if (mailAccountId != null && direction != null) {
+            return builder.and(
+                    builder.and(
+                            builder.eq("UserId", userId.toString()),
+                            builder.eq("MailAccountId", mailAccountId.toString())
+                    ),
+                    builder.eq("Direction", direction.name())
+            ).build();
+        }
+        if (mailAccountId != null) {
+            return builder.and(
+                    builder.eq("UserId", userId.toString()),
+                    builder.eq("MailAccountId", mailAccountId.toString())
+            ).build();
+        }
+        return builder.and(
+                builder.eq("UserId", userId.toString()),
+                builder.eq("Direction", direction.name())
+        ).build();
+    }
+
+    private UUID messageId(Document document) {
+        Object value = document.getMetadata().get("MessageId");
+        if (value == null) {
+            return null;
+        }
+        try {
+            return UUID.fromString(value.toString());
+        } catch (IllegalArgumentException exception) {
+            log.warn("Hybrid mail vector document has invalid MessageId metadata. messageId={}", value);
+            return null;
+        }
+    }
+
+    private List<UUID> findLexicalMessageIds(
+            UUID userId,
+            String query,
+            Direction direction,
+            UUID mailAccountId,
+            List<UUID> labelIds,
+            Boolean read,
+            int limit
+    ) {
+        String tsQuery = lexicalQueryBuilder.build(query);
+        if (tsQuery.isBlank()) {
+            return List.of();
+        }
+        try {
+            return mailSearchRepositoryPort.findHybridLexicalMessageIds(
+                    userId, mailAccountId, direction, tsQuery, labelIds, read, limit
+            );
+        } catch (RuntimeException exception) {
+            log.warn("Hybrid mail lexical search failed. userId={} direction={} mailAccountId={}",
+                    userId, direction, mailAccountId, exception);
+            return List.of();
+        }
+    }
+
+    private Map<UUID, RankedMessage> rankHybrid(List<UUID> vectorIds, List<UUID> lexicalIds, int limit) {
+        Map<UUID, RankedMessage> scores = new LinkedHashMap<>();
+        addRrfScores(scores, vectorIds, HybridMailSearchMatchType.VECTOR, VECTOR_RRF_WEIGHT);
+        addRrfScores(scores, lexicalIds, HybridMailSearchMatchType.LEXICAL, LEXICAL_RRF_WEIGHT);
+        return scores.entrySet().stream()
+                .sorted(Map.Entry.<UUID, RankedMessage>comparingByValue(
+                        Comparator.comparingDouble(RankedMessage::score)
+                ).reversed())
+                .limit(limit)
+                .collect(LinkedHashMap::new, (map, entry) -> map.put(entry.getKey(), entry.getValue()), Map::putAll);
+    }
+
+    private void addRrfScores(
+            Map<UUID, RankedMessage> scores,
+            List<UUID> ids,
+            HybridMailSearchMatchType matchType,
+            double weight
+    ) {
+        if (ids == null || ids.isEmpty()) {
+            return;
+        }
+        for (int index = 0; index < ids.size(); index++) {
+            UUID id = ids.get(index);
+            RankedMessage ranked = scores.computeIfAbsent(id, ignored -> new RankedMessage());
+            ranked.addScore(weight / (RRF_K + index + 1));
+            ranked.addMatchType(matchType);
+        }
+    }
+
+    private List<HybridMailSearchItemResult> orderByRank(
+            List<Message> messages,
+            Map<UUID, RankedMessage> ranked,
+            int limit
+    ) {
+        Map<UUID, Message> messageById = new LinkedHashMap<>();
+        for (Message message : messages) {
+            messageById.put(message.getId(), message);
+        }
+        List<HybridMailSearchItemResult> results = new ArrayList<>();
+        for (Map.Entry<UUID, RankedMessage> entry : ranked.entrySet()) {
+            Message message = messageById.get(entry.getKey());
+            if (message == null) {
+                continue;
+            }
+            RankedMessage score = entry.getValue();
+            results.add(new HybridMailSearchItemResult(message, score.matchTypes(), score.score()));
+            if (results.size() >= limit) {
+                break;
+            }
+        }
+        return results;
+    }
+
+    private Map<String, String> findContactNamesByEmails(UUID userId, List<HybridMailSearchItemResult> items) {
+        List<String> emails = items.stream()
+                .flatMap(item -> participantEmails(item.message()).stream())
+                .filter(email -> email != null && !email.isBlank())
+                .distinct()
+                .toList();
+        if (emails.isEmpty()) {
+            return Map.of();
+        }
+        return contactRepositoryPort.findAllByUserIdAndEmailInAndDeletedAtIsNull(userId, emails)
+                .stream()
+                .collect(java.util.stream.Collectors.toMap(Contact::getEmail, Contact::getName));
+    }
+
+    private List<String> participantEmails(Message message) {
+        List<String> emails = new ArrayList<>();
+        emails.add(message.getFromAddress());
+        if (message.getToAddresses() != null) {
+            emails.addAll(message.getToAddresses());
+        }
+        return emails;
+    }
+
+    private static final class RankedMessage {
+        private double score;
+        private final EnumSet<HybridMailSearchMatchType> matchTypes = EnumSet.noneOf(HybridMailSearchMatchType.class);
+
+        private void addScore(double value) {
+            score += value;
+        }
+
+        private void addMatchType(HybridMailSearchMatchType matchType) {
+            matchTypes.add(matchType);
+        }
+
+        private double score() {
+            return score;
+        }
+
+        private List<HybridMailSearchMatchType> matchTypes() {
+            return List.copyOf(matchTypes);
+        }
+    }
+}

--- a/core/src/main/java/com/mailsangja/core/service/search/HybridSearchLexicalQueryBuilder.java
+++ b/core/src/main/java/com/mailsangja/core/service/search/HybridSearchLexicalQueryBuilder.java
@@ -1,0 +1,30 @@
+package com.mailsangja.core.service.search;
+
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class HybridSearchLexicalQueryBuilder {
+
+    private static final int MAX_TERMS = 12;
+    private static final Pattern TERM_PATTERN = Pattern.compile("[가-힣A-Za-z0-9]+");
+
+    public String build(String query) {
+        if (query == null || query.isBlank()) {
+            return "";
+        }
+        Set<String> terms = new LinkedHashSet<>();
+        Matcher matcher = TERM_PATTERN.matcher(query);
+        while (matcher.find() && terms.size() < MAX_TERMS) {
+            String term = matcher.group().toLowerCase();
+            if (term.length() >= 2) {
+                terms.add(term);
+            }
+        }
+        return String.join(" | ", terms);
+    }
+}

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -108,6 +108,8 @@ mailsangja:
   ai:
     model:
       default-model: ${AI_DEFAULT_MODEL:${MAIL_DRAFT_DEFAULT_MODEL:google/gemini-3.5-flash}}
+      draft-model: ${MAIL_DRAFT_MODEL:${AI_DRAFT_MODEL:${AI_DEFAULT_MODEL:${MAIL_DRAFT_DEFAULT_MODEL:google/gemini-3.5-flash}}}}
+      label-suggestion-model: ${LABEL_SUGGESTION_MODEL:${AI_LABEL_MODEL:${AI_DEFAULT_MODEL:google/gemini-3.5-flash}}}
       allowed-models: ${AI_ALLOWED_MODELS:${MAIL_DRAFT_ALLOWED_MODELS:google/gemini-3.5-flash,google/gemini-3.1-pro-preview,google/gemini-3.1-flash-lite,google/gemini-3-pro-preview,google/gemini-3-flash-preview,google/gemini-2.5-pro,google/gemini-2.5-flash,google/gemini-2.5-flash-lite,openai/gpt-5.5,openai/gpt-5.5-pro,openai/gpt-5.4-nano,openai/gpt-5.4-mini,openai/gpt-5.4,openai/gpt-5.4-pro,openai/gpt-5.3-chat,openai/gpt-5.3-codex,openai/gpt-5.2-chat,openai/gpt-5.2,openai/gpt-5.1,openai/gpt-4.1,openai/gpt-4.1-mini,openai/gpt-4.1-nano,qwen/qwen3.6-flash,qwen/qwen3.5-plus-20260420,anthropic/claude-haiku-4.5,anthropic/claude-sonnet-4.6,anthropic/claude-sonnet-4.5,anthropic/claude-sonnet-4,anthropic/claude-opus-4.7,anthropic/claude-opus-4.7-fast,anthropic/claude-opus-4.6,anthropic/claude-opus-4.6-fast,anthropic/claude-opus-4.1,anthropic/claude-opus-4,mistralai/mistral-medium-3-5,x-ai/grok-4.3}}
   redis:
     rate-limit:

--- a/core/src/test/java/com/mailsangja/core/service/ai/draft/MailDraftLexicalQueryBuilderTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/ai/draft/MailDraftLexicalQueryBuilderTest.java
@@ -1,0 +1,40 @@
+package com.mailsangja.core.service.ai.draft;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MailDraftLexicalQueryBuilderTest {
+
+    private final MailDraftLexicalQueryBuilder builder = new MailDraftLexicalQueryBuilder();
+
+    @Test
+    void 문장에서안전한OrTsQuery를만든다() {
+        // when
+        String result = builder.build("김철수 교수님께 수강 정정 가능한지 메일 써줘?", Map.of());
+
+        // then
+        assertEquals("김철수 | 교수님께 | 수강 | 정정 | 가능한지 | 메일 | 써줘", result);
+    }
+
+    @Test
+    void tsquery문법문자는토큰에서제외한다() {
+        // when
+        String result = builder.build("수강 & 정정 | DROP! (교수)", Map.of());
+
+        // then
+        assertEquals("수강 | 정정 | drop | 교수", result);
+    }
+
+    @Test
+    void 마스킹토큰을복원한뒤검색토큰을만든다() {
+        // when
+        String result = builder.build("[PERSON_1]에게 [EMAIL_1] 관련 메일 써줘",
+                Map.of("[PERSON_1]", "김철수", "[EMAIL_1]", "kim@example.com"));
+
+        // then
+        assertEquals("김철수에게 | kim | example | com | 관련 | 메일 | 써줘", result);
+    }
+}

--- a/core/src/test/java/com/mailsangja/core/service/ai/draft/MailDraftQueryServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/ai/draft/MailDraftQueryServiceTest.java
@@ -287,6 +287,94 @@ class MailDraftQueryServiceTest {
     }
 
     @Test
+    void general은vector와lexical후보를Rrf로병합해계정관련메일을조회한다() {
+        // given
+        Fixture fixture = createFixture();
+        MailDraftCommand command = createCommandWithRestoreToken();
+        UUID vectorOnlyId = UUID.randomUUID();
+        UUID duplicatedId = UUID.randomUUID();
+        UUID lexicalOnlyId = UUID.randomUUID();
+        List<MailDraftReferenceMessageResult> rankedMessages = List.of(
+                reference(vectorOnlyId, command.mailAccountId(), Direction.OUTBOUND),
+                reference(duplicatedId, command.mailAccountId(), Direction.OUTBOUND),
+                reference(lexicalOnlyId, command.mailAccountId(), Direction.OUTBOUND)
+        );
+        when(fixture.vectorStore().similaritySearch(any(SearchRequest.class)))
+                .thenReturn(documents(List.of(rankedMessages.get(0), rankedMessages.get(1))), List.of());
+        when(fixture.referenceQueryPort().findAccountLexicalRelevantMessageIds(
+                eq(command.userId()), eq(command.mailAccountId()), any(), eq(40)
+        )).thenReturn(List.of(duplicatedId, lexicalOnlyId));
+        when(fixture.referenceQueryPort().findMessagesByIds(any())).thenReturn(rankedMessages);
+
+        // when
+        MailDraftRagContextResult result = fixture.service().generalRagContext(command);
+
+        // then
+        var idsCaptor = forClass(List.class);
+        verify(fixture.referenceQueryPort()).findMessagesByIds(idsCaptor.capture());
+        assertEquals(List.of(duplicatedId, vectorOnlyId, lexicalOnlyId), idsCaptor.getValue());
+        assertEquals(3, result.relevantMessages().size());
+    }
+
+    @Test
+    void general은lexical검색만성공해도관련메일을사용한다() {
+        // given
+        Fixture fixture = createFixture();
+        MailDraftCommand command = createCommand(null);
+        UUID lexicalId = UUID.randomUUID();
+        MailDraftReferenceMessageResult lexicalMessage = reference(lexicalId, command.mailAccountId(), Direction.INBOUND);
+        when(fixture.vectorStore().similaritySearch(any(SearchRequest.class))).thenReturn(List.of(), List.of());
+        when(fixture.referenceQueryPort().findAccountLexicalRelevantMessageIds(
+                eq(command.userId()), eq(command.mailAccountId()), any(), eq(40)
+        )).thenReturn(List.of(lexicalId));
+        when(fixture.referenceQueryPort().findMessagesByIds(any())).thenReturn(List.of(lexicalMessage));
+
+        // when
+        MailDraftRagContextResult result = fixture.service().generalRagContext(command);
+
+        // then
+        assertEquals(1, result.relevantMessages().size());
+        assertEquals("relevant_received", result.relevantMessages().getFirst().source());
+    }
+
+    @Test
+    void general은lexical검색실패시vector결과만사용한다() {
+        // given
+        Fixture fixture = createFixture();
+        MailDraftCommand command = createCommand(null);
+        MailDraftReferenceMessageResult vectorMessage = reference(UUID.randomUUID(), command.mailAccountId(), Direction.OUTBOUND);
+        when(fixture.vectorStore().similaritySearch(any(SearchRequest.class)))
+                .thenReturn(documents(List.of(vectorMessage)), List.of());
+        when(fixture.referenceQueryPort().findAccountLexicalRelevantMessageIds(any(), any(), any(), eq(40)))
+                .thenThrow(new RuntimeException("lexical failed"));
+        when(fixture.referenceQueryPort().findMessagesByIds(any())).thenReturn(List.of(vectorMessage));
+
+        // when
+        MailDraftRagContextResult result = fixture.service().generalRagContext(command);
+
+        // then
+        assertEquals(1, result.relevantMessages().size());
+        assertEquals("relevant_sent", result.relevantMessages().getFirst().source());
+    }
+
+    @Test
+    void general은복원된Query로lexical검색을수행한다() {
+        // given
+        Fixture fixture = createFixture();
+        MailDraftCommand command = createCommandWithRestoreToken();
+
+        // when
+        fixture.service().generalRagContext(command);
+
+        // then
+        var tsQueryCaptor = forClass(String.class);
+        verify(fixture.referenceQueryPort()).findAccountLexicalRelevantMessageIds(
+                eq(command.userId()), eq(command.mailAccountId()), tsQueryCaptor.capture(), eq(40)
+        );
+        assertTrue(tsQueryCaptor.getValue().contains("김철수"));
+    }
+
+    @Test
     void general은복원토큰원문을힌트로작성메일을추가검색한다() {
         // given
         Fixture fixture = createFixture();
@@ -461,6 +549,7 @@ class MailDraftQueryServiceTest {
     private Fixture createFixture() {
         MailDraftReferenceQueryPort referenceQueryPort = mock(MailDraftReferenceQueryPort.class);
         VectorStore vectorStore = mock(VectorStore.class);
+        when(vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(List.of());
         MailDraftQueryService service = createService(referenceQueryPort, vectorStore);
         return new Fixture(service, referenceQueryPort, vectorStore);
     }
@@ -470,7 +559,7 @@ class MailDraftQueryServiceTest {
     }
 
     private MailDraftQueryService createService(MailDraftReferenceQueryPort referenceQueryPort, VectorStore vectorStore) {
-        return new MailDraftQueryService(referenceQueryPort, vectorStore, new PhileasMaskingService());
+        return new MailDraftQueryService(referenceQueryPort, vectorStore, new PhileasMaskingService(), new MailDraftLexicalQueryBuilder());
     }
 
     private MailDraftCommand createCommand(UUID replyMessageId) {

--- a/core/src/test/java/com/mailsangja/core/service/ai/label/LabelSuggestionAiServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/ai/label/LabelSuggestionAiServiceTest.java
@@ -3,6 +3,7 @@ package com.mailsangja.core.service.ai.label;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mailsangja.core.common.exception.label.LabelErrorCode;
 import com.mailsangja.core.common.exception.label.LabelException;
+import com.mailsangja.core.config.properties.AiModelProperties;
 import com.mailsangja.core.config.properties.LabelSuggestionProperties;
 import com.mailsangja.core.dto.label.LlmLabelSuggestionResult;
 import com.mailsangja.db.entity.mail.Direction;
@@ -10,10 +11,16 @@ import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.port.MessageRepositoryPort;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.data.domain.PageRequest;
 
@@ -25,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -43,6 +51,9 @@ class LabelSuggestionAiServiceTest {
 
     @Mock
     private LabelSuggestionProperties properties;
+
+    @Mock
+    private AiModelProperties modelProperties;
 
     @Mock
     private SnippetPreprocessor snippetPreprocessor;
@@ -98,5 +109,40 @@ class LabelSuggestionAiServiceTest {
                 () -> service.suggest(userId, List.of()));
 
         assertEquals(LabelErrorCode.LABEL_SUGGESTION_AI_FAILED, exception.getErrorCode());
+    }
+
+    @Test
+    void 라벨추천모델을Prompt옵션에설정한다() throws Exception {
+        UUID userId = UUID.randomUUID();
+        Message message = Message.builder()
+                .id(UUID.randomUUID())
+                .gmailMessageId("gmail-001")
+                .direction(Direction.INBOUND)
+                .subject("회의 일정")
+                .fromAddress("sender@example.com")
+                .read(false)
+                .build();
+        ChatModel chatModel = mock(ChatModel.class);
+        when(properties.getRecentMailCount()).thenReturn(20);
+        when(messageRepositoryPort.findRecentByUserIdAndDirection(
+                eq(userId), eq(Direction.INBOUND), any(PageRequest.class)))
+                .thenReturn(List.of(message));
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+        when(chatModelProvider.getIfAvailable()).thenReturn(chatModel);
+        when(modelProperties.labelSuggestionModel()).thenReturn("label-test");
+        when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().model("gpt-test").build());
+        when(chatModel.call(any(Prompt.class))).thenReturn(response("{\"suggestions\":[]}"));
+
+        service.suggest(userId, List.of());
+
+        org.mockito.ArgumentCaptor<Prompt> captor = org.mockito.ArgumentCaptor.forClass(Prompt.class);
+        verify(chatModel).call(captor.capture());
+        assertEquals("label-test", captor.getValue().getOptions().getModel());
+    }
+
+    private ChatResponse response(String text) {
+        Generation generation = new Generation(AssistantMessage.builder().content(text).build());
+        ChatResponseMetadata metadata = ChatResponseMetadata.builder().model("gpt-test").build();
+        return new ChatResponse(List.of(generation), metadata);
     }
 }

--- a/core/src/test/java/com/mailsangja/core/service/search/HybridMailSearchQueryServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/search/HybridMailSearchQueryServiceTest.java
@@ -1,0 +1,146 @@
+package com.mailsangja.core.service.search;
+
+import com.mailsangja.core.dto.search.HybridMailSearchScope;
+import com.mailsangja.db.entity.mail.Direction;
+import com.mailsangja.db.entity.mail.MailAccount;
+import com.mailsangja.db.entity.mail.MailProvider;
+import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.entity.mail.Thread;
+import com.mailsangja.db.entity.user.Plan;
+import com.mailsangja.db.entity.user.Role;
+import com.mailsangja.db.entity.user.User;
+import com.mailsangja.db.port.ContactRepositoryPort;
+import com.mailsangja.db.port.MailSearchRepositoryPort;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HybridMailSearchQueryServiceTest {
+
+    @Test
+    void vector와lexical후보를Rrf로병합해Message를조회한다() {
+        UUID userId = UUID.randomUUID();
+        UUID accountId = UUID.randomUUID();
+        UUID vectorFirst = UUID.randomUUID();
+        UUID shared = UUID.randomUUID();
+        UUID lexicalOnly = UUID.randomUUID();
+        MailSearchRepositoryPort repositoryPort = mock(MailSearchRepositoryPort.class);
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        VectorStore vectorStore = mock(VectorStore.class);
+        HybridMailSearchQueryService service = new HybridMailSearchQueryService(
+                repositoryPort,
+                contactRepositoryPort,
+                vectorStore,
+                new HybridSearchLexicalQueryBuilder()
+        );
+        when(vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(List.of(
+                document(vectorFirst),
+                document(shared)
+        ));
+        when(repositoryPort.findHybridLexicalMessageIds(
+                eq(userId), eq(accountId), eq(Direction.INBOUND), any(), eq(List.of()), eq(null), any(Integer.class)
+        )).thenReturn(List.of(shared, lexicalOnly));
+        when(repositoryPort.findHybridMessagesByIds(
+                eq(userId), any(), eq(accountId), eq(Direction.INBOUND), eq(List.of()), eq(null)
+        )).thenReturn(List.of(
+                message(vectorFirst, accountId, Direction.INBOUND),
+                message(shared, accountId, Direction.INBOUND),
+                message(lexicalOnly, accountId, Direction.INBOUND)
+        ));
+        when(contactRepositoryPort.findAllByUserIdAndEmailInAndDeletedAtIsNull(eq(userId), any())).thenReturn(List.of());
+
+        var result = service.search(userId, "프로젝트 일정", HybridMailSearchScope.INBOX, accountId, List.of(), null, 10);
+
+        assertEquals(List.of(shared, vectorFirst, lexicalOnly), result.items().stream()
+                .map(item -> item.message().getId())
+                .toList());
+        verify(repositoryPort).findHybridMessagesByIds(
+                eq(userId),
+                eq(List.of(shared, vectorFirst, lexicalOnly)),
+                eq(accountId),
+                eq(Direction.INBOUND),
+                eq(List.of()),
+                eq(null)
+        );
+    }
+
+    @Test
+    void lexical만성공해도검색결과를반환한다() {
+        UUID userId = UUID.randomUUID();
+        UUID messageId = UUID.randomUUID();
+        MailSearchRepositoryPort repositoryPort = mock(MailSearchRepositoryPort.class);
+        ContactRepositoryPort contactRepositoryPort = mock(ContactRepositoryPort.class);
+        VectorStore vectorStore = mock(VectorStore.class);
+        HybridMailSearchQueryService service = new HybridMailSearchQueryService(
+                repositoryPort,
+                contactRepositoryPort,
+                vectorStore,
+                new HybridSearchLexicalQueryBuilder()
+        );
+        when(vectorStore.similaritySearch(any(SearchRequest.class))).thenThrow(new RuntimeException("vector failed"));
+        when(repositoryPort.findHybridLexicalMessageIds(eq(userId), eq(null), eq(null), any(), eq(null), eq(Boolean.FALSE), any(Integer.class)))
+                .thenReturn(List.of(messageId));
+        when(repositoryPort.findHybridMessagesByIds(eq(userId), eq(List.of(messageId)), eq(null), eq(null), eq(null), eq(Boolean.FALSE)))
+                .thenReturn(List.of(message(messageId, UUID.randomUUID(), Direction.OUTBOUND)));
+        when(contactRepositoryPort.findAllByUserIdAndEmailInAndDeletedAtIsNull(eq(userId), any())).thenReturn(List.of());
+
+        var result = service.search(userId, "회의", HybridMailSearchScope.ALL, null, null, Boolean.FALSE, 5);
+
+        assertEquals(List.of(messageId), result.items().stream()
+                .map(item -> item.message().getId())
+                .toList());
+    }
+
+    private Document document(UUID messageId) {
+        return new Document(messageId.toString(), "text", Map.of("MessageId", messageId.toString()));
+    }
+
+    private Message message(UUID messageId, UUID accountId, Direction direction) {
+        User user = User.builder()
+                .id(UUID.randomUUID())
+                .name("Alice")
+                .username("alice")
+                .password("password")
+                .plan(Plan.FREE)
+                .role(Role.USER)
+                .build();
+        MailAccount mailAccount = MailAccount.builder()
+                .id(accountId)
+                .user(user)
+                .provider(MailProvider.GMAIL)
+                .emailAddress("alice@example.com")
+                .alias("Alice")
+                .active(true)
+                .build();
+        Thread thread = Thread.builder()
+                .id(UUID.randomUUID())
+                .mailAccount(mailAccount)
+                .gmailThreadId("gmail-thread")
+                .direction(direction)
+                .messageCount(1)
+                .read(false)
+                .build();
+        return Message.builder()
+                .id(messageId)
+                .thread(thread)
+                .gmailMessageId("gmail-message")
+                .direction(direction)
+                .subject("subject")
+                .fromAddress("sender@example.com")
+                .toAddresses(List.of("alice@example.com"))
+                .read(false)
+                .build();
+    }
+}

--- a/core/src/test/java/com/mailsangja/core/service/search/HybridSearchLexicalQueryBuilderTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/search/HybridSearchLexicalQueryBuilderTest.java
@@ -1,0 +1,24 @@
+package com.mailsangja.core.service.search;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HybridSearchLexicalQueryBuilderTest {
+
+    private final HybridSearchLexicalQueryBuilder builder = new HybridSearchLexicalQueryBuilder();
+
+    @Test
+    void 문장검색어를OrTsQuery로변환한다() {
+        String result = builder.build("프로젝트 일정 조율 관련 메일 찾아줘");
+
+        assertEquals("프로젝트 | 일정 | 조율 | 관련 | 메일 | 찾아줘", result);
+    }
+
+    @Test
+    void 검색문법문자는제거하고안전한토큰만사용한다() {
+        String result = builder.build("프로젝트 & 일정 | DROP! (회의)");
+
+        assertEquals("프로젝트 | 일정 | drop | 회의", result);
+    }
+}

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/MailDraftReferenceQueryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/MailDraftReferenceQueryAdapter.java
@@ -64,6 +64,26 @@ public class MailDraftReferenceQueryAdapter implements MailDraftReferenceQueryPo
     }
 
     @Override
+    public List<UUID> findAccountLexicalRelevantMessageIds(UUID userId, UUID mailAccountId, String tsQuery, int limit) {
+        if (isBlank(tsQuery) || limit <= 0) {
+            return List.of();
+        }
+        return toUuids(messageJpaRepositoryModule.findAccountLexicalRelevantMessageIds(
+                userId.toString(), mailAccountId.toString(), tsQuery, limit
+        ));
+    }
+
+    @Override
+    public List<UUID> findUserLexicalRelevantMessageIds(UUID userId, String tsQuery, int limit) {
+        if (isBlank(tsQuery) || limit <= 0) {
+            return List.of();
+        }
+        return toUuids(messageJpaRepositoryModule.findUserLexicalRelevantMessageIds(
+                userId.toString(), tsQuery, limit
+        ));
+    }
+
+    @Override
     public List<MailDraftReferenceMessageResult> findMessagesByIds(List<UUID> messageIds) {
         if (messageIds == null || messageIds.isEmpty()) {
             return List.of();
@@ -133,6 +153,19 @@ public class MailDraftReferenceQueryAdapter implements MailDraftReferenceQueryPo
             }
         }
         return false;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private List<UUID> toUuids(List<String> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return List.of();
+        }
+        return ids.stream()
+                .map(UUID::fromString)
+                .toList();
     }
 
     private List<MailDraftReferenceMessageResult> toResults(List<Message> messages) {

--- a/db/src/main/java/com/mailsangja/db/adapter/search/MailSearchRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/search/MailSearchRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package com.mailsangja.db.adapter.search;
 
 import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.entity.mail.Direction;
 import com.mailsangja.db.entity.mail.Thread;
 import com.mailsangja.db.module.mail.MessageJpaRepositoryModule;
 import com.mailsangja.db.module.search.MailSearchJpaRepositoryModule;
@@ -134,6 +135,61 @@ public class MailSearchRepositoryAdapter implements MailSearchRepositoryPort {
     }
 
     @Override
+    public List<UUID> findHybridLexicalMessageIds(
+            UUID userId,
+            UUID mailAccountId,
+            Direction direction,
+            String tsQuery,
+            List<UUID> labelIds,
+            Boolean read,
+            int limit
+    ) {
+        if (userId == null || tsQuery == null || tsQuery.isBlank() || limit <= 0) {
+            return List.of();
+        }
+        List<String> effectiveLabelIds = toEffectiveLabelIds(labelIds);
+        boolean labelsEmpty = labelIds == null || labelIds.isEmpty();
+        return messageJpaRepositoryModule.findHybridLexicalMessageIds(
+                        userId.toString(),
+                        mailAccountId == null ? null : mailAccountId.toString(),
+                        direction == null ? null : direction.name(),
+                        tsQuery,
+                        effectiveLabelIds,
+                        labelsEmpty,
+                        read,
+                        limit
+                )
+                .stream()
+                .map(UUID::fromString)
+                .toList();
+    }
+
+    @Override
+    public List<Message> findHybridMessagesByIds(
+            UUID userId,
+            List<UUID> messageIds,
+            UUID mailAccountId,
+            Direction direction,
+            List<UUID> labelIds,
+            Boolean read
+    ) {
+        if (userId == null || messageIds == null || messageIds.isEmpty()) {
+            return List.of();
+        }
+        List<UUID> effectiveLabelIds = toEffectiveUuidLabelIds(labelIds);
+        boolean labelsEmpty = labelIds == null || labelIds.isEmpty();
+        return messageJpaRepositoryModule.findHybridMessagesByIdIn(
+                userId,
+                messageIds,
+                mailAccountId,
+                direction,
+                effectiveLabelIds,
+                labelsEmpty,
+                read
+        );
+    }
+
+    @Override
     public long countInboxThreads(UUID userId, String query, List<UUID> labelIds, Boolean read) {
         List<String> effectiveLabelIds = toEffectiveLabelIds(labelIds);
         boolean labelsEmpty = labelIds == null || labelIds.isEmpty();
@@ -195,5 +251,12 @@ public class MailSearchRepositoryAdapter implements MailSearchRepositoryPort {
             return List.of("00000000-0000-0000-0000-000000000000");
         }
         return labelIds.stream().map(UUID::toString).toList();
+    }
+
+    private List<UUID> toEffectiveUuidLabelIds(List<UUID> labelIds) {
+        if (labelIds == null || labelIds.isEmpty()) {
+            return List.of(UUID.fromString("00000000-0000-0000-0000-000000000000"));
+        }
+        return labelIds;
     }
 }

--- a/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
@@ -599,9 +599,95 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
             @Param("limit") int limit
     );
 
+    @Query(value = """
+            SELECT m.id
+            FROM messages m
+            JOIN threads t ON m.thread_id = t.id
+            JOIN mail_accounts ma ON t.mail_account_id = ma.id
+            WHERE ma.user_id = :userId
+              AND ma.is_active = TRUE
+              AND m.deleted_at IS NULL
+              AND t.deleted_at IS NULL
+              AND ma.deleted_at IS NULL
+              AND (:mailAccountId IS NULL OR ma.id = :mailAccountId)
+              AND (:direction IS NULL OR m.direction = :direction)
+              AND (:read IS NULL OR m.is_read = :read)
+              AND (:labelsEmpty = TRUE OR EXISTS (
+                  SELECT 1
+                  FROM message_labels ml
+                  WHERE ml.message_id = m.id
+                    AND ml.label_id IN (:labelIds)
+                    AND ml.deleted_at IS NULL
+              ))
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM message_labels ml
+                  JOIN labels l ON l.id = ml.label_id
+                  WHERE ml.message_id = m.id
+                    AND ml.deleted_at IS NULL
+                    AND l.deleted_at IS NULL
+                    AND l.is_sensitive = true
+              )
+              AND m.search_vector @@ to_tsquery('korean', :tsQuery)
+            ORDER BY
+              ts_rank_cd(m.search_vector, to_tsquery('korean', :tsQuery)) DESC,
+              m.sent_at DESC NULLS LAST,
+              m.id DESC
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<String> findHybridLexicalMessageIds(
+            @Param("userId") String userId,
+            @Param("mailAccountId") String mailAccountId,
+            @Param("direction") String direction,
+            @Param("tsQuery") String tsQuery,
+            @Param("labelIds") List<String> labelIds,
+            @Param("labelsEmpty") boolean labelsEmpty,
+            @Param("read") Boolean read,
+            @Param("limit") int limit
+    );
+
     @EntityGraph(attributePaths = {"thread", "thread.mailAccount"})
     @Query("SELECT m FROM Message m WHERE m.id IN :ids")
     List<Message> findAllByIdInWithThread(@Param("ids") List<UUID> ids);
+
+    @EntityGraph(attributePaths = {"thread", "thread.mailAccount"})
+    @Query("""
+            SELECT m
+            FROM Message m
+            WHERE m.id IN :messageIds
+              AND m.thread.mailAccount.user.id = :userId
+              AND m.thread.mailAccount.active = true
+              AND m.deletedAt IS NULL
+              AND m.thread.deletedAt IS NULL
+              AND m.thread.mailAccount.deletedAt IS NULL
+              AND (:mailAccountId IS NULL OR m.thread.mailAccount.id = :mailAccountId)
+              AND (:direction IS NULL OR m.direction = :direction)
+              AND (:read IS NULL OR m.read = :read)
+              AND (:labelsEmpty = true OR EXISTS (
+                  SELECT 1
+                  FROM MessageLabel ml
+                  WHERE ml.message.id = m.id
+                    AND ml.label.id IN :labelIds
+                    AND ml.deletedAt IS NULL
+              ))
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM MessageLabel ml
+                  WHERE ml.message.id = m.id
+                    AND ml.deletedAt IS NULL
+                    AND ml.label.deletedAt IS NULL
+                    AND ml.label.isSensitive = true
+              )
+            """)
+    List<Message> findHybridMessagesByIdIn(
+            @Param("userId") UUID userId,
+            @Param("messageIds") List<UUID> messageIds,
+            @Param("mailAccountId") UUID mailAccountId,
+            @Param("direction") Direction direction,
+            @Param("labelIds") List<UUID> labelIds,
+            @Param("labelsEmpty") boolean labelsEmpty,
+            @Param("read") Boolean read
+    );
 
     @EntityGraph(attributePaths = {"thread", "thread.mailAccount"})
     @Query("""

--- a/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
@@ -609,9 +609,9 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
               AND m.deleted_at IS NULL
               AND t.deleted_at IS NULL
               AND ma.deleted_at IS NULL
-              AND (:mailAccountId IS NULL OR ma.id = :mailAccountId)
-              AND (:direction IS NULL OR m.direction = :direction)
-              AND (:read IS NULL OR m.is_read = :read)
+              AND (CAST(:mailAccountId AS uuid) IS NULL OR ma.id = CAST(:mailAccountId AS uuid))
+              AND (CAST(:direction AS varchar) IS NULL OR m.direction = CAST(:direction AS varchar))
+              AND (CAST(:read AS boolean) IS NULL OR m.is_read = CAST(:read AS boolean))
               AND (:labelsEmpty = TRUE OR EXISTS (
                   SELECT 1
                   FROM message_labels ml

--- a/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/MessageJpaRepositoryModule.java
@@ -535,6 +535,70 @@ public interface MessageJpaRepositoryModule extends JpaRepository<Message, UUID>
             Pageable pageable
     );
 
+    @Query(value = """
+            SELECT m.id
+            FROM messages m
+            JOIN threads t ON m.thread_id = t.id
+            JOIN mail_accounts ma ON t.mail_account_id = ma.id
+            WHERE ma.user_id = :userId
+              AND ma.id = :mailAccountId
+              AND m.deleted_at IS NULL
+              AND t.deleted_at IS NULL
+              AND ma.deleted_at IS NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM message_labels ml
+                  JOIN labels l ON l.id = ml.label_id
+                  WHERE ml.message_id = m.id
+                    AND ml.deleted_at IS NULL
+                    AND l.deleted_at IS NULL
+                    AND l.is_sensitive = true
+              )
+              AND m.search_vector @@ to_tsquery('korean', :tsQuery)
+            ORDER BY
+              ts_rank_cd(m.search_vector, to_tsquery('korean', :tsQuery)) DESC,
+              m.sent_at DESC NULLS LAST,
+              m.id DESC
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<String> findAccountLexicalRelevantMessageIds(
+            @Param("userId") String userId,
+            @Param("mailAccountId") String mailAccountId,
+            @Param("tsQuery") String tsQuery,
+            @Param("limit") int limit
+    );
+
+    @Query(value = """
+            SELECT m.id
+            FROM messages m
+            JOIN threads t ON m.thread_id = t.id
+            JOIN mail_accounts ma ON t.mail_account_id = ma.id
+            WHERE ma.user_id = :userId
+              AND m.deleted_at IS NULL
+              AND t.deleted_at IS NULL
+              AND ma.deleted_at IS NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM message_labels ml
+                  JOIN labels l ON l.id = ml.label_id
+                  WHERE ml.message_id = m.id
+                    AND ml.deleted_at IS NULL
+                    AND l.deleted_at IS NULL
+                    AND l.is_sensitive = true
+              )
+              AND m.search_vector @@ to_tsquery('korean', :tsQuery)
+            ORDER BY
+              ts_rank_cd(m.search_vector, to_tsquery('korean', :tsQuery)) DESC,
+              m.sent_at DESC NULLS LAST,
+              m.id DESC
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<String> findUserLexicalRelevantMessageIds(
+            @Param("userId") String userId,
+            @Param("tsQuery") String tsQuery,
+            @Param("limit") int limit
+    );
+
     @EntityGraph(attributePaths = {"thread", "thread.mailAccount"})
     @Query("SELECT m FROM Message m WHERE m.id IN :ids")
     List<Message> findAllByIdInWithThread(@Param("ids") List<UUID> ids);

--- a/db/src/main/java/com/mailsangja/db/port/MailDraftReferenceQueryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/MailDraftReferenceQueryPort.java
@@ -13,6 +13,10 @@ public interface MailDraftReferenceQueryPort {
 
     List<MailDraftReferenceMessageResult> findRecipientHistoryMessages(UUID userId, UUID mailAccountId, List<String> recipientHints, int limit);
 
+    List<UUID> findAccountLexicalRelevantMessageIds(UUID userId, UUID mailAccountId, String tsQuery, int limit);
+
+    List<UUID> findUserLexicalRelevantMessageIds(UUID userId, String tsQuery, int limit);
+
     List<MailDraftReferenceMessageResult> findMessagesByIds(List<UUID> messageIds);
 
     List<MailDraftReferenceMessageResult> findThreadContextMessages(UUID replyMessageId);

--- a/db/src/main/java/com/mailsangja/db/port/MailSearchRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/MailSearchRepositoryPort.java
@@ -1,6 +1,7 @@
 package com.mailsangja.db.port;
 
 import com.mailsangja.db.entity.mail.Message;
+import com.mailsangja.db.entity.mail.Direction;
 import com.mailsangja.db.entity.mail.Thread;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -16,6 +17,25 @@ public interface MailSearchRepositoryPort {
     Slice<Thread> searchSentThreads(UUID userId, String query, List<UUID> labelIds, Boolean read, UUID markerId, Pageable pageable);
 
     Slice<Message> searchTrashMessages(UUID userId, String query, List<UUID> labelIds, Boolean read, UUID markerId, Pageable pageable);
+
+    List<UUID> findHybridLexicalMessageIds(
+            UUID userId,
+            UUID mailAccountId,
+            Direction direction,
+            String tsQuery,
+            List<UUID> labelIds,
+            Boolean read,
+            int limit
+    );
+
+    List<Message> findHybridMessagesByIds(
+            UUID userId,
+            List<UUID> messageIds,
+            UUID mailAccountId,
+            Direction direction,
+            List<UUID> labelIds,
+            Boolean read
+    );
 
     long countInboxThreads(UUID userId, String query, List<UUID> labelIds, Boolean read);
 

--- a/db/src/test/java/com/mailsangja/db/adapter/mail/MailDraftReferenceQueryAdapterTest.java
+++ b/db/src/test/java/com/mailsangja/db/adapter/mail/MailDraftReferenceQueryAdapterTest.java
@@ -61,7 +61,37 @@ class MailDraftReferenceQueryAdapterTest {
         List<MailDraftReferenceMessageResult> results = adapter.findMessagesByIds(List.of(messageId));
 
         // then
-        assertEquals("문의 user@example.com 감사합니다.", results.getFirst().body());
+        assertEquals("문의 user@example.com\n감사합니다.", results.getFirst().body());
+    }
+
+    @Test
+    void 계정Lexical검색결과Id를Uuid로변환한다() {
+        // given
+        UUID messageId = UUID.randomUUID();
+        MailDraftReferenceQueryAdapter adapter = createLexicalAdapter(messageId);
+
+        // when
+        List<UUID> results = adapter.findAccountLexicalRelevantMessageIds(
+                UUID.randomUUID(), UUID.randomUUID(), "수강 | 정정", 40
+        );
+
+        // then
+        assertEquals(List.of(messageId), results);
+    }
+
+    @Test
+    void 사용자Lexical검색결과Id를Uuid로변환한다() {
+        // given
+        UUID messageId = UUID.randomUUID();
+        MailDraftReferenceQueryAdapter adapter = createLexicalAdapter(messageId);
+
+        // when
+        List<UUID> results = adapter.findUserLexicalRelevantMessageIds(
+                UUID.randomUUID(), "수강 | 정정", 40
+        );
+
+        // then
+        assertEquals(List.of(messageId), results);
     }
 
     private MailDraftReferenceQueryAdapter createAdapter(Message message) {
@@ -91,6 +121,15 @@ class MailDraftReferenceQueryAdapterTest {
         return new MailDraftReferenceQueryAdapter(module);
     }
 
+    private MailDraftReferenceQueryAdapter createLexicalAdapter(UUID messageId) {
+        MessageJpaRepositoryModule module = (MessageJpaRepositoryModule) Proxy.newProxyInstance(
+                MessageJpaRepositoryModule.class.getClassLoader(),
+                new Class<?>[]{MessageJpaRepositoryModule.class},
+                (proxy, method, args) -> findLexicalMessageIds(method.getName(), messageId)
+        );
+        return new MailDraftReferenceQueryAdapter(module);
+    }
+
     private Object findRecentByUserIdAndMailAccountIdAndDirection(String methodName, Message message) {
         if ("findRecentByUserIdAndMailAccountIdAndDirection".equals(methodName)) {
             return List.of(message);
@@ -108,6 +147,14 @@ class MailDraftReferenceQueryAdapterTest {
     private Object findActiveByIdIn(String methodName, Message message) {
         if ("findActiveByIdIn".equals(methodName)) {
             return List.of(message);
+        }
+        throw new UnsupportedOperationException(methodName);
+    }
+
+    private Object findLexicalMessageIds(String methodName, UUID messageId) {
+        if ("findAccountLexicalRelevantMessageIds".equals(methodName)
+                || "findUserLexicalRelevantMessageIds".equals(methodName)) {
+            return List.of(messageId.toString());
         }
         throw new UnsupportedOperationException(methodName);
     }

--- a/db/src/test/java/com/mailsangja/db/adapter/search/MailSearchRepositoryAdapterTest.java
+++ b/db/src/test/java/com/mailsangja/db/adapter/search/MailSearchRepositoryAdapterTest.java
@@ -262,6 +262,50 @@ class MailSearchRepositoryAdapterTest {
         assertEquals(7L, result);
     }
 
+    @Test
+    void 하이브리드_lexical_검색은_필터를_전달하고_ID를_UUID로_변환한다() {
+        UUID userId = UUID.randomUUID();
+        UUID accountId = UUID.randomUUID();
+        UUID labelId = UUID.randomUUID();
+        UUID messageId = UUID.randomUUID();
+        when(messageJpaRepositoryModule.findHybridLexicalMessageIds(
+                userId.toString(),
+                accountId.toString(),
+                Direction.INBOUND.name(),
+                "프로젝트 | 일정",
+                List.of(labelId.toString()),
+                false,
+                Boolean.FALSE,
+                40
+        )).thenReturn(List.of(messageId.toString()));
+
+        List<UUID> result = mailSearchRepositoryAdapter.findHybridLexicalMessageIds(
+                userId, accountId, Direction.INBOUND, "프로젝트 | 일정", List.of(labelId), Boolean.FALSE, 40);
+
+        assertEquals(List.of(messageId), result);
+    }
+
+    @Test
+    void 하이브리드_상세조회는_라벨이_없으면_센티널을_전달한다() {
+        UUID userId = UUID.randomUUID();
+        UUID messageId = UUID.randomUUID();
+        Message message = message();
+        when(messageJpaRepositoryModule.findHybridMessagesByIdIn(
+                userId,
+                List.of(messageId),
+                null,
+                null,
+                List.of(UUID.fromString(SENTINEL_LABEL_ID)),
+                true,
+                null
+        )).thenReturn(List.of(message));
+
+        List<Message> result = mailSearchRepositoryAdapter.findHybridMessagesByIds(
+                userId, List.of(messageId), null, null, null, null);
+
+        assertEquals(List.of(message), result);
+    }
+
     private Thread thread() {
         return Thread.builder()
                 .id(UUID.randomUUID())

--- a/worker/src/main/java/com/mailsangja/worker/config/properties/AiModelProperties.java
+++ b/worker/src/main/java/com/mailsangja/worker/config/properties/AiModelProperties.java
@@ -1,0 +1,51 @@
+package com.mailsangja.worker.config.properties;
+
+import com.mailsangja.worker.common.exception.mq.MqErrorCode;
+import com.mailsangja.worker.common.exception.mq.MqException;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Component
+@Validated
+@ConfigurationProperties(prefix = "mailsangja.ai.model")
+public class AiModelProperties {
+
+    private String defaultModel;
+    private String replyDraftSuggestionModel;
+    private List<String> allowedModels = List.of();
+
+    public String replyDraftSuggestionModel() {
+        String model = normalize(replyDraftSuggestionModel);
+        if (model == null) {
+            model = normalize(defaultModel);
+        }
+        if (model == null || !normalizedAllowedModels().contains(model)) {
+            throw new MqException(MqErrorCode.INVALID_REPLY_DRAFT_SUGGESTION_MESSAGE);
+        }
+        return model;
+    }
+
+    private List<String> normalizedAllowedModels() {
+        if (allowedModels == null) {
+            return List.of();
+        }
+        return allowedModels.stream()
+                .map(this::normalize)
+                .filter(value -> value != null)
+                .toList();
+    }
+
+    private String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.strip();
+    }
+}

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionCommandService.java
@@ -5,6 +5,7 @@ import com.mailsangja.db.port.MessageRepositoryPort;
 import com.mailsangja.db.port.ReplyDraftSuggestionRepositoryPort;
 import com.mailsangja.worker.common.exception.mq.MqErrorCode;
 import com.mailsangja.worker.common.exception.mq.MqException;
+import com.mailsangja.worker.config.properties.AiModelProperties;
 import com.mailsangja.worker.dto.mail.reply.ReplyDraftSuggestionLlmResult;
 import com.mailsangja.worker.dto.mail.reply.ReplyDraftSuggestionOptionResult;
 import com.mailsangja.worker.dto.mail.reply.ReplyDraftSuggestionPromptResult;
@@ -18,6 +19,7 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.ai.converter.StructuredOutputConverter;
+import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -38,6 +40,7 @@ public class ReplyDraftSuggestionCommandService {
     private final ReplyDraftSuggestionRepositoryPort replyDraftSuggestionRepositoryPort;
     private final ReplyDraftSuggestionQueryService replyDraftSuggestionQueryService;
     private final TransactionTemplate transactionTemplate;
+    private final AiModelProperties modelProperties;
 
     public void generate(UUID messageId) {
         com.mailsangja.db.entity.mail.Message message = findActiveMessage(messageId);
@@ -76,6 +79,8 @@ public class ReplyDraftSuggestionCommandService {
         try {
             return Optional.ofNullable(ChatClient.create(chatModel)
                     .prompt(createPrompt(prompt))
+                    .options(OpenAiChatOptions.builder()
+                            .model(modelProperties.replyDraftSuggestionModel()))
                     .call()
                     .entity(converter));
         } catch (RuntimeException e) {

--- a/worker/src/main/resources/application.yaml
+++ b/worker/src/main/resources/application.yaml
@@ -93,6 +93,10 @@ scalar:
 
 mailsangja:
   ai:
+    model:
+      default-model: ${AI_DEFAULT_MODEL:google/gemini-3.5-flash}
+      reply-draft-suggestion-model: ${REPLY_DRAFT_SUGGESTION_MODEL:${AI_REPLY_MODEL:${AI_DEFAULT_MODEL:google/gemini-3.5-flash}}}
+      allowed-models: ${AI_ALLOWED_MODELS:google/gemini-3.5-flash,google/gemini-3.1-pro-preview,google/gemini-3.1-flash-lite,google/gemini-3-pro-preview,google/gemini-3-flash-preview,google/gemini-2.5-pro,google/gemini-2.5-flash,google/gemini-2.5-flash-lite,openai/gpt-5.5,openai/gpt-5.5-pro,openai/gpt-5.4-nano,openai/gpt-5.4-mini,openai/gpt-5.4,openai/gpt-5.4-pro,openai/gpt-5.3-chat,openai/gpt-5.3-codex,openai/gpt-5.2-chat,openai/gpt-5.2,openai/gpt-5.1,openai/gpt-4.1,openai/gpt-4.1-mini,openai/gpt-4.1-nano,qwen/qwen3.6-flash,qwen/qwen3.5-plus-20260420,anthropic/claude-haiku-4.5,anthropic/claude-sonnet-4.6,anthropic/claude-sonnet-4.5,anthropic/claude-sonnet-4,anthropic/claude-opus-4.7,anthropic/claude-opus-4.7-fast,anthropic/claude-opus-4.6,anthropic/claude-opus-4.6-fast,anthropic/claude-opus-4.1,anthropic/claude-opus-4,mistralai/mistral-medium-3-5,x-ai/grok-4.3}
     reply-draft:
       min-thread-message-count: ${AI_REPLY_DRAFT_MIN_THREAD_MESSAGE_COUNT:3}
     embedding:

--- a/worker/src/test/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryServiceTest.java
@@ -205,14 +205,19 @@ class GoogleMailMessageQueryServiceTest {
                         """))
                 .build();
 
-        GmailMessageApiService service = new GmailMessageApiService(properties, restClient);
+        GmailApiRateLimitService rateLimitService = mock(GmailApiRateLimitService.class);
+        GmailMessageApiService service = new GmailMessageApiService(properties, restClient, rateLimitService);
 
-        List<InitialMailSyncThreadResult> results = service.getThreads("token", List.of("thread-1"));
+        List<InitialMailSyncThreadResult> results = service.getThreads(
+                new GoogleMailApiContext("token", "alice@example.com"),
+                List.of("thread-1")
+        );
 
         assertEquals(1, results.size());
         assertEquals(1, results.getFirst().messages().getFirst().attachments().size());
         assertEquals("f_mpmdzs8f0", results.getFirst().messages().getFirst().attachments().getFirst().contentId());
         assertEquals(AttachmentDisposition.ATTACHMENT, results.getFirst().messages().getFirst().attachments().getFirst().disposition());
+        verify(rateLimitService).consumeThreadGet("alice@example.com");
     }
 
     private static final class StubClientHttpRequestFactory extends SimpleClientHttpRequestFactory {

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionCommandServiceTest.java
@@ -13,6 +13,7 @@ import com.mailsangja.db.port.MessageRepositoryPort;
 import com.mailsangja.db.port.ReplyDraftSuggestionRepositoryPort;
 import com.mailsangja.worker.common.exception.mq.MqErrorCode;
 import com.mailsangja.worker.common.exception.mq.MqException;
+import com.mailsangja.worker.config.properties.AiModelProperties;
 import com.mailsangja.worker.dto.mail.reply.ReplyDraftSuggestionPromptResult;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -59,7 +60,8 @@ class ReplyDraftSuggestionCommandServiceTest {
                 messageRepositoryPort,
                 suggestionRepositoryPort,
                 queryService,
-                transactionTemplate
+                transactionTemplate,
+                modelProperties()
         );
         when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId))
                 .thenReturn(Optional.of(message));
@@ -105,7 +107,8 @@ class ReplyDraftSuggestionCommandServiceTest {
                 messageRepositoryPort,
                 suggestionRepositoryPort,
                 queryService,
-                transactionTemplate
+                transactionTemplate,
+                modelProperties()
         );
         when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId))
                 .thenReturn(Optional.of(message));
@@ -159,7 +162,8 @@ class ReplyDraftSuggestionCommandServiceTest {
                 messageRepositoryPort,
                 suggestionRepositoryPort,
                 queryService,
-                transactionTemplate
+                transactionTemplate,
+                modelProperties()
         );
         when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId))
                 .thenReturn(Optional.of(message));
@@ -173,6 +177,56 @@ class ReplyDraftSuggestionCommandServiceTest {
         // then
         verify(suggestionRepositoryPort).saveAllByMessageIdUpToActiveLimit(eq(messageId), any(), eq(4));
         verify(suggestionRepositoryPort, never()).save(any());
+    }
+
+    @Test
+    void generate_답장추천모델을Prompt옵션에설정한다() {
+        // given
+        UUID messageId = UUID.randomUUID();
+        Message message = createMessage(messageId);
+        MessageRepositoryPort messageRepositoryPort = mock(MessageRepositoryPort.class);
+        ReplyDraftSuggestionRepositoryPort suggestionRepositoryPort = mock(ReplyDraftSuggestionRepositoryPort.class);
+        ReplyDraftSuggestionQueryService queryService = mock(ReplyDraftSuggestionQueryService.class);
+        TransactionTemplate transactionTemplate = transactionTemplate();
+        ChatModel chatModel = mock(ChatModel.class);
+        ReplyDraftSuggestionCommandService service = new ReplyDraftSuggestionCommandService(
+                chatModelProvider(chatModel),
+                messageRepositoryPort,
+                suggestionRepositoryPort,
+                queryService,
+                transactionTemplate,
+                modelProperties()
+        );
+        when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId))
+                .thenReturn(Optional.of(message));
+        when(queryService.existsByMessageId(messageId)).thenReturn(false);
+        when(queryService.createPrompt(eq(messageId), contains("suggestions")))
+                .thenReturn(new ReplyDraftSuggestionPromptResult("system", "user"));
+        when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().model("gpt-test").build());
+        when(chatModel.call(any(Prompt.class))).thenReturn(response("""
+                {
+                  "suggestions": [
+                    {
+                      "type": "승낙",
+                      "subject": "Re: 회의 일정",
+                      "body": "좋습니다. 해당 일정으로 진행하겠습니다."
+                    },
+                    {
+                      "type": "제안",
+                      "subject": "Re: 회의 일정",
+                      "body": "가능하다면 오후 시간으로 조정 가능할까요?"
+                    }
+                  ]
+                }
+                """));
+
+        // when
+        service.generate(messageId);
+
+        // then
+        org.mockito.ArgumentCaptor<Prompt> captor = org.mockito.ArgumentCaptor.forClass(Prompt.class);
+        verify(chatModel).call(captor.capture());
+        assertEquals("reply-test", captor.getValue().getOptions().getModel());
     }
 
     @Test
@@ -200,7 +254,8 @@ class ReplyDraftSuggestionCommandServiceTest {
                 messageRepositoryPort,
                 suggestionRepositoryPort,
                 queryService,
-                transactionTemplate
+                transactionTemplate,
+                modelProperties()
         );
         when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId))
                 .thenReturn(Optional.of(message));
@@ -229,7 +284,8 @@ class ReplyDraftSuggestionCommandServiceTest {
                 messageRepositoryPort,
                 suggestionRepositoryPort,
                 queryService,
-                transactionTemplate()
+                transactionTemplate(),
+                modelProperties()
         );
         when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId))
                 .thenReturn(Optional.empty());
@@ -255,7 +311,8 @@ class ReplyDraftSuggestionCommandServiceTest {
                 messageRepositoryPort,
                 suggestionRepositoryPort,
                 queryService,
-                transactionTemplate()
+                transactionTemplate(),
+                modelProperties()
         );
         when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(messageId))
                 .thenReturn(Optional.of(message));
@@ -291,6 +348,14 @@ class ReplyDraftSuggestionCommandServiceTest {
 
     private ChatModel chatModel(String text) {
         return new StubChatModel(response(text));
+    }
+
+    private AiModelProperties modelProperties() {
+        AiModelProperties properties = new AiModelProperties();
+        properties.setDefaultModel("gpt-test");
+        properties.setReplyDraftSuggestionModel("reply-test");
+        properties.setAllowedModels(List.of("gpt-test", "reply-test"));
+        return properties;
     }
 
     private ChatResponse response(String text) {


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#24

### 📌 Task
- Closes #151


## 💡 작업 내용

- VectorStore 유사도 검색과 PostgreSQL FTS 검색 결과를 RRF로 병합하는 하이브리드 메일 검색 API를 추가했습니다.
- `GET /api/v1/mail/search/hybrid` 엔드포인트를 추가하고, `q`, `scope`, `mailAccountId`, `labelId`, `read`, `size` 필터를 지원하도록 구현했습니다.
- 검색 결과는 페이지네이션 없이 `size` 개수만큼 message 단위로 반환하도록 구성했습니다.
- 하이브리드 검색 후보 조회 시 민감 라벨 메일, 삭제된 메일, 비활성/삭제 계정을 제외하도록 필터링했습니다.
- RRF 점수와 `matchedBy` 정보를 응답에 포함해 vector/lexical 매칭 근거를 확인할 수 있도록 했습니다.
- 하이브리드 검색 QueryService, Facade, Controller, DTO, DB Port/Adapter/JpaModule 쿼리와 단위 테스트를 추가했습니다.
- 라벨 추천, 메일 초안 작성, 자동 답장 추천에서 사용하는 LLM 모델을 각각 환경변수로 분리해 설정할 수 있도록 변경했습니다.


## 📝 추가 설명

### 1. API 설계

새 API는 기존 받은 편지함/보낸 편지함 목록의 `q` 검색과 분리했습니다.

기존 `GET /api/v1/threads/inbox?q=...`, `GET /api/v1/threads/sent?q=...` 검색은 FTS/LIKE 기반이며, 스레드 목록 UI와 marker pagination 계약을 유지합니다.

하이브리드 검색은 vector 검색과 FTS 검색 결과를 별도로 가져온 뒤 애플리케이션 레이어에서 RRF로 병합하므로, 기존 목록 검색과 정렬 의미가 다릅니다. 따라서 별도 엔드포인트로 분리했습니다.

| 항목 | 내용 |
| --- | --- |
| HTTP Method | `GET` |
| Endpoint | `/api/v1/mail/search/hybrid` |
| 결과 단위 | `Message` |
| Pagination | 없음 |
| 제한 방식 | `size`, 기본 20, 최대 50 |

지원 파라미터:

| 파라미터 | 설명 |
| --- | --- |
| `q` | 검색어. 필수 |
| `scope` | `ALL`, `INBOX`, `SENT`. 생략 시 `ALL` |
| `mailAccountId` | 특정 메일 계정 필터 |
| `labelId` | 라벨 필터. 여러 번 전달 가능 |
| `read` | 읽음 여부 필터 |
| `size` | 반환 결과 수 |

응답은 `HybridMailSearchResponse`로 감싸고, 각 항목은 message/thread/account 식별자, 방향, 제목, 발신자, 수신자, snippet, 읽음/별표 상태, 발송 시각, `matchedBy`, `score`를 포함합니다.

### 2. 하이브리드 검색 흐름

```mermaid
flowchart TD
    A[GET /api/v1/mail/search/hybrid] --> B[MailSearchController]
    B --> C[HybridMailSearchFacade]
    C --> D[요청 검증: q, size]
    D --> E[HybridMailSearchQueryService]
    E --> F[VectorStore similaritySearch]
    E --> G[PostgreSQL FTS lexical search]
    F --> H[Vector messageId 후보]
    G --> I[Lexical messageId 후보]
    H --> J[RRF 병합]
    I --> J
    J --> K[DB 상세 조회 및 권한/필터 재검증]
    K --> L[Contact 이름 보강]
    L --> M[HybridMailSearchResponse 반환]
```

vector 후보는 VectorStore metadata의 `UserId`, `MailAccountId`, `Direction` 필터를 사용해 1차 제한합니다.

lexical 후보는 `messages.search_vector @@ to_tsquery('korean', :tsQuery)` 기반으로 조회하며, 사용자 검색 문장은 안전한 term 목록으로 변환한 뒤 OR tsquery로 구성합니다.

최종 상세 조회 단계에서는 vector 결과도 DB에서 다시 검증합니다.

검증 조건:

- 로그인 사용자 소유 계정의 메시지
- 활성 계정
- 삭제되지 않은 message/thread/account
- `mailAccountId`, `scope`, `labelId`, `read` 필터
- 민감 라벨 제외

### 3. RRF 병합 기준

검색기별 점수 스케일을 직접 비교하지 않고 순위만 사용해 병합합니다.

```text
score += weight / (RRF_K + rank)
```

현재 기본값:

| 값 | 설정 |
| --- | --- |
| `RRF_K` | 60 |
| vector weight | 0.6 |
| lexical weight | 0.4 |
| candidate limit | `max(40, size * 5)` |

의도:

- 의미 기반 검색 품질을 위해 vector 검색에 약간 더 높은 가중치를 둡니다.
- 사람 이름, 과목명, 회사명, 특정 키워드처럼 정확히 일치하는 검색어는 lexical 검색으로 보완합니다.
- 양쪽 검색에서 동시에 잡힌 메시지는 한쪽에서만 잡힌 메시지보다 위로 올라오도록 합니다.
- `RRF_K = 60`으로 한 검색기의 1등 결과가 과도하게 전체 순위를 독점하지 않도록 완만하게 병합합니다.

### 4. 레이어 구조

프로젝트 레이어 규칙에 맞춰 HTTP 진입점과 비즈니스 조회 로직을 분리했습니다.

```text
MailSearchController
  -> HybridMailSearchFacade
    -> HybridMailSearchQueryService
      -> MailSearchRepositoryPort
      -> VectorStore
```

DB 접근은 기존 검색 도메인의 `MailSearchRepositoryPort`를 확장했습니다.

| 파일 | 변경 내용 |
| --- | --- |
| `core/controller/MailSearchController` | 하이브리드 검색 API 추가 |
| `core/controller/docs/MailSearchControllerDocs` | Swagger 문서 인터페이스 추가 |
| `core/facade/HybridMailSearchFacade` | 요청 검증 및 응답 조립 |
| `core/service/search/HybridMailSearchQueryService` | vector/lexical 후보 조회, RRF 병합, contact 이름 보강 |
| `core/service/search/HybridSearchLexicalQueryBuilder` | 사용자 검색 문장 → 안전한 OR tsquery 변환 |
| `core/dto/search/*` | 하이브리드 검색 응답/결과/범위 DTO 추가 |
| `db/port/MailSearchRepositoryPort` | 하이브리드 후보/상세 조회 계약 추가 |
| `db/adapter/search/MailSearchRepositoryAdapter` | Port 구현 및 검색 결과 ID 변환 |
| `db/module/mail/MessageJpaRepositoryModule` | 하이브리드 lexical native query, 상세 조회 JPQL 추가 |

### 5. LLM 모델 환경변수 분리

기존에는 라벨 추천, 메일 초안 작성, 자동 답장 추천이 공통 chat model 설정에 의존했습니다.

이번 변경에서는 공통 `ChatModel` 빈은 유지하되, 각 LLM 호출 시점에 `OpenAiChatOptions.model(...)`로 유스케이스별 모델을 명시하도록 분리했습니다.

| 기능 | 환경변수 | Fallback |
| --- | --- | --- |
| 메일 초안 작성 | `MAIL_DRAFT_MODEL` 또는 `AI_DRAFT_MODEL` | `AI_DEFAULT_MODEL` |
| 라벨 추천 | `LABEL_SUGGESTION_MODEL` 또는 `AI_LABEL_MODEL` | `AI_DEFAULT_MODEL` |
| 자동 답장 추천 | `REPLY_DRAFT_SUGGESTION_MODEL` 또는 `AI_REPLY_MODEL` | `AI_DEFAULT_MODEL` |

추가로 `AI_ALLOWED_MODELS` 검증은 유지했습니다. 따라서 개별 기능 모델도 허용 모델 목록에 포함되어야 사용할 수 있습니다.

주요 변경 파일:

| 파일 | 변경 내용 |
| --- | --- |
| `core/config/properties/AiModelProperties` | 초안/라벨 추천 모델 resolve 메서드 추가 |
| `core/service/ai/draft/MailDraftCommandService` | 요청 모델이 없으면 draft 전용 모델 사용 |
| `core/service/ai/label/LabelSuggestionAiService` | 라벨 추천 전용 모델을 ChatClient options에 설정 |
| `core/src/main/resources/application.yaml` | `draft-model`, `label-suggestion-model` 환경변수 매핑 추가 |
| `worker/config/properties/AiModelProperties` | 자동 답장 추천 모델 설정 추가 |
| `worker/service/mail/ReplyDraftSuggestionCommandService` | 자동 답장 추천 전용 모델을 ChatClient options에 설정 |
| `worker/src/main/resources/application.yaml` | `reply-draft-suggestion-model` 환경변수 매핑 추가 |

### 6. 보안 및 데이터 노출 제한

하이브리드 검색 결과는 vector 후보를 포함하므로, VectorStore metadata 필터만 신뢰하지 않고 DB 상세 조회 단계에서 다시 필터링합니다.

특히 아래 조건을 DB 조회에서 강제합니다.

- `m.thread.mailAccount.user.id = :userId`
- `m.thread.mailAccount.active = true`
- `deletedAt IS NULL`
- 민감 라벨 제외

따라서 vector metadata가 잘못되었거나 오래된 경우에도 최종 응답에는 권한 없는 메시지나 민감 라벨 메시지가 포함되지 않습니다.

### 7. 테스트 보강

- vector 후보와 lexical 후보가 RRF로 병합되는 순서를 검증했습니다.
- vector 검색 실패 시 lexical 결과만으로도 검색 결과가 반환되는지 검증했습니다.
- 문장형 검색어가 안전한 OR tsquery 문자열로 변환되는지 검증했습니다.
- DB 어댑터가 lexical 후보 ID를 UUID로 변환하고, 상세 조회 시 라벨 sentinel 값을 전달하는지 검증했습니다.
- 라벨 추천과 자동 답장 추천 호출 시 기능별 모델이 Prompt options에 반영되는지 검증했습니다.


## ⚡️ Test 결과

| 하이브리드 검색 랭킹 | lexical query builder | DB 검색 어댑터 | LLM 모델 분리 |
| -- | -- | -- | -- |
| Unit Test | Unit Test | Unit Test | Unit Test |
| `HybridMailSearchQueryServiceTest` | `HybridSearchLexicalQueryBuilderTest` | `MailSearchRepositoryAdapterTest` | `MailDraftCommandServiceTest`, `LabelSuggestionAiServiceTest`, `ReplyDraftSuggestionCommandServiceTest` |
| `BUILD SUCCESSFUL` | `BUILD SUCCESSFUL` | `BUILD SUCCESSFUL` | `BUILD SUCCESSFUL` |

실행한 테스트:

```bash
./gradlew :compileJava
```

```bash
./gradlew :test \
  --tests "com.mailsangja.core.service.search.HybridMailSearchQueryServiceTest" \
  --tests "com.mailsangja.core.service.search.HybridSearchLexicalQueryBuilderTest"
```

```bash
./gradlew :db:test \
  --tests "com.mailsangja.db.adapter.search.MailSearchRepositoryAdapterTest"
```

```bash
./gradlew :test \
  --tests "com.mailsangja.core.service.ai.draft.MailDraftCommandServiceTest" \
  --tests "com.mailsangja.core.service.ai.label.LabelSuggestionAiServiceTest" \
  --tests "com.mailsangja.core.service.ai.AiQueryServiceTest"
```

```bash
./gradlew :test \
  --tests "com.mailsangja.worker.service.mail.ReplyDraftSuggestionCommandServiceTest" \
  --tests "com.mailsangja.worker.service.google.GoogleMailMessageQueryServiceTest"
```

결과:

```text
BUILD SUCCESSFUL
```
<img width="1402" height="797" alt="image" src="https://github.com/user-attachments/assets/12362e3b-7ccf-4486-8013-7841e6d788b1" />
