### PR TITLE
[STORY-401] 라벨 목록 조회 API 응답 알림 설정 필드 추가

### DIFF
--- a/core/src/main/java/com/mailsangja/core/controller/docs/LabelControllerDocs.java
+++ b/core/src/main/java/com/mailsangja/core/controller/docs/LabelControllerDocs.java
@@ -28,7 +28,7 @@ public interface LabelControllerDocs {
 
     @Operation(
             summary = "라벨 목록 조회",
-            description = "로그인한 사용자의 활성 라벨 목록을 displayOrder ASC 정렬로 반환합니다. 라벨별 읽지 않은 스레드 수와 민감 라벨 여부를 포함합니다.",
+            description = "로그인한 사용자의 활성 라벨 목록을 displayOrder ASC 정렬로 반환합니다. 라벨별 알림 정책, 읽지 않은 스레드 수와 민감 라벨 여부를 포함합니다.",
             security = @SecurityRequirement(name = "cookieAuth")
     )
     @ApiResponses({

--- a/core/src/main/java/com/mailsangja/core/dto/label/LabelListResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/label/LabelListResponse.java
@@ -1,5 +1,6 @@
 package com.mailsangja.core.dto.label;
 
+import com.mailsangja.db.common.label.NotificationPolicy;
 import com.mailsangja.db.entity.label.Label;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -19,6 +20,9 @@ public record LabelListResponse(
         @Schema(description = "표시 순서", example = "0")
         int order,
 
+        @Schema(description = "알림 정책 (URGENT/INHERIT/SILENT)", example = "INHERIT")
+        NotificationPolicy notificationPolicy,
+
         @Schema(description = "AI 기능에서 제외할 민감 라벨 여부", example = "false")
         boolean isSensitive,
 
@@ -32,6 +36,7 @@ public record LabelListResponse(
                 label.getName(),
                 label.getColorCode(),
                 label.getDisplayOrder(),
+                label.getNotificationPolicy(),
                 label.isSensitive(),
                 unreadThreadCount
         );

--- a/core/src/test/java/com/mailsangja/core/facade/LabelFacadeTest.java
+++ b/core/src/test/java/com/mailsangja/core/facade/LabelFacadeTest.java
@@ -68,8 +68,8 @@ class LabelFacadeTest {
     @Test
     void 라벨목록조회_미읽은스레드수매핑및누락시_0반환() {
         User user = user();
-        Label first = label("업무", 1);
-        Label second = label("개인", 2);
+        Label first = label("업무", 1, null, NotificationPolicy.URGENT);
+        Label second = label("개인", 2, null, NotificationPolicy.SILENT);
         when(labelQueryService.findAllActiveByUserId(user.getId())).thenReturn(List.of(first, second));
         when(labelQueryService.findUnreadThreadCountsByUserId(user.getId())).thenReturn(Map.of(first.getId(), 7L));
 
@@ -77,9 +77,11 @@ class LabelFacadeTest {
 
         assertEquals(2, responses.size());
         assertEquals(first.getId(), responses.get(0).id());
+        assertEquals(NotificationPolicy.URGENT, responses.get(0).notificationPolicy());
         assertEquals(first.isSensitive(), responses.get(0).isSensitive());
         assertEquals(7L, responses.get(0).unreadThreadCount());
         assertEquals(second.getId(), responses.get(1).id());
+        assertEquals(NotificationPolicy.SILENT, responses.get(1).notificationPolicy());
         assertEquals(second.isSensitive(), responses.get(1).isSensitive());
         assertEquals(0L, responses.get(1).unreadThreadCount());
     }
@@ -307,11 +309,15 @@ class LabelFacadeTest {
     }
 
     private Label label(String name, int order, LabelRule rule) {
+        return label(name, order, rule, NotificationPolicy.INHERIT);
+    }
+
+    private Label label(String name, int order, LabelRule rule, NotificationPolicy notificationPolicy) {
         return Label.builder()
                 .id(UUID.randomUUID())
                 .name(name)
                 .colorCode("#3366FF")
-                .notificationPolicy(NotificationPolicy.INHERIT)
+                .notificationPolicy(notificationPolicy)
                 .displayOrder(order)
                 .rule(rule)
                 .build();


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#16

### 📌 Task

- Closes #165

## 💡 작업 내용

- 라벨 목록 조회 응답에 `notificationPolicy` 필드를 추가했습니다.
- 라벨 목록 Swagger 문서 설명에 알림 정책 반환 정보를 반영했습니다.
- 라벨 목록 응답 매핑 테스트에서 알림 정책이 함께 반환되는지 검증하도록 보강했습니다.

## 📝 추가 설명

### 1. 라벨 목록 응답 필드 확장
- `LabelListResponse`에 `NotificationPolicy notificationPolicy`를 추가했습니다.
- `LabelListResponse.of(...)`에서 `Label#getNotificationPolicy()`를 매핑합니다.
- 기존 `rule` 필드는 상세 조회 전용으로 유지하고, 목록에서는 라벨 행/카드 렌더링에 필요한 알림 정책만 노출합니다.

### 2. 라벨 제안 목록 영향
- `LabelListResponse`는 라벨 목록뿐 아니라 라벨 제안 생성/목록 응답에도 사용됩니다.
- AI 라벨 제안도 `notificationPolicy`를 생성하고 저장하므로, 제안 목록에서도 동일하게 알림 정책이 반환됩니다.
  - `GET /api/v1/labels`
  - `POST /api/v1/labels/suggestions`
  - `GET /api/v1/labels/suggestions`

## ⚡️ Test 결과

| 검증 항목 | 대상 | 결과 | 비고 |
| -- | -- | -- | -- |
| 단위 테스트 | `./gradlew :test --tests "com.mailsangja.core.facade.LabelFacadeTest" --rerun-tasks` | 통과 | `BUILD SUCCESSFUL in 5s` |