### PR TITLE
[STORY-401] PortOne 불필요 CustomData 필드 제거

### DIFF
--- a/core/src/main/java/com/mailsangja/core/common/exception/payment/PaymentErrorCode.java
+++ b/core/src/main/java/com/mailsangja/core/common/exception/payment/PaymentErrorCode.java
@@ -16,7 +16,8 @@ public enum PaymentErrorCode implements ErrorCode {
     PAYMENT_PLAN_UNKNOWN(400, "MS-PAYMENT-PLAN-UNKNOWN", "알 수 없는 플랜입니다."),
     PAYMENT_WEBHOOK_INVALID(400, "MS-PAYMENT-WEBHOOK-INVALID", "유효하지 않은 웹훅 요청입니다."),
     PAYMENT_USER_NOT_FOUND(404, "MS-PAYMENT-USER-NOT-FOUND", "결제 대상 사용자를 찾을 수 없습니다."),
-    ORDER_NOT_FOUND(404, "MS-PAYMENT-ORDER-NOT-FOUND", "주문 정보를 찾을 수 없습니다.");
+    ORDER_NOT_FOUND(404, "MS-PAYMENT-ORDER-NOT-FOUND", "주문 정보를 찾을 수 없습니다."),
+    ORDER_FORBIDDEN(403, "MS-PAYMENT-ORDER-FORBIDDEN", "해당 주문에 대한 권한이 없습니다.");
 
     private final int status;
     private final String code;

--- a/core/src/main/java/com/mailsangja/core/dto/payment/PortOnePaymentResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/payment/PortOnePaymentResponse.java
@@ -6,20 +6,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public record PortOnePaymentResponse(
         String id,
         String status,
-        Amount amount,
-        CustomData customData
+        Amount amount
 ) {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record Amount(int total) {
     }
 
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public record CustomData(String planCode) {
-    }
-
     public PortOnePaymentResult toResult() {
-        String planCode = customData != null ? customData.planCode() : null;
         int totalAmount = amount != null ? amount.total() : 0;
-        return new PortOnePaymentResult(id, status, totalAmount, planCode);
+        return new PortOnePaymentResult(id, status, totalAmount);
     }
 }

--- a/core/src/main/java/com/mailsangja/core/dto/payment/PortOnePaymentResult.java
+++ b/core/src/main/java/com/mailsangja/core/dto/payment/PortOnePaymentResult.java
@@ -3,7 +3,6 @@ package com.mailsangja.core.dto.payment;
 public record PortOnePaymentResult(
         String paymentId,
         String status,
-        int amount,
-        String planCode
+        int amount
 ) {
 }

--- a/core/src/main/java/com/mailsangja/core/facade/PaymentFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/PaymentFacade.java
@@ -29,7 +29,7 @@ public class PaymentFacade {
 
     public void completePayment(User user, CompletePaymentRequest request) {
         PortOnePaymentResult result = portOneApiService.fetchPayment(request.paymentId());
-        paymentProcessingService.process(null, result);
+        paymentProcessingService.process(null, result, user.getId());
 
         log.info("Payment completed by client. userId={} paymentId={}", user.getId(), request.paymentId());
     }

--- a/core/src/main/java/com/mailsangja/core/facade/PaymentFacade.java
+++ b/core/src/main/java/com/mailsangja/core/facade/PaymentFacade.java
@@ -1,7 +1,5 @@
 package com.mailsangja.core.facade;
 
-import com.mailsangja.core.common.exception.payment.PaymentErrorCode;
-import com.mailsangja.core.common.exception.payment.PaymentException;
 import com.mailsangja.core.dto.payment.CompletePaymentRequest;
 import com.mailsangja.core.dto.payment.CreateOrderRequest;
 import com.mailsangja.core.dto.payment.CreateOrderResponse;
@@ -10,13 +8,10 @@ import com.mailsangja.core.service.payment.PaymentCommandService;
 import com.mailsangja.core.service.payment.PaymentProcessingService;
 import com.mailsangja.core.service.payment.PortOneApiService;
 import com.mailsangja.db.entity.payment.Order;
-import com.mailsangja.db.entity.user.Plan;
 import com.mailsangja.db.entity.user.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-
-import java.util.Locale;
 
 @Slf4j
 @Component
@@ -34,23 +29,8 @@ public class PaymentFacade {
 
     public void completePayment(User user, CompletePaymentRequest request) {
         PortOnePaymentResult result = portOneApiService.fetchPayment(request.paymentId());
-        Plan plan = resolvePlan(result);
-        paymentProcessingService.process(null, result, plan);
+        paymentProcessingService.process(null, result);
 
-        log.info("Payment completed by client. userId={} paymentId={} plan={}",
-                user.getId(), request.paymentId(), plan);
-    }
-
-    private Plan resolvePlan(PortOnePaymentResult result) {
-        String planCode = result.planCode();
-        if (planCode == null || planCode.isBlank()) {
-            throw new PaymentException(PaymentErrorCode.PAYMENT_PLAN_UNKNOWN,
-                    "planCode is missing in customData. paymentId=" + result.paymentId());
-        }
-        try {
-            return Plan.valueOf(planCode.toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException e) {
-            throw new PaymentException(PaymentErrorCode.PAYMENT_PLAN_UNKNOWN, "Unknown planCode: " + planCode);
-        }
+        log.info("Payment completed by client. userId={} paymentId={}", user.getId(), request.paymentId());
     }
 }

--- a/core/src/main/java/com/mailsangja/core/service/payment/PaymentProcessingService.java
+++ b/core/src/main/java/com/mailsangja/core/service/payment/PaymentProcessingService.java
@@ -5,7 +5,6 @@ import com.mailsangja.core.common.exception.payment.PaymentException;
 import com.mailsangja.core.dto.payment.PortOnePaymentResult;
 import com.mailsangja.db.entity.payment.Order;
 import com.mailsangja.db.entity.payment.OrderStatus;
-import com.mailsangja.db.entity.user.Plan;
 import com.mailsangja.db.entity.user.User;
 import com.mailsangja.db.port.OrderRepositoryPort;
 import com.mailsangja.db.port.UserRepositoryPort;
@@ -25,7 +24,7 @@ public class PaymentProcessingService {
     private final OrderRepositoryPort orderRepositoryPort;
 
     @Transactional
-    public void process(String idempotencyKey, PortOnePaymentResult result, Plan plan) {
+    public void process(String idempotencyKey, PortOnePaymentResult result) {
         UUID orderId = parseOrderId(result.paymentId());
 
         Order order = orderRepositoryPort.findByIdWithLock(orderId)
@@ -46,13 +45,13 @@ public class PaymentProcessingService {
         User user = userRepositoryPort.findByIdWithLock(userId)
                 .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_USER_NOT_FOUND, "userId=" + userId));
 
-        user.updatePlan(plan);
+        user.updatePlan(order.getPlan());
         userRepositoryPort.save(user);
 
         order.complete(idempotencyKey, result.paymentId());
         orderRepositoryPort.save(order);
 
-        log.info("Payment processing completed. orderId={} userId={} plan={}", orderId, userId, plan);
+        log.info("Payment processing completed. orderId={} userId={} plan={}", orderId, userId, order.getPlan());
     }
 
     private UUID parseOrderId(String paymentId) {

--- a/core/src/main/java/com/mailsangja/core/service/payment/PaymentProcessingService.java
+++ b/core/src/main/java/com/mailsangja/core/service/payment/PaymentProcessingService.java
@@ -25,10 +25,25 @@ public class PaymentProcessingService {
 
     @Transactional
     public void process(String idempotencyKey, PortOnePaymentResult result) {
+        processInternal(idempotencyKey, result, null);
+    }
+
+    @Transactional
+    public void process(String idempotencyKey, PortOnePaymentResult result, UUID requiredUserId) {
+        processInternal(idempotencyKey, result, requiredUserId);
+    }
+
+    private void processInternal(String idempotencyKey, PortOnePaymentResult result, UUID requiredUserId) {
         UUID orderId = parseOrderId(result.paymentId());
 
         Order order = orderRepositoryPort.findByIdWithLock(orderId)
                 .orElseThrow(() -> new PaymentException(PaymentErrorCode.ORDER_NOT_FOUND, "orderId=" + orderId));
+
+        if (requiredUserId != null && !requiredUserId.equals(order.getUserId())) {
+            log.warn("Order ownership mismatch. orderId={} requiredUserId={} actualUserId={}",
+                    orderId, requiredUserId, order.getUserId());
+            throw new PaymentException(PaymentErrorCode.ORDER_FORBIDDEN, "orderId=" + orderId);
+        }
 
         if (OrderStatus.COMPLETED.equals(order.getStatus())) {
             log.info("Order already completed, skipping. orderId={}", orderId);

--- a/core/src/test/java/com/mailsangja/core/service/payment/PaymentProcessingServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/payment/PaymentProcessingServiceTest.java
@@ -78,6 +78,28 @@ class PaymentProcessingServiceTest {
     }
 
     @Test
+    void process_requiredUserId가주문소유자와다르면예외를던지고저장하지않는다() {
+        UUID orderId = UUID.randomUUID();
+        UUID orderOwner = UUID.randomUUID();
+        UUID otherUser = UUID.randomUUID();
+        Order order = createOrder(orderId, orderOwner, 9900, OrderStatus.PENDING);
+        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 9900);
+
+        when(orderRepositoryPort.findByIdWithLock(orderId)).thenReturn(Optional.of(order));
+
+        PaymentException exception = assertThrows(
+                PaymentException.class,
+                () -> createService().process(null, result, otherUser)
+        );
+
+        assertSame(PaymentErrorCode.ORDER_FORBIDDEN, exception.getErrorCode());
+        assertEquals(OrderStatus.PENDING, order.getStatus());
+        verify(userRepositoryPort, never()).findByIdWithLock(any(UUID.class));
+        verify(userRepositoryPort, never()).save(any(User.class));
+        verify(orderRepositoryPort, never()).save(any(Order.class));
+    }
+
+    @Test
     void process_결제금액이주문금액과다르면예외를던지고저장하지않는다() {
         UUID orderId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();

--- a/core/src/test/java/com/mailsangja/core/service/payment/PaymentProcessingServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/payment/PaymentProcessingServiceTest.java
@@ -43,12 +43,12 @@ class PaymentProcessingServiceTest {
         String paymentId = orderId.toString();
         Order order = createOrder(orderId, userId, 9900, OrderStatus.PENDING);
         User user = createUser(userId, Plan.FREE);
-        PortOnePaymentResult result = new PortOnePaymentResult(paymentId, "PAID", 9900, "PRO");
+        PortOnePaymentResult result = new PortOnePaymentResult(paymentId, "PAID", 9900);
 
         when(orderRepositoryPort.findByIdWithLock(orderId)).thenReturn(Optional.of(order));
         when(userRepositoryPort.findByIdWithLock(userId)).thenReturn(Optional.of(user));
 
-        createService().process(idempotencyKey, result, Plan.PRO);
+        createService().process(idempotencyKey, result);
 
         assertEquals(Plan.PRO, user.getPlan());
         assertEquals(OrderStatus.COMPLETED, order.getStatus());
@@ -64,11 +64,11 @@ class PaymentProcessingServiceTest {
         UUID userId = UUID.randomUUID();
         Order order = createOrder(orderId, userId, 9900, OrderStatus.COMPLETED);
         order.complete("existing-key", orderId.toString());
-        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 9900, "PRO");
+        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 9900);
 
         when(orderRepositoryPort.findByIdWithLock(orderId)).thenReturn(Optional.of(order));
 
-        createService().process("new-key", result, Plan.PRO);
+        createService().process("new-key", result);
 
         assertEquals("existing-key", order.getWebhookId());
         assertEquals(orderId.toString(), order.getPaymentId());
@@ -82,13 +82,13 @@ class PaymentProcessingServiceTest {
         UUID orderId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         Order order = createOrder(orderId, userId, 9900, OrderStatus.PENDING);
-        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 1000, "PRO");
+        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 1000);
 
         when(orderRepositoryPort.findByIdWithLock(orderId)).thenReturn(Optional.of(order));
 
         PaymentException exception = assertThrows(
                 PaymentException.class,
-                () -> createService().process("idempotency-key-123", result, Plan.PRO)
+                () -> createService().process("idempotency-key-123", result)
         );
 
         assertSame(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH, exception.getErrorCode());
@@ -100,11 +100,11 @@ class PaymentProcessingServiceTest {
 
     @Test
     void process_paymentId가UUID형식이아니면예외를던지고주문을조회하지않는다() {
-        PortOnePaymentResult result = new PortOnePaymentResult("invalid-uuid", "PAID", 9900, "PRO");
+        PortOnePaymentResult result = new PortOnePaymentResult("invalid-uuid", "PAID", 9900);
 
         PaymentException exception = assertThrows(
                 PaymentException.class,
-                () -> createService().process("idempotency-key-123", result, Plan.PRO)
+                () -> createService().process("idempotency-key-123", result)
         );
 
         assertSame(PaymentErrorCode.ORDER_NOT_FOUND, exception.getErrorCode());
@@ -118,14 +118,14 @@ class PaymentProcessingServiceTest {
         UUID orderId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         Order order = createOrder(orderId, userId, 9900, OrderStatus.PENDING);
-        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 9900, "PRO");
+        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 9900);
 
         when(orderRepositoryPort.findByIdWithLock(orderId)).thenReturn(Optional.of(order));
         when(userRepositoryPort.findByIdWithLock(userId)).thenReturn(Optional.empty());
 
         PaymentException exception = assertThrows(
                 PaymentException.class,
-                () -> createService().process("idempotency-key-123", result, Plan.PRO)
+                () -> createService().process("idempotency-key-123", result)
         );
 
         assertSame(PaymentErrorCode.PAYMENT_USER_NOT_FOUND, exception.getErrorCode());

--- a/worker/src/main/java/com/mailsangja/worker/dto/payment/PortOnePaymentResponse.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/payment/PortOnePaymentResponse.java
@@ -6,20 +6,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public record PortOnePaymentResponse(
         String id,
         String status,
-        Amount amount,
-        CustomData customData
+        Amount amount
 ) {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record Amount(int total) {
     }
 
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public record CustomData(String planCode) {
-    }
-
     public PortOnePaymentResult toResult() {
-        String planCode = customData != null ? customData.planCode() : null;
         int totalAmount = amount != null ? amount.total() : 0;
-        return new PortOnePaymentResult(id, status, totalAmount, planCode);
+        return new PortOnePaymentResult(id, status, totalAmount);
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/dto/payment/PortOnePaymentResult.java
+++ b/worker/src/main/java/com/mailsangja/worker/dto/payment/PortOnePaymentResult.java
@@ -3,7 +3,6 @@ package com.mailsangja.worker.dto.payment;
 public record PortOnePaymentResult(
         String paymentId,
         String status,
-        int amount,
-        String planCode
+        int amount
 ) {
 }

--- a/worker/src/main/java/com/mailsangja/worker/facade/PaymentFacade.java
+++ b/worker/src/main/java/com/mailsangja/worker/facade/PaymentFacade.java
@@ -1,8 +1,5 @@
 package com.mailsangja.worker.facade;
 
-import com.mailsangja.db.entity.user.Plan;
-import com.mailsangja.worker.common.exception.payment.PaymentErrorCode;
-import com.mailsangja.worker.common.exception.payment.PaymentException;
 import com.mailsangja.worker.dto.payment.PortOnePaymentResult;
 import com.mailsangja.worker.dto.payment.PortOneWebhookRequest;
 import com.mailsangja.worker.service.payment.PaymentProcessingService;
@@ -10,8 +7,6 @@ import com.mailsangja.worker.service.payment.PortOneApiService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-
-import java.util.Locale;
 
 @Slf4j
 @Component
@@ -35,23 +30,9 @@ public class PaymentFacade {
         }
 
         PortOnePaymentResult result = portOneApiService.fetchPayment(request.data().paymentId());
-        Plan plan = resolvePlan(result);
-        paymentProcessingService.process(request.webhookId(), result, plan);
+        paymentProcessingService.process(request.webhookId(), result);
 
-        log.info("Webhook handled. webhookId={} paymentId={} plan={}",
-                request.webhookId(), request.data().paymentId(), plan);
-    }
-
-    private Plan resolvePlan(PortOnePaymentResult result) {
-        String planCode = result.planCode();
-        if (planCode == null || planCode.isBlank()) {
-            throw new PaymentException(PaymentErrorCode.PAYMENT_PLAN_UNKNOWN,
-                    "planCode is missing in customData. paymentId=" + result.paymentId());
-        }
-        try {
-            return Plan.valueOf(planCode.toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException e) {
-            throw new PaymentException(PaymentErrorCode.PAYMENT_PLAN_UNKNOWN, "Unknown planCode: " + planCode);
-        }
+        log.info("Webhook handled. webhookId={} paymentId={}",
+                request.webhookId(), request.data().paymentId());
     }
 }

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/GoogleAccessTokenEnsureService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/GoogleAccessTokenEnsureService.java
@@ -5,10 +5,12 @@ import com.mailsangja.db.entity.mail.MailProvider;
 import com.mailsangja.worker.common.exception.mail.MailPushErrorCode;
 import com.mailsangja.worker.common.exception.mail.MailPushException;
 import com.mailsangja.worker.service.google.GoogleOAuthApiService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 
+@Slf4j
 @Service
 public class GoogleAccessTokenEnsureService {
 
@@ -40,10 +42,24 @@ public class GoogleAccessTokenEnsureService {
             throw new MailPushException(MailPushErrorCode.GOOGLE_REFRESH_TOKEN_MISSING);
         }
 
-        return mailAccountCommandService.refreshGoogleAccessToken(
-                mailAccount.getId(),
-                googleOAuthApiService.refreshAccessToken(mailAccount.getRefreshToken())
-        );
+        try {
+            return mailAccountCommandService.refreshGoogleAccessToken(
+                    mailAccount.getId(),
+                    googleOAuthApiService.refreshAccessToken(mailAccount.getRefreshToken())
+            );
+        } catch (MailPushException e) {
+            log.warn(
+                    "Google access token refresh failed. mailAccountId={} userId={} provider={} emailAddress={} accessTokenExpiresAt={} hasRefreshToken={} errorCode={}",
+                    mailAccount.getId(),
+                    mailAccount.getUser().getId(),
+                    mailAccount.getProvider(),
+                    mailAccount.getEmailAddress(),
+                    mailAccount.getAccessTokenExpiresAt(),
+                    !isBlank(mailAccount.getRefreshToken()),
+                    e.getErrorCode().getCode()
+            );
+            throw e;
+        }
     }
 
     private boolean needsRefresh(MailAccount mailAccount) {

--- a/worker/src/main/java/com/mailsangja/worker/service/payment/PaymentProcessingService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/payment/PaymentProcessingService.java
@@ -2,7 +2,6 @@ package com.mailsangja.worker.service.payment;
 
 import com.mailsangja.db.entity.payment.Order;
 import com.mailsangja.db.entity.payment.OrderStatus;
-import com.mailsangja.db.entity.user.Plan;
 import com.mailsangja.db.entity.user.User;
 import com.mailsangja.db.port.OrderRepositoryPort;
 import com.mailsangja.db.port.UserRepositoryPort;
@@ -29,7 +28,7 @@ public class PaymentProcessingService {
     }
 
     @Transactional
-    public void process(String webhookId, PortOnePaymentResult result, Plan plan) {
+    public void process(String webhookId, PortOnePaymentResult result) {
         UUID orderId = parseOrderId(result.paymentId());
 
         Order order = orderRepositoryPort.findByIdWithLock(orderId)
@@ -47,14 +46,14 @@ public class PaymentProcessingService {
         User user = userRepositoryPort.findByIdWithLock(userId)
                 .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_USER_NOT_FOUND, "userId=" + userId));
 
-        user.updatePlan(plan);
+        user.updatePlan(order.getPlan());
         userRepositoryPort.save(user);
 
         order.complete(webhookId, result.paymentId());
         orderRepositoryPort.save(order);
 
         log.info("Payment processing completed. webhookId={} orderId={} userId={} plan={}",
-                webhookId, orderId, userId, plan);
+                webhookId, orderId, userId, order.getPlan());
     }
 
     private void validatePaymentAmount(PortOnePaymentResult result, Order order) {

--- a/worker/src/test/java/com/mailsangja/worker/facade/PaymentFacadeTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/facade/PaymentFacadeTest.java
@@ -1,6 +1,5 @@
 package com.mailsangja.worker.facade;
 
-import com.mailsangja.db.entity.user.Plan;
 import com.mailsangja.worker.common.exception.payment.PaymentErrorCode;
 import com.mailsangja.worker.common.exception.payment.PaymentException;
 import com.mailsangja.worker.dto.payment.PortOnePaymentResult;
@@ -43,7 +42,7 @@ class PaymentFacadeTest {
         // then
         verify(paymentProcessingService, never()).isWebhookAlreadyProcessed(request.webhookId());
         verify(portOneApiService, never()).fetchPayment(request.data().paymentId());
-        verify(paymentProcessingService, never()).process(eq(request.webhookId()), any(PortOnePaymentResult.class), any(Plan.class));
+        verify(paymentProcessingService, never()).process(eq(request.webhookId()), any(PortOnePaymentResult.class));
     }
 
     @Test
@@ -59,15 +58,15 @@ class PaymentFacadeTest {
         // then
         verify(paymentProcessingService).isWebhookAlreadyProcessed(request.webhookId());
         verify(portOneApiService, never()).fetchPayment(request.data().paymentId());
-        verify(paymentProcessingService, never()).process(eq(request.webhookId()), any(PortOnePaymentResult.class), any(Plan.class));
+        verify(paymentProcessingService, never()).process(eq(request.webhookId()), any(PortOnePaymentResult.class));
     }
 
     @Test
-    void handleWebhook_정상결제웹훅이면결제정보조회후플랜을해석해처리한다() {
+    void handleWebhook_정상결제웹훅이면결제정보조회후처리한다() {
         // given
         UUID orderId = UUID.randomUUID();
         PortOneWebhookRequest request = createRequest("webhook-123", "Transaction.Paid", "payment-123");
-        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 9900, "pro");
+        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 9900);
 
         when(paymentProcessingService.isWebhookAlreadyProcessed(request.webhookId())).thenReturn(false);
         when(portOneApiService.fetchPayment(request.data().paymentId())).thenReturn(result);
@@ -79,47 +78,7 @@ class PaymentFacadeTest {
 
         // then
         verify(portOneApiService).fetchPayment(request.data().paymentId());
-        verify(paymentProcessingService).process(request.webhookId(), result, Plan.PRO);
-    }
-
-    @Test
-    void handleWebhook_planCode가비어있으면예외를던지고처리하지않는다() {
-        // given
-        UUID orderId = UUID.randomUUID();
-        PortOneWebhookRequest request = createRequest("webhook-123", "Transaction.Paid", "payment-123");
-        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 9900, " ");
-
-        when(paymentProcessingService.isWebhookAlreadyProcessed(request.webhookId())).thenReturn(false);
-        when(portOneApiService.fetchPayment(request.data().paymentId())).thenReturn(result);
-
-        PaymentFacade facade = createFacade();
-
-        // when
-        PaymentException exception = assertThrows(PaymentException.class, () -> facade.handleWebhook(request));
-
-        // then
-        assertSame(PaymentErrorCode.PAYMENT_PLAN_UNKNOWN, exception.getErrorCode());
-        verify(paymentProcessingService, never()).process(request.webhookId(), result, Plan.PRO);
-    }
-
-    @Test
-    void handleWebhook_알수없는planCode면예외를던지고처리하지않는다() {
-        // given
-        UUID orderId = UUID.randomUUID();
-        PortOneWebhookRequest request = createRequest("webhook-123", "Transaction.Paid", "payment-123");
-        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 9900, "ENTERPRISE");
-
-        when(paymentProcessingService.isWebhookAlreadyProcessed(request.webhookId())).thenReturn(false);
-        when(portOneApiService.fetchPayment(request.data().paymentId())).thenReturn(result);
-
-        PaymentFacade facade = createFacade();
-
-        // when
-        PaymentException exception = assertThrows(PaymentException.class, () -> facade.handleWebhook(request));
-
-        // then
-        assertSame(PaymentErrorCode.PAYMENT_PLAN_UNKNOWN, exception.getErrorCode());
-        verify(paymentProcessingService, never()).process(request.webhookId(), result, Plan.PRO);
+        verify(paymentProcessingService).process(request.webhookId(), result);
     }
 
     @Test

--- a/worker/src/test/java/com/mailsangja/worker/service/payment/PaymentProcessingServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/payment/PaymentProcessingServiceTest.java
@@ -45,7 +45,7 @@ class PaymentProcessingServiceTest {
         String paymentId = orderId.toString();
         Order order = createOrder(orderId, userId, 9900, OrderStatus.PENDING);
         User user = createUser(userId, Plan.FREE);
-        PortOnePaymentResult result = new PortOnePaymentResult(paymentId, "PAID", 9900, "PRO");
+        PortOnePaymentResult result = new PortOnePaymentResult(paymentId, "PAID", 9900);
 
         when(orderRepositoryPort.findByIdWithLock(orderId)).thenReturn(Optional.of(order));
         when(userRepositoryPort.findByIdWithLock(userId)).thenReturn(Optional.of(user));
@@ -53,7 +53,7 @@ class PaymentProcessingServiceTest {
         PaymentProcessingService service = createService();
 
         // when
-        service.process(webhookId, result, Plan.PRO);
+        service.process(webhookId, result);
 
         // then
         assertEquals(Plan.PRO, user.getPlan());
@@ -71,14 +71,14 @@ class PaymentProcessingServiceTest {
         UUID userId = UUID.randomUUID();
         Order order = createOrder(orderId, userId, 9900, OrderStatus.COMPLETED);
         order.complete("existing-webhook", orderId.toString());
-        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 9900, "PRO");
+        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 9900);
 
         when(orderRepositoryPort.findByIdWithLock(orderId)).thenReturn(Optional.of(order));
 
         PaymentProcessingService service = createService();
 
         // when
-        service.process("new-webhook", result, Plan.PRO);
+        service.process("new-webhook", result);
 
         // then
         assertEquals("existing-webhook", order.getWebhookId());
@@ -94,7 +94,7 @@ class PaymentProcessingServiceTest {
         UUID orderId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         Order order = createOrder(orderId, userId, 9900, OrderStatus.PENDING);
-        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 1000, "PRO");
+        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 1000);
 
         when(orderRepositoryPort.findByIdWithLock(orderId)).thenReturn(Optional.of(order));
 
@@ -103,7 +103,7 @@ class PaymentProcessingServiceTest {
         // when
         PaymentException exception = assertThrows(
                 PaymentException.class,
-                () -> service.process("webhook-123", result, Plan.PRO)
+                () -> service.process("webhook-123", result)
         );
 
         // then
@@ -118,13 +118,13 @@ class PaymentProcessingServiceTest {
     @Test
     void process_paymentId가UUID형식이아니면예외를던지고주문을조회하지않는다() {
         // given
-        PortOnePaymentResult result = new PortOnePaymentResult("invalid-uuid", "PAID", 9900, "PRO");
+        PortOnePaymentResult result = new PortOnePaymentResult("invalid-uuid", "PAID", 9900);
         PaymentProcessingService service = createService();
 
         // when
         PaymentException exception = assertThrows(
                 PaymentException.class,
-                () -> service.process("webhook-123", result, Plan.PRO)
+                () -> service.process("webhook-123", result)
         );
 
         // then
@@ -140,7 +140,7 @@ class PaymentProcessingServiceTest {
         UUID orderId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         Order order = createOrder(orderId, userId, 9900, OrderStatus.PENDING);
-        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 9900, "PRO");
+        PortOnePaymentResult result = new PortOnePaymentResult(orderId.toString(), "PAID", 9900);
 
         when(orderRepositoryPort.findByIdWithLock(orderId)).thenReturn(Optional.of(order));
         when(userRepositoryPort.findByIdWithLock(userId)).thenReturn(Optional.empty());
@@ -150,7 +150,7 @@ class PaymentProcessingServiceTest {
         // when
         PaymentException exception = assertThrows(
                 PaymentException.class,
-                () -> service.process("webhook-123", result, Plan.PRO)
+                () -> service.process("webhook-123", result)
         );
 
         // then


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#20

### 📌 Task
- Closes #82


## 💡 작업 내용


> 문제 원인: PortOne API가 customData를 JSON 객체가 아닌 JSON 문자열('{"planCode":"PRO"}')로 반환하는데, Jackson이 이걸 객체로 역직렬화하려다 실패했습니다.

### customData에 의존하는 로직 제거
  - Pre-Order 생성 시 이미 plan=PRO를 DB의 Order에 저장하고 있음
  - PaymentProcessingService가 어차피 Order를 DB에서 조회하므로 order.getPlan()으로 플랜을 읽는 방식으로 수정

## 📝 추가 설명

- core/PortOnePaymentResponse — customData 필드 제거
- core/PortOnePaymentRespult ——planCode 필드 제거
- worker/PortOnePaymentResponse — customData 필드 제거
- worker/PortOnePaymentRespult ——planCode 필드 제거
- core/PaymentProcessingService — Plan plan 파라미터 제거, order.getPlan() 사용
- worker/PaymentProcessingService — 동일
- core/PaymentFacade — resolvePlan() 제거
- worker/PaymentFacade — resolvePlan() 제거
- 테스트 3개 수정