### PR TITLE
[STORY-703] 에러 로깅 개선

### DIFF
--- a/worker/src/main/java/com/mailsangja/worker/service/google/GmailMessageApiService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/google/GmailMessageApiService.java
@@ -165,7 +165,7 @@ public class GmailMessageApiService {
             return validateThreadResponse(response);
         } catch (RestClientException e) {
             String status = e instanceof RestClientResponseException re ? re.getStatusCode().toString() : "N/A";
-            log.warn("Gmail thread fetch failed. threadId={} accountKey={} status={} error={}", threadId, context.accountKey(), status, e.getMessage());
+            log.warn("Gmail thread fetch failed. threadId={} accountKey={} status={} error={}", threadId, context.accountKey(), status, e.getMessage(), e);
             throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_FETCH_FAILED);
         }
     }

--- a/worker/src/main/java/com/mailsangja/worker/service/google/GmailMessageApiService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/google/GmailMessageApiService.java
@@ -20,6 +20,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.util.HtmlUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -109,6 +110,8 @@ public class GmailMessageApiService {
 
             return validateThreadListResponse(response);
         } catch (RestClientException e) {
+            String status = e instanceof RestClientResponseException re ? re.getStatusCode().toString() : "N/A";
+            log.warn("Gmail thread list fetch failed. accountKey={} status={} error={}", context.accountKey(), status, e.getMessage());
             throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_FETCH_FAILED);
         }
     }
@@ -161,6 +164,8 @@ public class GmailMessageApiService {
 
             return validateThreadResponse(response);
         } catch (RestClientException e) {
+            String status = e instanceof RestClientResponseException re ? re.getStatusCode().toString() : "N/A";
+            log.warn("Gmail thread fetch failed. threadId={} accountKey={} status={} error={}", threadId, context.accountKey(), status, e.getMessage());
             throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_FETCH_FAILED);
         }
     }

--- a/worker/src/main/java/com/mailsangja/worker/service/google/GmailMessageApiService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/google/GmailMessageApiService.java
@@ -111,7 +111,7 @@ public class GmailMessageApiService {
             return validateThreadListResponse(response);
         } catch (RestClientException e) {
             String status = e instanceof RestClientResponseException re ? re.getStatusCode().toString() : "N/A";
-            log.warn("Gmail thread list fetch failed. accountKey={} status={} error={}", context.accountKey(), status, e.getMessage());
+            log.warn("Gmail thread list fetch failed. accountKey={} status={} error={}", context.accountKey(), status, e.getMessage(), e);
             throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_FETCH_FAILED);
         }
     }

--- a/worker/src/main/java/com/mailsangja/worker/service/notification/DiscordAlertService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/notification/DiscordAlertService.java
@@ -119,7 +119,7 @@ public class DiscordAlertService {
 
     private String findFirstAppFrame(Throwable cause) {
         Throwable current = cause;
-        while (current != null) {
+        while (current != null && current.getCause() != current) {
             for (StackTraceElement frame : current.getStackTrace()) {
                 if (frame.getClassName().startsWith("com.mailsangja")) {
                     return frame.toString();

--- a/worker/src/main/java/com/mailsangja/worker/service/notification/DiscordAlertService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/notification/DiscordAlertService.java
@@ -112,7 +112,22 @@ public class DiscordAlertService {
             root = root.getCause();
         }
         String message = root.getMessage() != null ? root.getMessage() : "(no message)";
-        return root.getClass().getSimpleName() + ": " + message;
+        String summary = root.getClass().getSimpleName() + ": " + message;
+        String callSite = findFirstAppFrame(cause);
+        return callSite != null ? summary + "\nat " + callSite : summary;
+    }
+
+    private String findFirstAppFrame(Throwable cause) {
+        Throwable current = cause;
+        while (current != null) {
+            for (StackTraceElement frame : current.getStackTrace()) {
+                if (frame.getClassName().startsWith("com.mailsangja")) {
+                    return frame.toString();
+                }
+            }
+            current = current.getCause();
+        }
+        return null;
     }
 
     private String nullSafe(String value) {


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#33

### 📌 Task
- Closes #131 


## 💡 작업 내용


 ### 1. GmailMessageApiService.java : Gmail API 오류 원인 가시화

- 기존 catch (RestClientException e) 두 곳 모두 원본 예외를 삼키고 있었습니다.
- 이제 RestClientResponseException 여부를 판별해 HTTP 상태코드를 함께 로깅합니다.

```
  // 이제 이런 로그가 남습니다
  WARN Gmail thread fetch failed. threadId=18fe... accountKey=user@gmail.com status=401 error=401 Unauthorized: ...
```

- 401이면 토큰 만료, 404면 이미 삭제된 스레드, 429면 할당량 초과임을 즉시 확인할 수 있습니다.


### 2. DiscordAlertService.java : 임베딩 DLQ 알림에 호출 지점 추가

- extractRootCauseMessage가 예외 메시지만 반환하다 보니 `ConnectException: Connection refused` 만 표시되어 어느 서비스(OpenAI API, pgvector 등)인지 알 수 없었습니다.
- 이제 예외 체인 전체를 탐색해 첫 번째 com.mailsangja 프레임을 함께 포함합니다.

```
  // 이제 Discord 알림에 이렇게 표시됩니다
  Root Cause: ConnectException: Connection refused
  at com.mailsangja.worker.service.ai.embedding.MailEmbeddingCommandService.embed(MailEmbeddingCommandService.java:45)
```

- 어느 라인의 어느 서비스 호출에서 연결이 거부됐는지 바로 파악할 수 있습니다.