### PR TITLE
[STORY-804] JaCoCo 테스트 커버리지 측정 및 Codecov 연동 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,10 @@ jobs:
           gradle-version: "9.4.1"
 
       - name: Run tests
-        run: gradle clean :core:test :worker:test --no-daemon
+        run: gradle :core:clean :worker:clean :core:test :worker:test --no-daemon
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@b5f6c0e474ea37f31a25da3857e97926b8c43336 # v5.1.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: core/build/reports/jacoco/test/jacocoTestReport.xml,worker/build/reports/jacoco/test/jacocoTestReport.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run: gradle :core:clean :worker:clean :core:test :worker:test --no-daemon
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@b5f6c0e474ea37f31a25da3857e97926b8c43336 # v5.1.2
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: core/build/reports/jacoco/test/jacocoTestReport.xml,worker/build/reports/jacoco/test/jacocoTestReport.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-    defaults:
-      run:
-        working-directory: core
-
     env:
       DB_HOST: 127.0.0.1
       DB_PORT: 5432
@@ -62,4 +58,11 @@ jobs:
           gradle-version: "9.4.1"
 
       - name: Run tests
-        run: gradle clean test -x :db:test --no-daemon
+        run: gradle clean :core:test :worker:test --no-daemon
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: core/build/reports/jacoco/test/jacocoTestReport.xml,worker/build/reports/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: false

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
     id 'org.springframework.boot' version '4.0.5'
     id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -56,4 +57,26 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+    classDirectories.setFrom(
+        files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                '**/*Application*',
+                '**/config/**',
+                '**/controller/**',
+                '**/dto/**',
+                '**/common/exception/**',
+                '**/common/observability/**',
+                '**/scheduler/**',
+            ])
+        })
+    )
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -68,14 +68,9 @@ jacocoTestReport {
     }
     classDirectories.setFrom(
         files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: [
-                '**/*Application*',
-                '**/config/**',
-                '**/controller/**',
-                '**/dto/**',
-                '**/common/exception/**',
-                '**/common/observability/**',
-                '**/scheduler/**',
+            fileTree(dir: it, include: [
+                '**/facade/**',
+                '**/service/**',
             ])
         })
     )

--- a/worker/build.gradle
+++ b/worker/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
     id 'org.springframework.boot' version '4.0.5'
     id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -56,4 +57,27 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+    classDirectories.setFrom(
+        files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                '**/*Application*',
+                '**/config/**',
+                '**/controller/**',
+                '**/dto/**',
+                '**/common/exception/**',
+                '**/common/observability/**',
+                '**/scheduler/**',
+                '**/messaging/**',
+            ])
+        })
+    )
 }

