### PR TITLE
[STORY-201] 메일 스레드 데이터 누락 가능 무결성 문제 수정

### DIFF
--- a/core/src/main/java/com/mailsangja/core/dto/inbox/MailAddressResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/MailAddressResponse.java
@@ -11,6 +11,10 @@ public record MailAddressResponse(
         @Schema(description = "이메일 주소", example = "hramst0618@gmail.com")
         String email
 ) {
+    public MailAddressResponse {
+        email = email == null ? "" : email;
+    }
+
     public static MailAddressResponse of(String email, Map<String, String> contactNameByEmail) {
         return new MailAddressResponse(contactNameByEmail.get(email), email);
     }

--- a/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponse.java
+++ b/core/src/main/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponse.java
@@ -37,6 +37,11 @@ public record ThreadSummaryResponse(
         @Schema(description = "스레드에 적용된 라벨 목록")
         List<LabelSummary> labels
 ) {
+    public ThreadSummaryResponse {
+        latestSubject = latestSubject == null ? "" : latestSubject;
+        snippet = snippet == null ? "" : snippet;
+    }
+
     public record LabelSummary(
             @Schema(description = "라벨 ID") UUID labelId,
             @Schema(description = "라벨 이름") String name,

--- a/core/src/main/java/com/mailsangja/core/service/google/GoogleMailMessageQueryService.java
+++ b/core/src/main/java/com/mailsangja/core/service/google/GoogleMailMessageQueryService.java
@@ -191,7 +191,7 @@ public class GoogleMailMessageQueryService {
 
     private LocalDateTime resolveSentAt(String internalDate) {
         if (isBlank(internalDate)) {
-            return null;
+            throw new MailSendException(MailSendErrorCode.GOOGLE_MAIL_MESSAGE_RESULT_INVALID);
         }
 
         try {

--- a/core/src/test/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponseTest.java
+++ b/core/src/test/java/com/mailsangja/core/dto/inbox/ThreadSummaryResponseTest.java
@@ -1,0 +1,33 @@
+package com.mailsangja.core.dto.inbox;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ThreadSummaryResponseTest {
+
+    @Test
+    void nullableSummaryStringsAreNormalizedToEmptyStrings() {
+        ThreadSummaryResponse response = new ThreadSummaryResponse(
+                UUID.randomUUID(),
+                "gmail-thread-id",
+                UUID.randomUUID(),
+                null,
+                new MailAddressResponse(null, null),
+                null,
+                false,
+                false,
+                null,
+                List.of(),
+                0,
+                List.of()
+        );
+
+        assertEquals("", response.latestSubject());
+        assertEquals("", response.snippet());
+        assertEquals("", response.participant().email());
+    }
+}

--- a/core/src/test/java/com/mailsangja/core/service/google/GoogleMailMessageQueryServiceTest.java
+++ b/core/src/test/java/com/mailsangja/core/service/google/GoogleMailMessageQueryServiceTest.java
@@ -1,5 +1,6 @@
 package com.mailsangja.core.service.google;
 
+import com.mailsangja.core.common.exception.mail.MailSendException;
 import com.mailsangja.core.config.properties.GoogleMailProperties;
 import com.mailsangja.core.dto.mail.GoogleMailMessageResult;
 import com.mailsangja.db.entity.mail.AttachmentDisposition;
@@ -18,8 +19,32 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class GoogleMailMessageQueryServiceTest {
+
+    @Test
+    void getMessage_internalDate가없으면유효하지않은응답예외가발생한다() {
+        GoogleMailProperties properties = new GoogleMailProperties();
+        properties.setMessagesUri("https://gmail.googleapis.com/gmail/v1/users/me/messages");
+
+        RestClient restClient = RestClient.builder()
+                .requestFactory(new StubClientHttpRequestFactory("""
+                        {
+                          "id": "message-1",
+                          "threadId": "thread-1",
+                          "payload": {
+                            "headers": [
+                              {"name": "From", "value": "Alice <alice@example.com>"}
+                            ]
+                          }
+                        }
+                        """))
+                .build();
+        GoogleMailMessageQueryService service = new GoogleMailMessageQueryService(properties, restClient);
+
+        assertThrows(MailSendException.class, () -> service.getMessage("token", "message-1"));
+    }
 
     @Test
     void getMessage_본문이미지첨부의contentId와disposition을보존한다() {

--- a/worker/src/main/java/com/mailsangja/worker/service/google/GmailMessageApiService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/google/GmailMessageApiService.java
@@ -342,7 +342,7 @@ public class GmailMessageApiService {
 
     private LocalDateTime resolveSentAt(GoogleMailThreadResponse.GoogleMailThreadMessageResponse messageResponse) {
         if (isBlank(messageResponse.internalDate())) {
-            return null;
+            throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
         }
 
         try {

--- a/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
+++ b/worker/src/main/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandService.java
@@ -59,7 +59,7 @@ public class InitialMailSyncCommandService {
                 .collect(Collectors.groupingBy(InitialMailSyncMessageSaveCommand::direction))
                 .forEach((direction, messageCommands) -> saveMissingMessagesByDirection(
                         mailAccount,
-                        command.gmailThreadId(),
+                        command,
                         direction,
                         messageCommands
                 ));
@@ -115,7 +115,7 @@ public class InitialMailSyncCommandService {
 
     private void saveMissingMessagesByDirection(
             MailAccount mailAccount,
-            String gmailThreadId,
+            InitialMailSyncThreadSaveCommand threadCommand,
             Direction direction,
             List<InitialMailSyncMessageSaveCommand> messageCommands
     ) {
@@ -123,7 +123,8 @@ public class InitialMailSyncCommandService {
             throw new MailPushException(MailPushErrorCode.GMAIL_MESSAGES_RESULT_INVALID);
         }
 
-        Thread thread = findOrCreateThread(mailAccount, gmailThreadId, direction);
+        Thread thread = findOrCreateThread(mailAccount, threadCommand.gmailThreadId(), direction);
+        ThreadAggregate aggregate = ThreadAggregate.from(thread);
         int insertedCount = 0;
 
         for (InitialMailSyncMessageSaveCommand messageCommand : messageCommands) {
@@ -139,17 +140,31 @@ public class InitialMailSyncCommandService {
             );
             if (anyMessage.isPresent()) {
                 // 활성 메시지는 이미 존재, 소프트 삭제된 메시지는 재삽입하지 않고 skip
+                if (!anyMessage.get().isDeleted()) {
+                    aggregate.merge(threadCommand, messageCommand, false);
+                }
                 continue;
             }
 
             Message message = Message.from(thread, messageCommand.toCreateValues());
             message.replaceAttachments(createAttachments(message, messageCommand.attachments()));
             messageRepositoryPort.save(message);
+            aggregate.merge(threadCommand, messageCommand, true);
             insertedCount++;
         }
 
+        thread.updateHistoryId(aggregate.historyId());
+        thread.updateLatestMessageInfoIfNewer(
+                aggregate.latestSubject(),
+                aggregate.latestSnippet(),
+                aggregate.latestParticipantAddress(),
+                aggregate.latestParticipantName(),
+                aggregate.lastMessageAt(),
+                aggregate.read()
+        );
+
         if (insertedCount > 0) {
-            synchronizeThreadMessageCount(mailAccount.getId(), gmailThreadId);
+            synchronizeThreadMessageCount(mailAccount.getId(), threadCommand.gmailThreadId());
         }
     }
 

--- a/worker/src/test/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/google/GoogleMailMessageQueryServiceTest.java
@@ -2,6 +2,7 @@ package com.mailsangja.worker.service.google;
 
 import com.mailsangja.db.entity.mail.Direction;
 import com.mailsangja.db.entity.mail.AttachmentDisposition;
+import com.mailsangja.worker.common.exception.mail.MailPushException;
 import com.mailsangja.worker.config.properties.GoogleMailInitialSyncProperties;
 import com.mailsangja.worker.dto.gmail.GoogleMailApiContext;
 import com.mailsangja.worker.dto.gmail.message.GoogleMailThreadResponse;
@@ -24,12 +25,49 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 class GoogleMailMessageQueryServiceTest {
+
+    @Test
+    void getThreads_internalDate가없으면유효하지않은응답예외가발생한다() {
+        GoogleMailInitialSyncProperties properties = new GoogleMailInitialSyncProperties();
+        properties.setThreadsUri("https://gmail.googleapis.com/gmail/v1/users/me/threads");
+
+        RestClient restClient = RestClient.builder()
+                .requestFactory(new StubClientHttpRequestFactory("""
+                        {
+                          "id": "thread-1",
+                          "messages": [
+                            {
+                              "id": "message-1",
+                              "threadId": "thread-1",
+                              "labelIds": ["INBOX"],
+                              "payload": {
+                                "headers": [
+                                  {"name": "From", "value": "Alice <alice@example.com>"}
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                        """))
+                .build();
+        GmailMessageApiService service = new GmailMessageApiService(
+                properties,
+                restClient,
+                mock(GmailApiRateLimitService.class)
+        );
+
+        assertThrows(MailPushException.class, () -> service.getThreads(
+                new GoogleMailApiContext("token", "alice@example.com"),
+                List.of("thread-1")
+        ));
+    }
 
     @Test
     void getInitialThreadIds_fetchesThreadListUntilMaxThreads() {

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
@@ -548,6 +548,85 @@ class InitialMailSyncCommandServiceTest {
         assertEquals(2, outboundThread.getMessageCount());
     }
 
+    @Test
+    void saveMissingMessagesFromThreadSnapshot_updatesThreadSummaryFromInsertedMessage() {
+        MailAccount mailAccount = createMailAccount();
+        Thread thread = createThread(mailAccount, "thread-1", Direction.INBOUND);
+        LocalDateTime sentAt = LocalDateTime.of(2026, 6, 19, 9, 32, 10);
+
+        when(threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccount.getId(), "thread-1", Direction.INBOUND
+        )).thenReturn(Optional.of(thread));
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageId(thread.getId(), "message-1"))
+                .thenReturn(Optional.empty());
+        when(messageRepositoryPort.save(any(Message.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(messageRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccount.getId(), "thread-1"))
+                .thenReturn(List.of(createMessage(UUID.randomUUID(), thread, "message-1")));
+        when(threadRepositoryPort.findAllByMailAccountIdAndGmailThreadIdAndDeletedAtIsNull(mailAccount.getId(), "thread-1"))
+                .thenReturn(List.of(thread));
+
+        service.saveMissingMessagesFromThreadSnapshot(mailAccount, threadCommand(sentAt));
+
+        assertEquals("history-1", thread.getHistoryId());
+        assertEquals("subject", thread.getLatestSubject());
+        assertEquals("snippet", thread.getLatestSnippet());
+        assertEquals("alice@example.com", thread.getLatestParticipantAddress());
+        assertEquals("Alice", thread.getLatestParticipantName());
+        assertEquals(sentAt, thread.getLastMessageAt());
+        assertEquals(1, thread.getMessageCount());
+    }
+
+    @Test
+    void saveMissingMessagesFromThreadSnapshot_repairsSummaryFromExistingActiveMessage() {
+        MailAccount mailAccount = createMailAccount();
+        Thread thread = createThread(mailAccount, "thread-1", Direction.INBOUND);
+        Message existingMessage = createMessage(UUID.randomUUID(), thread, "message-1");
+        LocalDateTime sentAt = LocalDateTime.of(2026, 6, 19, 9, 32, 10);
+
+        when(threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccount.getId(), "thread-1", Direction.INBOUND
+        )).thenReturn(Optional.of(thread));
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageId(thread.getId(), "message-1"))
+                .thenReturn(Optional.of(existingMessage));
+
+        service.saveMissingMessagesFromThreadSnapshot(mailAccount, threadCommand(sentAt));
+
+        assertEquals("subject", thread.getLatestSubject());
+        assertEquals("snippet", thread.getLatestSnippet());
+        assertEquals("alice@example.com", thread.getLatestParticipantAddress());
+        assertEquals(sentAt, thread.getLastMessageAt());
+    }
+
+    private InitialMailSyncThreadSaveCommand threadCommand(LocalDateTime sentAt) {
+        return new InitialMailSyncThreadSaveCommand(
+                "thread-1",
+                "history-1",
+                List.of(new InitialMailSyncMessageSaveCommand(
+                        "message-1",
+                        "history-1",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        Direction.INBOUND,
+                        "subject",
+                        "alice@example.com",
+                        "Alice",
+                        List.of("me@example.com"),
+                        List.of("Me"),
+                        List.of(),
+                        List.of(),
+                        "snippet",
+                        false,
+                        sentAt,
+                        "body",
+                        null,
+                        List.of()
+                ))
+        );
+    }
+
     private MailAccount createMailAccount() {
         return MailAccount.builder()
                 .id(UUID.randomUUID())

--- a/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
+++ b/worker/src/test/java/com/mailsangja/worker/service/mail/InitialMailSyncCommandServiceTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -595,6 +596,44 @@ class InitialMailSyncCommandServiceTest {
         assertEquals("snippet", thread.getLatestSnippet());
         assertEquals("alice@example.com", thread.getLatestParticipantAddress());
         assertEquals(sentAt, thread.getLastMessageAt());
+    }
+
+    @Test
+    void saveMissingMessagesFromThreadSnapshot_doesNotRestoreOrAggregateSoftDeletedMessage() {
+        MailAccount mailAccount = createMailAccount();
+        Thread thread = createThread(mailAccount, "thread-1", Direction.INBOUND);
+        LocalDateTime existingSentAt = LocalDateTime.of(2026, 6, 18, 10, 0);
+        thread.updateHistoryId("existing-history");
+        thread.updateLatestMessageInfo(
+                "existing subject",
+                "existing snippet",
+                "existing@example.com",
+                "Existing",
+                existingSentAt
+        );
+        thread.updateMessageCount(1);
+        Message deletedMessage = createMessage(UUID.randomUUID(), thread, "message-1");
+        deletedMessage.delete();
+
+        when(threadRepositoryPort.findByMailAccountIdAndGmailThreadIdAndDirectionAndDeletedAtIsNull(
+                mailAccount.getId(), "thread-1", Direction.INBOUND
+        )).thenReturn(Optional.of(thread));
+        when(messageRepositoryPort.findByThreadIdAndGmailMessageId(thread.getId(), "message-1"))
+                .thenReturn(Optional.of(deletedMessage));
+
+        service.saveMissingMessagesFromThreadSnapshot(
+                mailAccount,
+                threadCommand(LocalDateTime.of(2026, 6, 19, 9, 32, 10))
+        );
+
+        assertEquals("existing-history", thread.getHistoryId());
+        assertEquals("existing subject", thread.getLatestSubject());
+        assertEquals("existing snippet", thread.getLatestSnippet());
+        assertEquals("existing@example.com", thread.getLatestParticipantAddress());
+        assertEquals("Existing", thread.getLatestParticipantName());
+        assertEquals(existingSentAt, thread.getLastMessageAt());
+        assertEquals(1, thread.getMessageCount());
+        verify(messageRepositoryPort, never()).save(any(Message.class));
     }
 
     private InitialMailSyncThreadSaveCommand threadCommand(LocalDateTime sentAt) {


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#4

### 📌 Task

- Closes #167 

## 💡 작업 내용

- Thread 목록 응답의 nullable 제목, snippet, 참여자 이메일을 빈 문자열로 정규화했습니다.
- Gmail 메시지의 `internalDate`가 누락된 경우 유효하지 않은 외부 응답으로 처리해 저장을 차단했습니다.
- 상태 변경 스냅샷으로 누락 메시지를 저장할 때 Thread 최신 요약 정보도 함께 갱신하도록 수정했습니다.
- 배포 DB의 불완전 Thread 9건과 하위 데이터를 정리하고 해당 Gmail Thread만 재동기화했습니다.

## 📝 추가 설명

### 1. 문제 원인 및 수정

- `saveMissingMessagesFromThreadSnapshot()` 경로에서 Message는 정상 저장됐지만 Thread의 최신 제목, snippet, 참여자, 메시지 시각은 갱신되지 않았습니다.
- 이 상태의 Thread가 목록 API에 포함되면서 프론트엔드가 `null`에 `replace()` 또는 `trim()`을 호출하는 런타임 오류가 발생했습니다.
- 누락 메시지 저장 시 `ThreadAggregate`에 신규 또는 기존 활성 Message를 병합하고 최신 요약 정보를 Thread에 반영하도록 수정했습니다.

```mermaid
flowchart LR
    A[Gmail 상태 변경 이벤트] --> B[Thread 스냅샷 조회]
    B --> C[누락 Message 저장]
    C --> D[ThreadAggregate 병합]
    D --> E[Thread 최신 요약 갱신]
    E --> F[nonnull 목록 응답]
```

### 2. 응답 및 외부 연동 방어

- `ThreadSummaryResponse`의 `latestSubject`, `snippet`과 `MailAddressResponse.email`은 `null`이면 빈 문자열로 변환합니다.
- Gmail `internalDate`가 없으면 core는 `MailSendException`, worker는 `MailPushException`을 발생시켜 불완전 메시지 저장을 방지합니다.
- `lastMessageAt`에는 임의 시각을 사용하지 않고 Gmail 메시지 시각의 유효성을 보장합니다.

### 3. 배포 DB 정리 및 검증

- 활성 상태이면서 `last_message_at IS NULL`인 Thread 9건을 대상으로 확정했습니다.
- FK 순서에 따라 Attachment 1건, Message 9건, Thread 9건을 하나의 트랜잭션에서 삭제했습니다.
- 4개 Gmail 계정의 대상 Thread 9건을 `mail.sync.gmail.initial.thread-batch` 큐로 재동기화했습니다.
- 재생성된 모든 Thread의 제목, snippet, 참여자, `last_message_at`이 유효함을 확인했습니다.
- 전체 활성 Thread의 `last_message_at IS NULL` 잔여 건수는 0건이며, 동기화 DLQ도 증가하지 않았습니다.

## ⚡️ Test 결과

| 검증 항목 | 대상 | 결과 | 비고 |
| -- | -- | -- | -- |
| core 전체 테스트 | `cd core && ./gradlew :test` | 통과 | 응답 정규화 및 Gmail 시각 검증 포함 |
| worker 전체 테스트 | `cd worker && ./gradlew :test` | 통과 | 스냅샷 집계 및 Gmail 시각 검증 포함 |
| 코드 형식 검사 | `git diff --check` | 통과 | 공백 오류 없음 |
| 배포 DB 검증 | 재동기화 Thread 9건 | 통과 | 필수 요약 필드 모두 유효 |
| RabbitMQ 검증 | targeted sync queue / DLQ | 통과 | queue 0건, DLQ 증가 없음 |