### PR TITLE
[STROY-901] 별표 편지함 필터링 파라미터 추가 및 계정 삭제 Gmail Watch 구독 해제

### DIFF
--- a/core/src/main/java/com/mailsangja/core/config/properties/GoogleMailProperties.java
+++ b/core/src/main/java/com/mailsangja/core/config/properties/GoogleMailProperties.java
@@ -19,6 +19,7 @@ public class GoogleMailProperties {
 
     private String topicName;
     private String watchUri;
+    private String stopUri;
     private String threadModifyUri;
     private String messageModifyUri;
     private String sendUri;

--- a/core/src/main/java/com/mailsangja/core/controller/StarController.java
+++ b/core/src/main/java/com/mailsangja/core/controller/StarController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -23,9 +24,12 @@ public class StarController implements StarControllerDocs {
     public ResponseEntity<MarkerSliceResponse<ThreadSummaryResponse>> getStarred(
             @AuthUser User user,
             @RequestParam(required = false) UUID marker,
-            @RequestParam(defaultValue = "${mailsangja.inbox.page-size:50}") int size
+            @RequestParam(defaultValue = "${mailsangja.inbox.page-size:50}") int size,
+            @RequestParam(required = false, name = "labelId") List<UUID> labelIds,
+            @RequestParam(required = false) Boolean read,
+            @RequestParam(required = false) String q
     ) {
-        return ResponseEntity.ok(starFacade.getStarred(user, marker, size));
+        return ResponseEntity.ok(starFacade.getStarred(user, marker, size, labelIds, read, q));
     }
 
     @Override

--- a/core/src/main/java/com/mailsangja/core/controller/docs/StarControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/StarControllerDocs.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Star", description = "별표 API")
@@ -39,7 +40,13 @@ public interface StarControllerDocs {
             @Parameter(description = "이전 응답의 nextMarker (첫 요청 시 생략)", example = "550e8400-e29b-41d4-a716-446655440000")
             @RequestParam(required = false) UUID marker,
             @Parameter(description = "한 번에 조회할 스레드 수", example = "50")
-            @RequestParam(defaultValue = "${mailsangja.inbox.page-size:50}") int size
+            @RequestParam(defaultValue = "${mailsangja.inbox.page-size:50}") int size,
+            @Parameter(description = "라벨 ID 필터 (복수 지정 가능)")
+            @RequestParam(required = false, name = "labelId") List<UUID> labelIds,
+            @Parameter(description = "읽음 여부 필터 (true: 읽음만, false: 안읽음만, 생략: 전체)")
+            @RequestParam(required = false) Boolean read,
+            @Parameter(description = "검색어 (제목·본문·첨부파일명 대상 전문 검색)")
+            @RequestParam(required = false) String q
     );
 
     @Operation(

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/MessageResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/MessageResponse.java
@@ -32,7 +32,7 @@ public record MessageResponse(
         @Schema(description = "읽음 여부", example = "true")
         boolean isRead,
         @Schema(description = "별표 여부", example = "false")
-        boolean isStar,
+        boolean star,
         @Schema(description = "발송/수신 시각")
         LocalDateTime sentAt,
         @Schema(description = "본문 plain text")

--- a/core/src/main/java/com/mailsangja/core/facade/MailAccountFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/MailAccountFacade.java
@@ -109,6 +109,9 @@ public class MailAccountFacade {
 
     public void deleteMailAccount(User user, UUID mailAccountId) {
         MailAccount mailAccount = mailAccountQueryService.findById(mailAccountId);
+        if (!mailAccount.getUser().getId().equals(user.getId())) {
+            throw new MailAccountException(MailAccountErrorCode.MAIL_ACCOUNT_ACCESS_DENIED);
+        }
         if (mailAccount.getProvider() == MailProvider.GMAIL) {
             stopGmailWatch(mailAccount);
         }

--- a/core/src/main/java/com/mailsangja/core/facade/MailAccountFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/MailAccountFacade.java
@@ -108,7 +108,24 @@ public class MailAccountFacade {
     }
 
     public void deleteMailAccount(User user, UUID mailAccountId) {
+        MailAccount mailAccount = mailAccountQueryService.findById(mailAccountId);
+        if (mailAccount.getProvider() == MailProvider.GMAIL) {
+            stopGmailWatch(mailAccount);
+        }
         mailAccountCommandService.deleteMailAccount(user, mailAccountId);
+    }
+
+    private void stopGmailWatch(MailAccount mailAccount) {
+        try {
+            googleMailWatchQueryService.stop(mailAccount.getAccessToken());
+        } catch (Exception e) {
+            log.warn(
+                    "Failed to stop Gmail watch on account deletion. mailAccountId={} emailAddress={}",
+                    mailAccount.getId(),
+                    mailAccount.getEmailAddress(),
+                    e
+            );
+        }
     }
 
     private void validateMailAccountCount(User user) {

--- a/core/src/main/java/com/mailsangja/core/facade/StarFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/StarFacade.java
@@ -8,6 +8,7 @@ import com.mailsangja.core.dto.inbox.ThreadSummaryResponse;
 import com.mailsangja.core.service.inbox.InboxCommandService;
 import com.mailsangja.core.service.inbox.InboxQueryService;
 import com.mailsangja.core.service.mail.MailAccountQueryService;
+import com.mailsangja.core.service.search.MailSearchQueryService;
 import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.Message;
 import com.mailsangja.db.entity.mail.Thread;
@@ -28,13 +29,36 @@ public class StarFacade {
     private final InboxCommandService inboxCommandService;
     private final InboxQueryService inboxQueryService;
     private final MailAccountQueryService mailAccountQueryService;
+    private final MailSearchQueryService mailSearchQueryService;
 
-    public MarkerSliceResponse<ThreadSummaryResponse> getStarred(User user, UUID marker, int size) {
+    public MarkerSliceResponse<ThreadSummaryResponse> getStarred(
+            User user,
+            UUID marker,
+            int size,
+            List<UUID> labelIds,
+            Boolean read,
+            String q
+    ) {
+        if (q != null && !q.isBlank()) {
+            String trimmed = q.trim();
+            ThreadListResult result = mailSearchQueryService.searchStarredThreadsResult(
+                    user.getId(), trimmed, labelIds, read, marker, PageRequest.of(0, size));
+            long unreadCount = mailSearchQueryService.countUnreadStarredThreads(user.getId(), trimmed, labelIds, read);
+            long totalCount = mailSearchQueryService.countStarredThreads(user.getId(), trimmed, labelIds, read);
+            return toMarkerSlice(result, unreadCount, totalCount);
+        }
         ThreadListResult result = inboxQueryService.findStarredThreadsResult(
-                user.getId(), marker, PageRequest.of(0, size));
-        long totalCount = inboxQueryService.countStarred(user.getId());
+                user.getId(), marker, labelIds, read, PageRequest.of(0, size));
+        long unreadCount = inboxQueryService.countUnreadStarred(user.getId(), labelIds, read);
+        long totalCount = inboxQueryService.countStarred(user.getId(), labelIds, read);
+        return toMarkerSlice(result, unreadCount, totalCount);
+    }
 
-        long unreadCount = inboxQueryService.countUnreadStarred(user.getId());
+    private MarkerSliceResponse<ThreadSummaryResponse> toMarkerSlice(
+            ThreadListResult result,
+            long unreadCount,
+            long totalCount
+    ) {
         List<ThreadSummaryResponse> content = result.threads().getContent().stream()
                 .map(thread -> ThreadSummaryResponse.from(
                         thread,

--- a/core/src/main/java/com/mailsangja/core/service/google/GoogleMailWatchQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/google/GoogleMailWatchQueryService.java
@@ -34,6 +34,23 @@ public class GoogleMailWatchQueryService {
         this.googleMailRestClient = googleMailRestClient;
     }
 
+    public void stop(String accessToken) {
+        if (isBlank(accessToken) || isBlank(googleMailProperties.getStopUri())) {
+            throw new MailAccountException(MailAccountErrorCode.GOOGLE_MAIL_WATCH_FAILED);
+        }
+
+        try {
+            googleMailRestClient
+                    .post()
+                    .uri(googleMailProperties.getStopUri())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (RestClientException e) {
+            throw new MailAccountException(MailAccountErrorCode.GOOGLE_MAIL_WATCH_FAILED);
+        }
+    }
+
     public GoogleMailWatchResult watch(String accessToken) {
         validateWatchInput(accessToken);
 

--- a/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/inbox/InboxQueryService.java
@@ -112,17 +112,29 @@ public class InboxQueryService {
         return threadRepositoryPort.countSentByUserIdAndFilters(userId, normalizeLabelIds(labelIds), read);
     }
 
-    public ThreadListResult findStarredThreadsResult(UUID userId, UUID markerId, Pageable pageable) {
-        Slice<Thread> threads = threadRepositoryPort.findStarredByUserIdAndDeletedAtIsNull(userId, markerId, pageable);
+    public ThreadListResult findStarredThreadsResult(
+            UUID userId,
+            UUID markerId,
+            List<UUID> labelIds,
+            Boolean read,
+            Pageable pageable
+    ) {
+        Slice<Thread> threads = threadRepositoryPort.findStarredByUserIdAndFilters(
+                userId,
+                normalizeLabelIds(labelIds),
+                read,
+                markerId,
+                pageable
+        );
         return buildThreadListResult(userId, threads);
     }
 
-    public long countStarred(UUID userId) {
-        return threadRepositoryPort.countStarredByUserId(userId);
+    public long countStarred(UUID userId, List<UUID> labelIds, Boolean read) {
+        return threadRepositoryPort.countStarredByUserIdAndFilters(userId, normalizeLabelIds(labelIds), read);
     }
 
-    public long countUnreadStarred(UUID userId) {
-        return threadRepositoryPort.countUnreadStarredByUserId(userId);
+    public long countUnreadStarred(UUID userId, List<UUID> labelIds, Boolean read) {
+        return threadRepositoryPort.countUnreadStarredByUserIdAndFilters(userId, normalizeLabelIds(labelIds), read);
     }
 
     private List<UUID> normalizeLabelIds(List<UUID> labelIds) {

--- a/core/src/main/java/com/mailsangja/core/service/search/MailSearchQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/search/MailSearchQueryService.java
@@ -42,6 +42,19 @@ public class MailSearchQueryService {
         return buildThreadListResult(userId, threads);
     }
 
+    public ThreadListResult searchStarredThreadsResult(UUID userId, String query, List<UUID> labelIds, Boolean read, UUID markerId, Pageable pageable) {
+        Slice<Thread> threads = mailSearchRepositoryPort.searchStarredThreads(userId, query, labelIds, read, markerId, pageable);
+        return buildThreadListResult(userId, threads);
+    }
+
+    public long countStarredThreads(UUID userId, String query, List<UUID> labelIds, Boolean read) {
+        return mailSearchRepositoryPort.countStarredThreads(userId, query, labelIds, read);
+    }
+
+    public long countUnreadStarredThreads(UUID userId, String query, List<UUID> labelIds, Boolean read) {
+        return mailSearchRepositoryPort.countUnreadStarredThreads(userId, query, labelIds, read);
+    }
+
     public Slice<Message> searchTrashMessages(UUID userId, String query, List<UUID> labelIds, Boolean read, UUID markerId, Pageable pageable) {
         return mailSearchRepositoryPort.searchTrashMessages(userId, query, labelIds, read, markerId, pageable);
     }

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -177,6 +177,7 @@ mailsangja:
     google-watch:
       topic-name: ${GOOGLE_GMAIL_WATCH_TOPIC_NAME:projects/local/topics/mailbox-gmail-watch}
       watch-uri: ${GOOGLE_GMAIL_WATCH_URI:https://gmail.googleapis.com/gmail/v1/users/me/watch}
+      stop-uri: ${GOOGLE_GMAIL_STOP_URI:https://gmail.googleapis.com/gmail/v1/users/me/stop}
       thread-modify-uri: ${GOOGLE_GMAIL_THREAD_MODIFY_URI:https://gmail.googleapis.com/gmail/v1/users/me/threads/{gmailThreadId}/modify}
       message-modify-uri: ${GOOGLE_GMAIL_MESSAGE_MODIFY_URI:https://gmail.googleapis.com/gmail/v1/users/me/messages/{gmailMessageId}/modify}
       send-uri: ${GOOGLE_GMAIL_SEND_URI:https://gmail.googleapis.com/gmail/v1/users/me/messages/send}

--- a/core/src/test/java/com/mailsangja/core/facade/MailAccountFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/MailAccountFacadeTest.java
@@ -372,6 +372,63 @@ class MailAccountFacadeTest {
     }
 
     @Test
+    void deleteMailAccount_Gmail계정이면watch를중단하고삭제한다() {
+        // given
+        User user = createUser();
+        UUID mailAccountId = UUID.randomUUID();
+        MailAccount mailAccount = createMailAccount(user);
+        MailAccountCommandService mailAccountCommandService = mock(MailAccountCommandService.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        GoogleMailWatchQueryService googleMailWatchQueryService = mock(GoogleMailWatchQueryService.class);
+        MailAccountFacade facade = createFacade(
+                mailAccountCommandService,
+                mailAccountQueryService,
+                mock(GoogleOAuthQueryService.class),
+                googleMailWatchQueryService,
+                mock(InitialMailSyncMessageCommandService.class),
+                mock(GooglePeopleContactQueryService.class),
+                mock(ContactCommandService.class)
+        );
+        when(mailAccountQueryService.findById(mailAccountId)).thenReturn(mailAccount);
+
+        // when
+        facade.deleteMailAccount(user, mailAccountId);
+
+        // then
+        InOrder inOrder = inOrder(googleMailWatchQueryService, mailAccountCommandService);
+        inOrder.verify(googleMailWatchQueryService).stop("access-token");
+        inOrder.verify(mailAccountCommandService).deleteMailAccount(user, mailAccountId);
+    }
+
+    @Test
+    void deleteMailAccount_watch중단이실패해도계정삭제는진행한다() {
+        // given
+        User user = createUser();
+        UUID mailAccountId = UUID.randomUUID();
+        MailAccount mailAccount = createMailAccount(user);
+        MailAccountCommandService mailAccountCommandService = mock(MailAccountCommandService.class);
+        MailAccountQueryService mailAccountQueryService = mock(MailAccountQueryService.class);
+        GoogleMailWatchQueryService googleMailWatchQueryService = mock(GoogleMailWatchQueryService.class);
+        MailAccountFacade facade = createFacade(
+                mailAccountCommandService,
+                mailAccountQueryService,
+                mock(GoogleOAuthQueryService.class),
+                googleMailWatchQueryService,
+                mock(InitialMailSyncMessageCommandService.class),
+                mock(GooglePeopleContactQueryService.class),
+                mock(ContactCommandService.class)
+        );
+        when(mailAccountQueryService.findById(mailAccountId)).thenReturn(mailAccount);
+        doThrow(new RuntimeException("Gmail API failed")).when(googleMailWatchQueryService).stop("access-token");
+
+        // when
+        facade.deleteMailAccount(user, mailAccountId);
+
+        // then
+        verify(mailAccountCommandService).deleteMailAccount(user, mailAccountId);
+    }
+
+    @Test
     void deactivateMailAccount_서비스에위임한다() {
         // given
         User user = createUser();

--- a/core/src/test/java/com/mailsangja/core/facade/StarFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/StarFacadeTest.java
@@ -7,6 +7,7 @@ import com.mailsangja.core.dto.inbox.ThreadSummaryResponse;
 import com.mailsangja.core.service.inbox.InboxCommandService;
 import com.mailsangja.core.service.inbox.InboxQueryService;
 import com.mailsangja.core.service.mail.MailAccountQueryService;
+import com.mailsangja.core.service.search.MailSearchQueryService;
 import com.mailsangja.db.entity.mail.Direction;
 import com.mailsangja.db.entity.mail.MailAccount;
 import com.mailsangja.db.entity.mail.MailProvider;
@@ -27,11 +28,12 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,57 +44,169 @@ class StarFacadeTest {
     @Mock private InboxCommandService inboxCommandService;
     @Mock private InboxQueryService inboxQueryService;
     @Mock private MailAccountQueryService mailAccountQueryService;
+    @Mock private MailSearchQueryService mailSearchQueryService;
 
     @InjectMocks
     private StarFacade starFacade;
 
     @Test
-    void 별표_목록_조회는_QueryService를_호출하고_MarkerSlice를_조립한다() {
+    void 검색어가_null이면_기본_starred_조회_서비스를_사용한다() {
         User user = user();
         Thread thread = thread(mailAccount(user, MailProvider.GMAIL), Direction.INBOUND);
-        when(inboxQueryService.findStarredThreadsResult(user.getId(), null, PageRequest.of(0, 20)))
+        when(inboxQueryService.findStarredThreadsResult(user.getId(), null, null, null, PageRequest.of(0, 20)))
                 .thenReturn(threadListResult(List.of(thread), false));
-        when(inboxQueryService.countStarred(user.getId())).thenReturn(3L);
-        when(inboxQueryService.countUnreadStarred(user.getId())).thenReturn(2L);
+        when(inboxQueryService.countStarred(user.getId(), null, null)).thenReturn(3L);
+        when(inboxQueryService.countUnreadStarred(user.getId(), null, null)).thenReturn(2L);
 
-        MarkerSliceResponse<ThreadSummaryResponse> result = starFacade.getStarred(user, null, 20);
+        MarkerSliceResponse<ThreadSummaryResponse> result = starFacade.getStarred(user, null, 20, null, null, null);
 
         assertEquals(1, result.content().size());
         assertEquals(3L, result.totalCount());
         assertEquals(2L, result.unreadCount());
         assertNull(result.nextMarker());
+        verify(mailSearchQueryService, never()).searchStarredThreadsResult(any(), any(), anyList(), any(), any(), any());
+    }
+
+    @Test
+    void 검색어가_공백이면_기본_starred_조회_서비스를_사용한다() {
+        User user = user();
+        when(inboxQueryService.findStarredThreadsResult(user.getId(), null, null, null, PageRequest.of(0, 10)))
+                .thenReturn(threadListResult(List.of(), false));
+        when(inboxQueryService.countStarred(user.getId(), null, null)).thenReturn(0L);
+        when(inboxQueryService.countUnreadStarred(user.getId(), null, null)).thenReturn(0L);
+
+        MarkerSliceResponse<ThreadSummaryResponse> result = starFacade.getStarred(user, null, 10, null, null, "   ");
+
+        assertEquals(0, result.content().size());
+        verify(inboxQueryService).findStarredThreadsResult(user.getId(), null, null, null, PageRequest.of(0, 10));
+        verify(mailSearchQueryService, never()).searchStarredThreadsResult(any(), any(), anyList(), any(), any(), any());
     }
 
     @Test
     void 별표_목록이_비어있으면_nextMarker가_null이다() {
         User user = user();
-        when(inboxQueryService.findStarredThreadsResult(user.getId(), null, PageRequest.of(0, 10)))
+        when(inboxQueryService.findStarredThreadsResult(user.getId(), null, null, null, PageRequest.of(0, 10)))
                 .thenReturn(threadListResult(List.of(), false));
-        when(inboxQueryService.countStarred(user.getId())).thenReturn(0L);
-        when(inboxQueryService.countUnreadStarred(user.getId())).thenReturn(0L);
+        when(inboxQueryService.countStarred(user.getId(), null, null)).thenReturn(0L);
+        when(inboxQueryService.countUnreadStarred(user.getId(), null, null)).thenReturn(0L);
 
-        MarkerSliceResponse<ThreadSummaryResponse> result = starFacade.getStarred(user, null, 10);
+        MarkerSliceResponse<ThreadSummaryResponse> result = starFacade.getStarred(user, null, 10, null, null, null);
 
-        assertEquals(0, result.content().size());
         assertNull(result.nextMarker());
+        assertFalse(result.hasNext());
         assertEquals(0L, result.totalCount());
-        assertEquals(0L, result.unreadCount());
     }
 
     @Test
     void 별표_목록에_다음_페이지가_있으면_마지막_스레드_ID가_nextMarker가_된다() {
         User user = user();
         Thread thread = thread(mailAccount(user, MailProvider.GMAIL), Direction.INBOUND);
-        when(inboxQueryService.findStarredThreadsResult(user.getId(), null, PageRequest.of(0, 5)))
+        when(inboxQueryService.findStarredThreadsResult(user.getId(), null, null, null, PageRequest.of(0, 5)))
                 .thenReturn(threadListResult(List.of(thread), true));
-        when(inboxQueryService.countStarred(user.getId())).thenReturn(10L);
-        when(inboxQueryService.countUnreadStarred(user.getId())).thenReturn(4L);
+        when(inboxQueryService.countStarred(user.getId(), null, null)).thenReturn(10L);
+        when(inboxQueryService.countUnreadStarred(user.getId(), null, null)).thenReturn(4L);
 
-        MarkerSliceResponse<ThreadSummaryResponse> result = starFacade.getStarred(user, null, 5);
+        MarkerSliceResponse<ThreadSummaryResponse> result = starFacade.getStarred(user, null, 5, null, null, null);
 
         assertEquals(thread.getId(), result.nextMarker());
         assertTrue(result.hasNext());
     }
+
+    @Test
+    void label_필터가_있으면_기본_조회_서비스에_label_필터를_전달한다() {
+        User user = user();
+        List<UUID> labelIds = List.of(UUID.randomUUID());
+        Thread thread = thread(mailAccount(user, MailProvider.GMAIL), Direction.INBOUND);
+        when(inboxQueryService.findStarredThreadsResult(user.getId(), null, labelIds, null, PageRequest.of(0, 50)))
+                .thenReturn(threadListResult(List.of(thread), false));
+        when(inboxQueryService.countStarred(user.getId(), labelIds, null)).thenReturn(1L);
+        when(inboxQueryService.countUnreadStarred(user.getId(), labelIds, null)).thenReturn(0L);
+
+        MarkerSliceResponse<ThreadSummaryResponse> result = starFacade.getStarred(user, null, 50, labelIds, null, null);
+
+        assertEquals(1, result.content().size());
+        verify(inboxQueryService).findStarredThreadsResult(user.getId(), null, labelIds, null, PageRequest.of(0, 50));
+        verify(mailSearchQueryService, never()).searchStarredThreadsResult(any(), any(), anyList(), any(), any(), any());
+    }
+
+    @Test
+    void read_false_필터가_있으면_기본_조회_서비스에_read_필터를_전달한다() {
+        User user = user();
+        Thread thread = thread(mailAccount(user, MailProvider.GMAIL), Direction.INBOUND);
+        when(inboxQueryService.findStarredThreadsResult(user.getId(), null, null, false, PageRequest.of(0, 50)))
+                .thenReturn(threadListResult(List.of(thread), false));
+        when(inboxQueryService.countStarred(user.getId(), null, false)).thenReturn(1L);
+        when(inboxQueryService.countUnreadStarred(user.getId(), null, false)).thenReturn(1L);
+
+        MarkerSliceResponse<ThreadSummaryResponse> result = starFacade.getStarred(user, null, 50, null, false, null);
+
+        assertEquals(1, result.content().size());
+        verify(inboxQueryService).findStarredThreadsResult(user.getId(), null, null, false, PageRequest.of(0, 50));
+    }
+
+    @Test
+    void label과_read_필터를_동시에_전달하면_기본_조회_서비스에_모두_전달된다() {
+        User user = user();
+        List<UUID> labelIds = List.of(UUID.randomUUID());
+        UUID marker = UUID.randomUUID();
+        Thread thread = thread(mailAccount(user, MailProvider.GMAIL), Direction.INBOUND);
+        when(inboxQueryService.findStarredThreadsResult(user.getId(), marker, labelIds, true, PageRequest.of(0, 30)))
+                .thenReturn(threadListResult(List.of(thread), false));
+        when(inboxQueryService.countStarred(user.getId(), labelIds, true)).thenReturn(1L);
+        when(inboxQueryService.countUnreadStarred(user.getId(), labelIds, true)).thenReturn(0L);
+
+        MarkerSliceResponse<ThreadSummaryResponse> result = starFacade.getStarred(user, marker, 30, labelIds, true, null);
+
+        assertEquals(1, result.content().size());
+        assertEquals(1L, result.totalCount());
+        assertEquals(0L, result.unreadCount());
+    }
+
+    // -------------------------------------------------------------------------
+    // getStarred — q 있음(검색 분기)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void 검색어가_있으면_starred_검색_서비스에_trim된_검색어와_필터를_전달한다() {
+        User user = user();
+        UUID marker = UUID.randomUUID();
+        List<UUID> labelIds = List.of(UUID.randomUUID());
+        Thread thread = thread(mailAccount(user, MailProvider.GMAIL), Direction.INBOUND);
+        when(mailSearchQueryService.searchStarredThreadsResult(
+                user.getId(), "프로젝트", labelIds, false, marker, PageRequest.of(0, 30)))
+                .thenReturn(threadListResult(List.of(thread), true));
+        when(mailSearchQueryService.countUnreadStarredThreads(user.getId(), "프로젝트", labelIds, false)).thenReturn(1L);
+        when(mailSearchQueryService.countStarredThreads(user.getId(), "프로젝트", labelIds, false)).thenReturn(2L);
+
+        MarkerSliceResponse<ThreadSummaryResponse> result =
+                starFacade.getStarred(user, marker, 30, labelIds, false, "  프로젝트  ");
+
+        assertEquals(thread.getId(), result.nextMarker());
+        assertEquals(1L, result.unreadCount());
+        assertEquals(2L, result.totalCount());
+        verify(inboxQueryService, never()).findStarredThreadsResult(any(), any(), anyList(), any(), any());
+    }
+
+    @Test
+    void 검색어만_있고_필터_없으면_검색_서비스에_null_필터로_전달한다() {
+        User user = user();
+        Thread thread = thread(mailAccount(user, MailProvider.GMAIL), Direction.INBOUND);
+        when(mailSearchQueryService.searchStarredThreadsResult(
+                user.getId(), "회의", null, null, null, PageRequest.of(0, 50)))
+                .thenReturn(threadListResult(List.of(thread), false));
+        when(mailSearchQueryService.countUnreadStarredThreads(user.getId(), "회의", null, null)).thenReturn(0L);
+        when(mailSearchQueryService.countStarredThreads(user.getId(), "회의", null, null)).thenReturn(1L);
+
+        MarkerSliceResponse<ThreadSummaryResponse> result = starFacade.getStarred(user, null, 50, null, null, "회의");
+
+        assertEquals(1, result.content().size());
+        assertNull(result.nextMarker());
+        verify(inboxQueryService, never()).findStarredThreadsResult(any(), any(), anyList(), any(), any());
+    }
+
+    // -------------------------------------------------------------------------
+    // toggleThreadStar
+    // -------------------------------------------------------------------------
 
     @Test
     void 스레드_별표_토글은_소유_계정_스레드면_CommandService를_호출한다() {
@@ -121,6 +235,10 @@ class StarFacadeTest {
         assertThrows(InboxException.class, () -> starFacade.toggleThreadStar(user, thread.getId()));
         verify(inboxCommandService, never()).toggleStar(any());
     }
+
+    // -------------------------------------------------------------------------
+    // toggleMessageStar
+    // -------------------------------------------------------------------------
 
     @Test
     void 메시지_별표_토글은_소유_계정_메시지면_CommandService를_호출한다() {
@@ -151,6 +269,10 @@ class StarFacadeTest {
         assertThrows(InboxException.class, () -> starFacade.toggleMessageStar(user, message.getId()));
         verify(inboxCommandService, never()).toggleMessageStar(any());
     }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
 
     private ThreadListResult threadListResult(List<Thread> threads, boolean hasNext) {
         return new ThreadListResult(new SliceImpl<>(threads, PageRequest.of(0, 50), hasNext), Map.of(), Map.of(), Map.of());

--- a/core/src/test/java/com/mailsangja/core/service/inbox/InboxQueryServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/inbox/InboxQueryServiceTest.java
@@ -152,7 +152,7 @@ class InboxQueryServiceTest {
         Attachment attachment = attachment(message);
         message.replaceAttachments(List.of(attachment));
         ThreadMessageLabelView label = new ThreadMessageLabelView(thread.getId(), UUID.randomUUID(), "중요", "#FF0000", false);
-        when(threadRepositoryPort.findStarredByUserIdAndDeletedAtIsNull(user.getId(), null, PageRequest.of(0, 20)))
+        when(threadRepositoryPort.findStarredByUserIdAndFilters(user.getId(), List.of(), null, null, PageRequest.of(0, 20)))
                 .thenReturn(new SliceImpl<>(List.of(thread), PageRequest.of(0, 20), false));
         when(messageRepositoryPort.findAllByThreadIdInAndDeletedAtIsNull(List.of(thread.getId())))
                 .thenReturn(List.of(message));
@@ -163,7 +163,7 @@ class InboxQueryServiceTest {
 
         // when
         ThreadListResult result =
-                inboxQueryService.findStarredThreadsResult(user.getId(), null, PageRequest.of(0, 20));
+                inboxQueryService.findStarredThreadsResult(user.getId(), null, null, null, PageRequest.of(0, 20));
 
         // then
         assertEquals(1, result.threads().getContent().size());
@@ -175,12 +175,12 @@ class InboxQueryServiceTest {
     void 별표_스레드_목록이_비어있으면_라벨과_첨부와_연락처를_조회하지_않는다() {
         // given
         User user = user();
-        when(threadRepositoryPort.findStarredByUserIdAndDeletedAtIsNull(user.getId(), null, PageRequest.of(0, 10)))
+        when(threadRepositoryPort.findStarredByUserIdAndFilters(user.getId(), List.of(), null, null, PageRequest.of(0, 10)))
                 .thenReturn(new SliceImpl<>(List.of(), PageRequest.of(0, 10), false));
 
         // when
         ThreadListResult result =
-                inboxQueryService.findStarredThreadsResult(user.getId(), null, PageRequest.of(0, 10));
+                inboxQueryService.findStarredThreadsResult(user.getId(), null, null, null, PageRequest.of(0, 10));
 
         // then
         assertEquals(0, result.threads().getContent().size());
@@ -190,17 +190,49 @@ class InboxQueryServiceTest {
     }
 
     @Test
-    void 별표_스레드_카운트는_port에_userId를_전달한다() {
+    void 별표_스레드_목록_조회는_라벨_ID에서_null과_중복을_제거하고_read_필터를_전달한다() {
         // given
-        UUID userId = UUID.randomUUID();
-        when(threadRepositoryPort.countStarredByUserId(userId)).thenReturn(5L);
+        User user = user();
+        UUID labelId = UUID.randomUUID();
+        List<UUID> labelIds = Arrays.asList(labelId, null, labelId);
+        when(threadRepositoryPort.findStarredByUserIdAndFilters(user.getId(), List.of(labelId), false, null, PageRequest.of(0, 10)))
+                .thenReturn(new SliceImpl<>(List.of(), PageRequest.of(0, 10), false));
 
         // when
-        long result = inboxQueryService.countStarred(userId);
+        ThreadListResult result =
+                inboxQueryService.findStarredThreadsResult(user.getId(), null, labelIds, false, PageRequest.of(0, 10));
+
+        // then
+        verify(threadRepositoryPort).findStarredByUserIdAndFilters(user.getId(), List.of(labelId), false, null, PageRequest.of(0, 10));
+    }
+
+    @Test
+    void 별표_스레드_카운트는_port에_필터를_전달한다() {
+        // given
+        UUID userId = UUID.randomUUID();
+        when(threadRepositoryPort.countStarredByUserIdAndFilters(userId, List.of(), null)).thenReturn(5L);
+
+        // when
+        long result = inboxQueryService.countStarred(userId, null, null);
 
         // then
         assertEquals(5L, result);
-        verify(threadRepositoryPort).countStarredByUserId(userId);
+        verify(threadRepositoryPort).countStarredByUserIdAndFilters(userId, List.of(), null);
+    }
+
+    @Test
+    void 읽지_않은_별표_카운트는_read_필터와_정규화된_라벨_ID를_전달한다() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID labelId = UUID.randomUUID();
+        when(threadRepositoryPort.countUnreadStarredByUserIdAndFilters(userId, List.of(labelId), null)).thenReturn(3L);
+
+        // when
+        long result = inboxQueryService.countUnreadStarred(userId, Arrays.asList(labelId, null, labelId), null);
+
+        // then
+        assertEquals(3L, result);
+        verify(threadRepositoryPort).countUnreadStarredByUserIdAndFilters(userId, List.of(labelId), null);
     }
 
     @Test

--- a/db/src/main/java/com/mailsangja/db/adapter/mail/ThreadRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/mail/ThreadRepositoryAdapter.java
@@ -181,6 +181,23 @@ public class ThreadRepositoryAdapter implements ThreadRepositoryPort {
     }
 
     @Override
+    public Slice<Thread> findStarredByUserIdAndFilters(
+            UUID userId,
+            List<UUID> labelIds,
+            Boolean read,
+            UUID markerId,
+            Pageable pageable
+    ) {
+        if (labelIds == null || labelIds.isEmpty()) {
+            if (read == null) {
+                return threadJpaRepositoryModule.findStarredByUserId(userId, markerId, pageable);
+            }
+            return threadJpaRepositoryModule.findStarredByUserIdAndReadFilter(userId, markerId, read, pageable);
+        }
+        return threadJpaRepositoryModule.findStarredByUserIdAndLabelIdsAndReadFilter(userId, labelIds, markerId, read, pageable);
+    }
+
+    @Override
     public long countStarredByUserId(UUID userId) {
         return threadJpaRepositoryModule.countStarredByUserId(userId);
     }
@@ -188,5 +205,24 @@ public class ThreadRepositoryAdapter implements ThreadRepositoryPort {
     @Override
     public long countUnreadStarredByUserId(UUID userId) {
         return threadJpaRepositoryModule.countUnreadStarredByUserId(userId);
+    }
+
+    @Override
+    public long countStarredByUserIdAndFilters(UUID userId, List<UUID> labelIds, Boolean read) {
+        if (labelIds == null || labelIds.isEmpty()) {
+            return threadJpaRepositoryModule.countStarredByUserIdAndReadFilter(userId, read);
+        }
+        return threadJpaRepositoryModule.countStarredByUserIdAndLabelIdsAndReadFilter(userId, labelIds, read);
+    }
+
+    @Override
+    public long countUnreadStarredByUserIdAndFilters(UUID userId, List<UUID> labelIds, Boolean read) {
+        if (Boolean.TRUE.equals(read)) {
+            return 0L;
+        }
+        if (labelIds == null || labelIds.isEmpty()) {
+            return threadJpaRepositoryModule.countUnreadStarredByUserId(userId);
+        }
+        return threadJpaRepositoryModule.countUnreadStarredByUserIdAndLabelIds(userId, labelIds);
     }
 }

--- a/db/src/main/java/com/mailsangja/db/adapter/search/MailSearchRepositoryAdapter.java
+++ b/db/src/main/java/com/mailsangja/db/adapter/search/MailSearchRepositoryAdapter.java
@@ -190,6 +190,48 @@ public class MailSearchRepositoryAdapter implements MailSearchRepositoryPort {
     }
 
     @Override
+    public Slice<Thread> searchStarredThreads(UUID userId, String query, List<UUID> labelIds, Boolean read, UUID markerId, Pageable pageable) {
+        int limit = pageable.getPageSize() + 1;
+        String userIdStr = userId.toString();
+        List<String> effectiveLabelIds = toEffectiveLabelIds(labelIds);
+        boolean labelsEmpty = labelIds == null || labelIds.isEmpty();
+
+        List<String> rawIds = (markerId == null)
+                ? mailSearchJpaRepositoryModule.searchStarredThreadIdsFirstPage(userIdStr, query, effectiveLabelIds, labelsEmpty, read, limit)
+                : mailSearchJpaRepositoryModule.searchStarredThreadIdsAfterMarker(userIdStr, query, effectiveLabelIds, labelsEmpty, read, markerId.toString(), limit);
+
+        if (rawIds.isEmpty()) return new SliceImpl<>(Collections.emptyList(), pageable, false);
+
+        boolean hasNext = rawIds.size() > pageable.getPageSize();
+        List<UUID> pageIds = (hasNext ? rawIds.subList(0, pageable.getPageSize()) : rawIds)
+                .stream().map(UUID::fromString).toList();
+
+        Map<UUID, Thread> threadById = mailSearchJpaRepositoryModule.findAllByIdInWithMailAccount(pageIds)
+                .stream().collect(Collectors.toMap(Thread::getId, Function.identity()));
+        List<Thread> ordered = pageIds.stream().map(threadById::get).filter(Objects::nonNull).toList();
+        return new SliceImpl<>(ordered, pageable, hasNext);
+    }
+
+    @Override
+    public long countStarredThreads(UUID userId, String query, List<UUID> labelIds, Boolean read) {
+        List<String> effectiveLabelIds = toEffectiveLabelIds(labelIds);
+        boolean labelsEmpty = labelIds == null || labelIds.isEmpty();
+        Long result = mailSearchJpaRepositoryModule.countStarredThreads(userId.toString(), query, effectiveLabelIds, labelsEmpty, read);
+        return result != null ? result : 0L;
+    }
+
+    @Override
+    public long countUnreadStarredThreads(UUID userId, String query, List<UUID> labelIds, Boolean read) {
+        if (Boolean.TRUE.equals(read)) {
+            return 0L;
+        }
+        List<String> effectiveLabelIds = toEffectiveLabelIds(labelIds);
+        boolean labelsEmpty = labelIds == null || labelIds.isEmpty();
+        Long result = mailSearchJpaRepositoryModule.countUnreadStarredThreads(userId.toString(), query, effectiveLabelIds, labelsEmpty);
+        return result != null ? result : 0L;
+    }
+
+    @Override
     public long countInboxThreads(UUID userId, String query, List<UUID> labelIds, Boolean read) {
         List<String> effectiveLabelIds = toEffectiveLabelIds(labelIds);
         boolean labelsEmpty = labelIds == null || labelIds.isEmpty();

--- a/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/mail/ThreadJpaRepositoryModule.java
@@ -391,6 +391,160 @@ public interface ThreadJpaRepositoryModule extends JpaRepository<Thread, UUID> {
             """)
     long countUnreadStarredByUserId(@Param("userId") UUID userId);
 
+    @EntityGraph(attributePaths = {"mailAccount"})
+    @Query("""
+            SELECT t FROM Thread t
+            WHERE t.mailAccount.id IN (
+                SELECT ma.id FROM MailAccount ma
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
+            )
+              AND t.star = true
+              AND t.deletedAt IS NULL
+              AND (:read IS NULL OR t.read = :read)
+              AND (
+                :markerId IS NULL
+                OR t.lastMessageAt < (
+                  SELECT m.lastMessageAt FROM Thread m
+                  WHERE m.id = :markerId
+                    AND m.mailAccount.id IN (
+                      SELECT ma.id FROM MailAccount ma
+                      WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
+                    )
+                    AND m.star = true
+                )
+                OR (
+                  t.lastMessageAt = (
+                    SELECT m.lastMessageAt FROM Thread m
+                    WHERE m.id = :markerId
+                      AND m.mailAccount.id IN (
+                        SELECT ma.id FROM MailAccount ma
+                        WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
+                      )
+                      AND m.star = true
+                  )
+                  AND t.id < :markerId
+                )
+              )
+            ORDER BY t.lastMessageAt DESC, t.id DESC
+            """)
+    Slice<Thread> findStarredByUserIdAndReadFilter(
+            @Param("userId") UUID userId,
+            @Param("markerId") UUID markerId,
+            @Param("read") Boolean read,
+            Pageable pageable
+    );
+
+    @EntityGraph(attributePaths = {"mailAccount"})
+    @Query("""
+            SELECT DISTINCT t FROM Thread t
+            WHERE t.mailAccount.id IN (
+                SELECT ma.id FROM MailAccount ma
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
+            )
+              AND t.star = true
+              AND t.deletedAt IS NULL
+              AND (:read IS NULL OR t.read = :read)
+              AND EXISTS (
+                SELECT 1 FROM MessageLabel ml
+                WHERE ml.message.thread = t
+                  AND ml.deletedAt IS NULL
+                  AND ml.label.id IN :labelIds
+                  AND ml.label.deletedAt IS NULL
+              )
+              AND (
+                :markerId IS NULL
+                OR t.lastMessageAt < (
+                    SELECT m.lastMessageAt FROM Thread m
+                    WHERE m.id = :markerId
+                      AND m.mailAccount.id IN (
+                        SELECT ma.id FROM MailAccount ma
+                        WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
+                      )
+                      AND m.star = true
+                )
+                OR (
+                    t.lastMessageAt = (
+                        SELECT m.lastMessageAt FROM Thread m
+                        WHERE m.id = :markerId
+                          AND m.mailAccount.id IN (
+                            SELECT ma.id FROM MailAccount ma
+                            WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
+                          )
+                          AND m.star = true
+                    )
+                    AND t.id < :markerId
+                )
+              )
+            ORDER BY t.lastMessageAt DESC, t.id DESC
+            """)
+    Slice<Thread> findStarredByUserIdAndLabelIdsAndReadFilter(
+            @Param("userId") UUID userId,
+            @Param("labelIds") List<UUID> labelIds,
+            @Param("markerId") UUID markerId,
+            @Param("read") Boolean read,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT COUNT(t) FROM Thread t
+            WHERE t.mailAccount.id IN (
+                SELECT ma.id FROM MailAccount ma
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
+            )
+              AND t.star = true
+              AND t.deletedAt IS NULL
+              AND (:read IS NULL OR t.read = :read)
+            """)
+    long countStarredByUserIdAndReadFilter(
+            @Param("userId") UUID userId,
+            @Param("read") Boolean read
+    );
+
+    @Query("""
+            SELECT COUNT(DISTINCT t) FROM Thread t
+            WHERE t.mailAccount.id IN (
+                SELECT ma.id FROM MailAccount ma
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
+            )
+              AND t.star = true
+              AND t.read = false
+              AND t.deletedAt IS NULL
+              AND EXISTS (
+                SELECT 1 FROM MessageLabel ml
+                WHERE ml.message.thread = t
+                  AND ml.deletedAt IS NULL
+                  AND ml.label.id IN :labelIds
+                  AND ml.label.deletedAt IS NULL
+              )
+            """)
+    long countUnreadStarredByUserIdAndLabelIds(
+            @Param("userId") UUID userId,
+            @Param("labelIds") List<UUID> labelIds
+    );
+
+    @Query("""
+            SELECT COUNT(DISTINCT t) FROM Thread t
+            WHERE t.mailAccount.id IN (
+                SELECT ma.id FROM MailAccount ma
+                WHERE ma.user.id = :userId AND ma.active = true AND ma.deletedAt IS NULL
+            )
+              AND t.star = true
+              AND t.deletedAt IS NULL
+              AND (:read IS NULL OR t.read = :read)
+              AND EXISTS (
+                SELECT 1 FROM MessageLabel ml
+                WHERE ml.message.thread = t
+                  AND ml.deletedAt IS NULL
+                  AND ml.label.id IN :labelIds
+                  AND ml.label.deletedAt IS NULL
+              )
+            """)
+    long countStarredByUserIdAndLabelIdsAndReadFilter(
+            @Param("userId") UUID userId,
+            @Param("labelIds") List<UUID> labelIds,
+            @Param("read") Boolean read
+    );
+
     @Query("SELECT t FROM Thread t WHERE t.mailAccount.id = :mailAccountId AND t.gmailThreadId = :gmailThreadId")
     List<Thread> findAllByMailAccountIdAndGmailThreadId(
             @Param("mailAccountId") UUID mailAccountId,

--- a/db/src/main/java/com/mailsangja/db/module/search/MailSearchJpaRepositoryModule.java
+++ b/db/src/main/java/com/mailsangja/db/module/search/MailSearchJpaRepositoryModule.java
@@ -267,6 +267,90 @@ public interface MailSearchJpaRepositoryModule extends JpaRepository<Thread, UUI
     );
 
     // -------------------------------------------------------------------------
+    // starred FTS (t.is_star = TRUE, t.deleted_at IS NULL)
+    // -------------------------------------------------------------------------
+
+    @Query(value = """
+            SELECT t.id FROM threads t JOIN mail_accounts ma ON t.mail_account_id = ma.id
+            WHERE ma.user_id = :userId AND ma.is_active = TRUE AND ma.deleted_at IS NULL
+              AND t.deleted_at IS NULL AND t.is_star = TRUE
+              AND (EXISTS (SELECT 1 FROM messages m WHERE m.thread_id = t.id AND m.deleted_at IS NULL AND (m.search_vector @@ websearch_to_tsquery('korean', :query) OR m.search_text LIKE '%' || replace(replace(replace(lower(:query), '!', '!!'), '%', '!%'), '_', '!_') || '%' ESCAPE '!'))
+                   OR EXISTS (SELECT 1 FROM attachments a JOIN messages m ON a.message_id = m.id WHERE m.thread_id = t.id AND m.deleted_at IS NULL AND a.deleted_at IS NULL AND (a.filename_vector @@ websearch_to_tsquery('korean', :query) OR lower(a.filename) LIKE '%' || replace(replace(replace(lower(:query), '!', '!!'), '%', '!%'), '_', '!_') || '%' ESCAPE '!')))
+              AND (:read IS NULL OR t.is_read = :read)
+              AND (:labelsEmpty = TRUE OR EXISTS (SELECT 1 FROM message_labels ml JOIN messages m2 ON ml.message_id = m2.id WHERE m2.thread_id = t.id AND m2.deleted_at IS NULL AND ml.label_id IN (:labelIds) AND ml.deleted_at IS NULL))
+            ORDER BY t.last_message_at DESC, t.id DESC LIMIT :limit
+            """, nativeQuery = true)
+    List<String> searchStarredThreadIdsFirstPage(
+            @Param("userId") String userId,
+            @Param("query") String query,
+            @Param("labelIds") List<String> labelIds,
+            @Param("labelsEmpty") boolean labelsEmpty,
+            @Param("read") Boolean read,
+            @Param("limit") int limit
+    );
+
+    @Query(value = """
+            SELECT t.id FROM threads t JOIN mail_accounts ma ON t.mail_account_id = ma.id
+            WHERE ma.user_id = :userId AND ma.is_active = TRUE AND ma.deleted_at IS NULL
+              AND t.deleted_at IS NULL AND t.is_star = TRUE
+              AND (EXISTS (SELECT 1 FROM messages m WHERE m.thread_id = t.id AND m.deleted_at IS NULL AND (m.search_vector @@ websearch_to_tsquery('korean', :query) OR m.search_text LIKE '%' || replace(replace(replace(lower(:query), '!', '!!'), '%', '!%'), '_', '!_') || '%' ESCAPE '!'))
+                   OR EXISTS (SELECT 1 FROM attachments a JOIN messages m ON a.message_id = m.id WHERE m.thread_id = t.id AND m.deleted_at IS NULL AND a.deleted_at IS NULL AND (a.filename_vector @@ websearch_to_tsquery('korean', :query) OR lower(a.filename) LIKE '%' || replace(replace(replace(lower(:query), '!', '!!'), '%', '!%'), '_', '!_') || '%' ESCAPE '!')))
+              AND (:read IS NULL OR t.is_read = :read)
+              AND (:labelsEmpty = TRUE OR EXISTS (SELECT 1 FROM message_labels ml JOIN messages m2 ON ml.message_id = m2.id WHERE m2.thread_id = t.id AND m2.deleted_at IS NULL AND ml.label_id IN (:labelIds) AND ml.deleted_at IS NULL))
+              AND (t.last_message_at < (SELECT t2.last_message_at FROM threads t2
+                                        JOIN mail_accounts ma2 ON t2.mail_account_id = ma2.id
+                                        WHERE t2.id = :markerId AND ma2.user_id = :userId
+                                          AND ma2.is_active = TRUE AND ma2.deleted_at IS NULL AND t2.deleted_at IS NULL)
+                   OR (t.last_message_at = (SELECT t2.last_message_at FROM threads t2
+                                            JOIN mail_accounts ma2 ON t2.mail_account_id = ma2.id
+                                            WHERE t2.id = :markerId AND ma2.user_id = :userId
+                                              AND ma2.is_active = TRUE AND ma2.deleted_at IS NULL AND t2.deleted_at IS NULL)
+                       AND t.id < :markerId))
+            ORDER BY t.last_message_at DESC, t.id DESC LIMIT :limit
+            """, nativeQuery = true)
+    List<String> searchStarredThreadIdsAfterMarker(
+            @Param("userId") String userId,
+            @Param("query") String query,
+            @Param("labelIds") List<String> labelIds,
+            @Param("labelsEmpty") boolean labelsEmpty,
+            @Param("read") Boolean read,
+            @Param("markerId") String markerId,
+            @Param("limit") int limit
+    );
+
+    @Query(value = """
+            SELECT COUNT(*) FROM threads t JOIN mail_accounts ma ON t.mail_account_id = ma.id
+            WHERE ma.user_id = :userId AND ma.is_active = TRUE AND ma.deleted_at IS NULL
+              AND t.deleted_at IS NULL AND t.is_star = TRUE
+              AND (EXISTS (SELECT 1 FROM messages m WHERE m.thread_id = t.id AND m.deleted_at IS NULL AND (m.search_vector @@ websearch_to_tsquery('korean', :query) OR m.search_text LIKE '%' || replace(replace(replace(lower(:query), '!', '!!'), '%', '!%'), '_', '!_') || '%' ESCAPE '!'))
+                   OR EXISTS (SELECT 1 FROM attachments a JOIN messages m ON a.message_id = m.id WHERE m.thread_id = t.id AND m.deleted_at IS NULL AND a.deleted_at IS NULL AND (a.filename_vector @@ websearch_to_tsquery('korean', :query) OR lower(a.filename) LIKE '%' || replace(replace(replace(lower(:query), '!', '!!'), '%', '!%'), '_', '!_') || '%' ESCAPE '!')))
+              AND (:read IS NULL OR t.is_read = :read)
+              AND (:labelsEmpty = TRUE OR EXISTS (SELECT 1 FROM message_labels ml JOIN messages m2 ON ml.message_id = m2.id WHERE m2.thread_id = t.id AND m2.deleted_at IS NULL AND ml.label_id IN (:labelIds) AND ml.deleted_at IS NULL))
+            """, nativeQuery = true)
+    Long countStarredThreads(
+            @Param("userId") String userId,
+            @Param("query") String query,
+            @Param("labelIds") List<String> labelIds,
+            @Param("labelsEmpty") boolean labelsEmpty,
+            @Param("read") Boolean read
+    );
+
+    @Query(value = """
+            SELECT COUNT(*) FROM threads t JOIN mail_accounts ma ON t.mail_account_id = ma.id
+            WHERE ma.user_id = :userId AND ma.is_active = TRUE AND ma.deleted_at IS NULL
+              AND t.deleted_at IS NULL AND t.is_star = TRUE AND t.is_read = FALSE
+              AND (EXISTS (SELECT 1 FROM messages m WHERE m.thread_id = t.id AND m.deleted_at IS NULL AND (m.search_vector @@ websearch_to_tsquery('korean', :query) OR m.search_text LIKE '%' || replace(replace(replace(lower(:query), '!', '!!'), '%', '!%'), '_', '!_') || '%' ESCAPE '!'))
+                   OR EXISTS (SELECT 1 FROM attachments a JOIN messages m ON a.message_id = m.id WHERE m.thread_id = t.id AND m.deleted_at IS NULL AND a.deleted_at IS NULL AND (a.filename_vector @@ websearch_to_tsquery('korean', :query) OR lower(a.filename) LIKE '%' || replace(replace(replace(lower(:query), '!', '!!'), '%', '!%'), '_', '!_') || '%' ESCAPE '!')))
+              AND (:labelsEmpty = TRUE OR EXISTS (SELECT 1 FROM message_labels ml JOIN messages m2 ON ml.message_id = m2.id WHERE m2.thread_id = t.id AND m2.deleted_at IS NULL AND ml.label_id IN (:labelIds) AND ml.deleted_at IS NULL))
+            """, nativeQuery = true)
+    Long countUnreadStarredThreads(
+            @Param("userId") String userId,
+            @Param("query") String query,
+            @Param("labelIds") List<String> labelIds,
+            @Param("labelsEmpty") boolean labelsEmpty
+    );
+
+    // -------------------------------------------------------------------------
     // COUNT queries (inbox / sent / trash)
     // -------------------------------------------------------------------------
 

--- a/db/src/main/java/com/mailsangja/db/port/MailSearchRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/MailSearchRepositoryPort.java
@@ -45,6 +45,12 @@ public interface MailSearchRepositoryPort {
 
     long countUnreadSentThreads(UUID userId, String query, List<UUID> labelIds, Boolean read);
 
+    Slice<Thread> searchStarredThreads(UUID userId, String query, List<UUID> labelIds, Boolean read, UUID markerId, Pageable pageable);
+
+    long countStarredThreads(UUID userId, String query, List<UUID> labelIds, Boolean read);
+
+    long countUnreadStarredThreads(UUID userId, String query, List<UUID> labelIds, Boolean read);
+
     long countTrashMessages(UUID userId, String query, List<UUID> labelIds, Boolean read);
 
     long countUnreadTrashMessages(UUID userId, String query, List<UUID> labelIds, Boolean read);

--- a/db/src/main/java/com/mailsangja/db/port/ThreadRepositoryPort.java
+++ b/db/src/main/java/com/mailsangja/db/port/ThreadRepositoryPort.java
@@ -34,6 +34,9 @@ public interface ThreadRepositoryPort {
 
     Slice<Thread> findInboxByUserIdAndLabelIdsAndDeletedAtIsNull(UUID userId, List<UUID> labelIds, UUID markerId, Pageable pageable);
     Slice<Thread> findStarredByUserIdAndDeletedAtIsNull(UUID userId, UUID markerId, Pageable pageable);
+    Slice<Thread> findStarredByUserIdAndFilters(UUID userId, List<UUID> labelIds, Boolean read, UUID markerId, Pageable pageable);
     long countStarredByUserId(UUID userId);
     long countUnreadStarredByUserId(UUID userId);
+    long countStarredByUserIdAndFilters(UUID userId, List<UUID> labelIds, Boolean read);
+    long countUnreadStarredByUserIdAndFilters(UUID userId, List<UUID> labelIds, Boolean read);
 }


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#31
- mailsangja/docs4capstone#2

### 📌 Task
- Closes #146 
- Closes #7 


## 💡 작업 내용

- 별표 목록 조회 API(`GET /api/v1/threads/starred`)에 라벨·읽음 필터 및 전문 검색 파라미터 추가
- Gmail 계정 삭제 시 Gmail Watch 중지(`stop`) 연동 추가
- `MessageResponse.isStar` 필드명을 `star`로 통일


## 📝 추가 설명

### 1. 별표 목록 필터 및 전문 검색 (Star API 리팩토링)

기존 `GET /api/v1/threads/starred`는 페이지네이션만 지원했으나, Inbox/Sent 조회와 동일한 수준의 필터를 지원하도록 확장했습니다.

추가된 쿼리 파라미터:

| 파라미터 | 타입 | 설명 |
|---|---|---|
| `labelId` | `List<UUID>` (optional) | 라벨 ID 복수 필터 |
| `read` | `Boolean` (optional) | 읽음 여부 필터 (true/false/생략) |
| `q` | `String` (optional) | 전문 검색어 (제목·본문·첨부파일명) |

- `q` 파라미터가 존재하면 `MailSearchQueryService` → `MailSearchRepositoryAdapter` 경로의 하이브리드 FTS(PostgreSQL `search_vector` + LIKE fallback)를 사용합니다.
- `q`가 없으면 `InboxQueryService` → `ThreadRepositoryAdapter` 경로로 JPQL 쿼리를 실행합니다.
- 두 경로 모두 `labelIds`, `read` 필터를 동일하게 적용합니다.

**`StarFacade` 분기 흐름:**
```
q 존재 → searchStarredThreadsResult (FTS)
q 없음 → findStarredThreadsResult (JPQL)
```

### 2. Gmail Watch 중지 연동

메일 계정(`MailAccount`)을 삭제할 때 Gmail 계정인 경우 Google API의 `/users/me/stop` 엔드포인트를 호출해 Push 알림 구독을 정리합니다.

- `GoogleMailWatchQueryService.stop(accessToken)` 메서드를 신규 추가
- `MailAccountFacade.deleteMailAccount()`에서 provider가 `GMAIL`인 경우 삭제 전에 `stopGmailWatch()` 호출
- Watch 중지 실패 시 `WARN` 로그만 남기고 계정 삭제는 계속 진행 (watch 중지 실패가 삭제를 막아서는 안 되므로)
- `application.yaml`에 `stop-uri` 환경변수(`GOOGLE_GMAIL_STOP_URI`) 추가, `GoogleMailProperties`에 `stopUri` 필드 추가

### 3. MessageResponse 필드명 통일

`ThreadSummaryResponse`, `ThreadDetailResponse` 등 다른 DTO는 모두 `boolean star`를 사용하나 `MessageResponse`만 `boolean isStar`를 사용해 JSON 응답 키가 `"isStar"`로 직렬화되는 불일치가 있었습니다.  
`boolean isStar` → `boolean star`로 통일했습니다.


## ⚡️ Test 결과

| 별표 목록 조회 (필터 없음) | 별표 목록 조회 (라벨/읽음 필터) | 별표 목록 조회 (전문 검색) | 메일 계정 삭제 (Gmail) |
| -- | -- | -- | -- |
| GET | GET | GET | DELETE |
| /api/v1/threads/starred | /api/v1/threads/starred?labelId=\{uuid\}&read=false | /api/v1/threads/starred?q=검색어 | /api/v1/mail-accounts/{mailAccountId} |
| MarkerSliceResponse 반환 | 필터 조건 적용된 MarkerSliceResponse 반환 | FTS 결과 MarkerSliceResponse 반환 | Watch 중지 후 계정 삭제 |