--- a/worker/build.gradle
+++ b/worker/build.gradle
@@ -68,15 +68,10 @@ jacocoTestReport {
     }
     classDirectories.setFrom(
         files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: [
-                '**/*Application*',
-                '**/config/**',
-                '**/controller/**',
-                '**/dto/**',
-                '**/common/exception/**',
-                '**/common/observability/**',
-                '**/scheduler/**',
-                '**/messaging/**',
+            fileTree(dir: it, include: [
+                '**/facade/**',
+                '**/service/**',
+                '**/handler/**',
             ])
         })
     )

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/GmailNewMessageApplyCommandServiceTest.java
@@ -19,9 +19,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -95,7 +97,16 @@ class GmailNewMessageApplyCommandServiceTest {
                 .thenReturn(Optional.of(oldMessage));
         when(messageRepositoryPort.findByThreadIdAndGmailMessageId(deletedThread.getId(), "message-new"))
                 .thenReturn(Optional.empty());
-        when(messageRepositoryPort.save(any(Message.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        AtomicReference<Message> savedNewMessage = new AtomicReference<>();
+        when(messageRepositoryPort.save(any(Message.class))).thenAnswer(invocation -> {
+            Message m = invocation.getArgument(0);
+            savedNewMessage.set(m);
+            return m;
+        });
+        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccount.getId(), "thread-1"))
+                .thenAnswer(invocation -> savedNewMessage.get() != null ? List.of(savedNewMessage.get()) : List.of());
+        when(threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccount.getId(), "thread-1"))
+                .thenReturn(List.of(deletedThread));
 
         GmailHistoryEvent event = new GmailHistoryEvent(
                 GmailHistoryEventType.MESSAGE_ADDED,
@@ -115,7 +126,7 @@ class GmailNewMessageApplyCommandServiceTest {
         assertFalse(deletedThread.isDeleted());
         assertTrue(oldMessage.isDeleted());
         assertEquals("message-new", messageCaptor.getValue().getGmailMessageId());
-        assertEquals(2, deletedThread.getMessageCount());
+        assertEquals(1, deletedThread.getMessageCount());
         assertEquals("new subject", deletedThread.getLatestSubject());
         assertEquals("new snippet", deletedThread.getLatestSnippet());
         assertEquals(LocalDateTime.of(2026, 4, 14, 10, 0), deletedThread.getLastMessageAt());
@@ -150,7 +161,20 @@ class GmailNewMessageApplyCommandServiceTest {
                 .thenReturn(Optional.of(existingMessage));
         when(messageRepositoryPort.findByThreadIdAndGmailMessageId(activeThread.getId(), "message-new"))
                 .thenReturn(Optional.empty());
-        when(messageRepositoryPort.save(any(Message.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        AtomicReference<Message> savedNewMessage = new AtomicReference<>();
+        when(messageRepositoryPort.save(any(Message.class))).thenAnswer(invocation -> {
+            Message m = invocation.getArgument(0);
+            savedNewMessage.set(m);
+            return m;
+        });
+        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccount.getId(), "thread-2"))
+                .thenAnswer(invocation -> {
+                    List<Message> msgs = new ArrayList<>(List.of(existingMessage));
+                    if (savedNewMessage.get() != null) msgs.add(savedNewMessage.get());
+                    return msgs;
+                });
+        when(threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccount.getId(), "thread-2"))
+                .thenReturn(List.of(activeThread));
 
         GmailHistoryEvent event = new GmailHistoryEvent(
                 GmailHistoryEventType.MESSAGE_ADDED,

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
@@ -64,6 +64,10 @@ class InitialMailSyncCommandServiceTest {
             storedMessage.set(message);
             return message;
         });
+        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccount.getId(), "thread-1"))
+                .thenAnswer(invocation -> storedMessage.get() != null ? List.of(storedMessage.get()) : List.of());
+        when(threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccount.getId(), "thread-1"))
+                .thenReturn(List.of(thread));
 
         service.saveThreadBatch(mailAccount, java.util.List.of(new InitialMailSyncThreadSaveCommand(
                 "thread-1",
@@ -132,6 +136,7 @@ class InitialMailSyncCommandServiceTest {
         MailAccount mailAccount = createMailAccount();
         Thread thread = createThread(mailAccount, "thread-1", Direction.INBOUND);
         AtomicReference<Message> firstMessage = new AtomicReference<>();
+        List<Message> activeMessages = new ArrayList<>();
 
         when(threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
                 mailAccount.getId(), "thread-1", Direction.INBOUND
@@ -145,8 +150,13 @@ class InitialMailSyncCommandServiceTest {
             if ("message-1".equals(message.getGmailMessageId())) {
                 firstMessage.set(message);
             }
+            activeMessages.add(message);
             return message;
         });
+        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccount.getId(), "thread-1"))
+                .thenAnswer(invocation -> List.copyOf(activeMessages));
+        when(threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccount.getId(), "thread-1"))
+                .thenReturn(List.of(thread));
 
         service.saveThreadBatch(mailAccount, java.util.List.of(new InitialMailSyncThreadSaveCommand(
                 "thread-1",

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionQueryServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/ReplyDraftSuggestionQueryServiceTest.java
@@ -287,8 +287,8 @@ class ReplyDraftSuggestionQueryServiceTest {
                 LocalDateTime.now()
         );
         ReplyDraftSuggestionQueryService service = createService();
-        when(messageRepositoryPort.findByIdIncludingDeleted(latestMessageId)).thenReturn(Optional.of(latestMessage));
-        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccountId, "gmail-thread-1"))
+        when(messageRepositoryPort.findByIdIncludingDeletedAndSensitiveLabelsExcluded(latestMessageId)).thenReturn(Optional.of(latestMessage));
+        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNullAndSensitiveLabelsExcluded(mailAccountId, "gmail-thread-1"))
                 .thenReturn(List.of(latestMessage));
         when(referenceQueryPort.findWrittenMessagesByHints(any(), any(), any(), any(Integer.class))).thenReturn(List.of());
         when(referenceQueryPort.findRecentWrittenMessages(userId, mailAccountId, 4)).thenReturn(List.of());


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story
- mailsangja/docs4capstone#38

### 📌 Task
- Closes #160 

## 💡 작업 내용

- `core`, `worker` 모듈에 JaCoCo 플러그인 추가 및 `jacocoTestReport` 설정 (XML/HTML 리포트, 측정 대상 제한)
- `.github/workflows/ci.yml` 수정 — `working-directory: core` 제거, `:core:test :worker:test` 명시 실행, Codecov 업로드 스텝 추가
\
## 📝 추가 설명

### 1. 커버리지 측정 대상 범위
- 측정: `facade`, `service`, `handler` (비즈니스 로직 계층)
- 제외: `config`, `controller`, `dto`, `exception`, `observability`, `scheduler`, `messaging` (worker)

### 2. 리포트 생성 위치
- HTML: `{module}/build/reports/jacoco/test/html/index.html` (로컬 확인용)
- XML: `{module}/build/reports/jacoco/test/jacocoTestReport.xml` (Codecov 업로드용)

### 3. 사전 준비 필요
- codecov.io에서 레포 연결 후 발급받은 토큰을 GitHub Secrets에 `CODECOV_TOKEN`으로 등록 필요
- 등록 완료 시 PR마다 Codecov 봇이 커버리지 변화를 코멘트로 표시

---

## ⚡️ Test 결과

| CI 파이프라인 | core 커버리지 리포트 | worker 커버리지 리포트 | Codecov 코멘트 |
| -- | -- | -- | -- |
| GitHub Actions | JaCoCo HTML | JaCoCo HTML | PR 자동 코멘트 |
| `gradle :core:test :worker:test` 성공 | `html/index.html` 생성 확인 | `html/index.html` 생성 확인 | 커버리지 변화 표시 확인 |
